### PR TITLE
Fix crash when children widget selectors have parents

### DIFF
--- a/lib/src/selectors.dart
+++ b/lib/src/selectors.dart
@@ -536,7 +536,7 @@ class ChildFilter implements ElementFilter {
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
-    final tree = widgetTreeSnapshot();
+    final tree = currentWidgetTreeSnapshot();
     final List<WidgetTreeNode> matchingChildNodes = [];
     // Then check for every queryMatch if the children and props match
     for (final WidgetTreeNode candidate in candidates) {

--- a/lib/src/selectors.dart
+++ b/lib/src/selectors.dart
@@ -536,18 +536,31 @@ class ChildFilter implements ElementFilter {
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
-    final tree = snapshotWidgetTree();
+    final tree = widgetTreeSnapshot();
     final List<WidgetTreeNode> matchingChildNodes = [];
     // Then check for every queryMatch if the children and props match
     for (final WidgetTreeNode candidate in candidates) {
-      // TODO it must check all child selectors before adding to the list
+      final Map<WidgetSelector, List<WidgetTreeNode>> matchesPerChild = {};
+
+      final subtreeNodes = tree.scope(candidate).allNodes;
       for (final WidgetSelector<Widget> childSelector in children) {
-        final MultiWidgetSnapshot snapshot =
-            findWithinScope(tree.scope(candidate), childSelector);
-        if (snapshot.discovered.isNotEmpty) {
-          matchingChildNodes.add(candidate);
+        matchesPerChild[childSelector] = [];
+        final MultiWidgetSnapshot ss = snapshot(childSelector);
+        final discoveredInSubtree = ss.discovered
+            .where((element) => subtreeNodes.contains(element))
+            .toList();
+
+        if (discoveredInSubtree.isNotEmpty) {
+          matchesPerChild[childSelector] = discoveredInSubtree;
+        } else {
+          continue;
         }
       }
+      if (matchesPerChild.values.any((list) => list.isEmpty)) {
+        // not all children match
+        continue;
+      }
+      matchingChildNodes.add(candidate);
     }
     return matchingChildNodes;
   }

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -6,7 +6,7 @@ import 'package:spot/src/selectors.dart';
 import 'package:spot/src/tree_snapshot.dart';
 
 MultiWidgetSnapshot<W> snapshot<W extends Widget>(WidgetSelector<W> selector) {
-  final treeSnapshot = snapshotWidgetTree();
+  final treeSnapshot = widgetTreeSnapshot();
 
   if (selector.parents.isEmpty) {
     final MultiWidgetSnapshot<W> snapshot =
@@ -65,7 +65,7 @@ class CandidateGeneratorFromParents<W extends Widget>
 
   @override
   Iterable<WidgetTreeNode> generateCandidates() {
-    final tree = snapshotWidgetTree();
+    final tree = widgetTreeSnapshot();
     final List<MultiWidgetSnapshot<Widget>> parentSnapshots =
         selector.parents.map((selector) {
       final MultiWidgetSnapshot<Widget> widgetSnapshot = snapshot(selector);
@@ -85,7 +85,8 @@ class CandidateGeneratorFromParents<W extends Widget>
       return widgetSnapshot;
     }).toList();
 
-    final selectorWithoutParents = selector.copyWith(parents: []);
+    final WidgetSelector<W> selectorWithoutParents = selector
+        .copyWith(parents: [], expectedQuantity: ExpectedQuantity.multi);
 
     // Take a snapshot from each parent and get the snapshots of all nodes that match
     final List<Map<WidgetTreeNode, List<MultiWidgetSnapshot<W>>>>

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -6,7 +6,7 @@ import 'package:spot/src/selectors.dart';
 import 'package:spot/src/tree_snapshot.dart';
 
 MultiWidgetSnapshot<W> snapshot<W extends Widget>(WidgetSelector<W> selector) {
-  final treeSnapshot = widgetTreeSnapshot();
+  final treeSnapshot = currentWidgetTreeSnapshot();
 
   if (selector.parents.isEmpty) {
     final MultiWidgetSnapshot<W> snapshot =
@@ -65,7 +65,7 @@ class CandidateGeneratorFromParents<W extends Widget>
 
   @override
   Iterable<WidgetTreeNode> generateCandidates() {
-    final tree = widgetTreeSnapshot();
+    final tree = currentWidgetTreeSnapshot();
     final List<MultiWidgetSnapshot<Widget>> parentSnapshots =
         selector.parents.map((selector) {
       final MultiWidgetSnapshot<Widget> widgetSnapshot = snapshot(selector);

--- a/lib/src/tree_snapshot.dart
+++ b/lib/src/tree_snapshot.dart
@@ -6,11 +6,18 @@ import 'package:spot/src/element_extensions.dart';
 WidgetTreeSnapshot? _cachedTree;
 
 /// Creates a snapshot of the currently pumped widget via [WidgetTester.pumpWidget].
-WidgetTreeSnapshot widgetTreeSnapshot() {
+WidgetTreeSnapshot currentWidgetTreeSnapshot() {
   if (_cachedTree != null && _cachedTree!.isFromThisFrame) {
     return _cachedTree!;
   }
 
+  return _cachedTree = createWidgetTreeSnapshot();
+}
+
+/// Creates a new snapshot of the widget tree. Might be useful for testing and
+/// can be called repeatedly within the same frame
+@visibleForTesting
+WidgetTreeSnapshot createWidgetTreeSnapshot() {
   // ignore: deprecated_member_use
   final rootElement = WidgetsBinding.instance.renderViewElement!;
 
@@ -28,7 +35,7 @@ WidgetTreeSnapshot widgetTreeSnapshot() {
 
   final origin = build(rootElement);
 
-  return _cachedTree = WidgetTreeSnapshot(
+  return WidgetTreeSnapshot(
     origin: origin,
     timestamp: DateTime.now(),
   );

--- a/lib/src/tree_snapshot.dart
+++ b/lib/src/tree_snapshot.dart
@@ -2,8 +2,15 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/src/element_extensions.dart';
 
+/// caching the tree for the current frame
+WidgetTreeSnapshot? _cachedTree;
+
 /// Creates a snapshot of the currently pumped widget via [WidgetTester.pumpWidget].
-WidgetTreeSnapshot snapshotWidgetTree() {
+WidgetTreeSnapshot widgetTreeSnapshot() {
+  if (_cachedTree != null && _cachedTree!.isFromThisFrame) {
+    return _cachedTree!;
+  }
+
   // ignore: deprecated_member_use
   final rootElement = WidgetsBinding.instance.renderViewElement!;
 
@@ -21,8 +28,7 @@ WidgetTreeSnapshot snapshotWidgetTree() {
 
   final origin = build(rootElement);
 
-  // TODO add caching for the current frame
-  return WidgetTreeSnapshot(
+  return _cachedTree = WidgetTreeSnapshot(
     origin: origin,
     timestamp: DateTime.now(),
   );

--- a/test/parents_and_children_test.dart
+++ b/test/parents_and_children_test.dart
@@ -1,0 +1,100 @@
+// ignore_for_file: avoid_unnecessary_containers, prefer_const_constructors
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+
+void main() {
+  testWidgets('parents can have parents too', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Container(
+          child: Scaffold(
+            appBar: AppBar(
+              title: DefaultTextStyle(
+                style: TextStyle(),
+                maxLines: 2,
+                child: Text('Pepe'),
+              ),
+              actions: [
+                Wrap(
+                  children: [
+                    Container(
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+
+                        /// find this IconButton
+                        child: IconButton(
+                          icon: const Icon(Icons.home),
+                          onPressed: () {},
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                IconButton(
+                  icon: const Icon(Icons.home),
+                  onPressed: () {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final materialApp = spotSingle<MaterialApp>();
+    final scaffold = materialApp.spotSingle<Scaffold>();
+    final wrap = scaffold.spotSingle<Wrap>();
+
+    // IconButton has parents with a different scope
+    // and search is not limited to scope of IconButton
+    scaffold.spot<IconButton>(parents: [wrap]).existsOnce();
+  });
+
+  testWidgets('children can have parents too', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Container(
+          child: Scaffold(
+            appBar: AppBar(
+              title: DefaultTextStyle(
+                style: TextStyle(),
+                maxLines: 2,
+                child: Text('Pepe'),
+              ),
+              actions: [
+                Wrap(
+                  children: [
+                    /// find this Container
+                    Container(
+                      child: Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: IconButton(
+                          icon: const Icon(Icons.home),
+                          onPressed: () {},
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                IconButton(
+                  icon: const Icon(Icons.home),
+                  onPressed: () {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final materialApp = spotSingle<MaterialApp>();
+    final scaffold = materialApp.spotSingle<Scaffold>();
+    final wrap = scaffold.spotSingle<Wrap>();
+
+    final iconButton = wrap.spotSingle<IconButton>();
+
+    scaffold.spot<Container>(children: [iconButton]).existsOnce();
+  });
+}

--- a/test/tree_snapshot_test.dart
+++ b/test/tree_snapshot_test.dart
@@ -21,7 +21,7 @@ void main() {
         ),
       ),
     );
-    final tree = snapshotWidgetTree();
+    final tree = widgetTreeSnapshot();
     final widgets = tree.allElements;
     expect(widgets, isNotEmpty);
     final center =
@@ -57,7 +57,7 @@ void main() {
         ),
       ),
     );
-    final tree = snapshotWidgetTree();
+    final tree = widgetTreeSnapshot();
     final widgets = tree.allElements;
     final flutterOrderWidgets =
         collectAllElementsFrom(tree.origin.element, skipOffstage: true)
@@ -80,7 +80,7 @@ void main() {
         ),
       ),
     );
-    final tree = snapshotWidgetTree();
+    final tree = widgetTreeSnapshot();
     final items = tree.allNodes;
     final row =
         items.firstWhere((node) => node.element.widget.runtimeType == Row);
@@ -99,7 +99,7 @@ void main() {
 
   testWidgets('invalidate', (tester) async {
     await tester.pumpWidget(Center());
-    final tree = snapshotWidgetTree();
+    final tree = widgetTreeSnapshot();
     expect(tree.isFromThisFrame, isTrue);
     await tester.pumpWidget(Center());
     expect(tree.isFromThisFrame, isFalse);

--- a/test/tree_snapshot_test.dart
+++ b/test/tree_snapshot_test.dart
@@ -21,7 +21,7 @@ void main() {
         ),
       ),
     );
-    final tree = widgetTreeSnapshot();
+    final tree = currentWidgetTreeSnapshot();
     final widgets = tree.allElements;
     expect(widgets, isNotEmpty);
     final center =
@@ -57,7 +57,7 @@ void main() {
         ),
       ),
     );
-    final tree = widgetTreeSnapshot();
+    final tree = currentWidgetTreeSnapshot();
     final widgets = tree.allElements;
     final flutterOrderWidgets =
         collectAllElementsFrom(tree.origin.element, skipOffstage: true)
@@ -80,7 +80,7 @@ void main() {
         ),
       ),
     );
-    final tree = widgetTreeSnapshot();
+    final tree = currentWidgetTreeSnapshot();
     final items = tree.allNodes;
     final row =
         items.firstWhere((node) => node.element.widget.runtimeType == Row);
@@ -99,7 +99,7 @@ void main() {
 
   testWidgets('invalidate', (tester) async {
     await tester.pumpWidget(Center());
-    final tree = widgetTreeSnapshot();
+    final tree = currentWidgetTreeSnapshot();
     expect(tree.isFromThisFrame, isTrue);
     await tester.pumpWidget(Center());
     expect(tree.isFromThisFrame, isFalse);


### PR DESCRIPTION
Ran into this crash:

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following message was thrown running a test:
Don't use findWithinScope with a selector that has parents. Either remove them or use snapshot()
instead

When the exception was thrown, this was the stack:
#0      findWithinScope (package:spot/src/snapshot.dart:149:5)
#1      ChildFilter.filter (package:spot/src/selectors.dart:546:13)
#2      findWithinScope.<anonymous closure> (package:spot/src/snapshot.dart:157:52)
#3      ListBase.fold (dart:collection/list.dart:202:22)
#4      findWithinScope (package:spot/src/snapshot.dart:156:8)
#5      CandidateGeneratorFromParents.generateCandidates.<anonymous closure> (package:spot/src/snapshot.dart:101:13)
#6      MappedListIterable.elementAt (dart:_internal/iterable.dart:415:31)
#7      ListIterator.moveNext (dart:_internal/iterable.dart:344:26)
#8      new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:189:27)
#9      new _GrowableList.of (dart:core-patch/growable_array.dart:150:28)
#10     new List.of (dart:core-patch/array_patch.dart:47:28)
#11     ListIterable.toList (dart:_internal/iterable.dart:214:7)
#12     CandidateGeneratorFromParents.generateCandidates (package:spot/src/snapshot.dart:111:8)
#13     snapshot (package:spot/src/snapshot.dart:30:43)
#14     SelectorToSnapshot.snapshot (package:spot/src/selectors.dart:868:26)
#15     _FinderFromWidgetSelector.apply (package:spot/src/finder_interop.dart:81:28)
#16     Finder.evaluate (package:flutter_test/src/finders.dart:509:55)
#17     WidgetController._getElementPoint (package:flutter_test/src/controller.dart:1291:47)
#18     WidgetController.getCenter (package:flutter_test/src/controller.dart:1232:12)
#19     WidgetController.tap (package:flutter_test/src/controller.dart:554:18)
#20     WiredashTestRobot._tap (file:///Users/pascalwelsch/Projects/wiredash/wiredash-sdk/test/util/robot.dart:456:18)
#21     WiredashTestRobot.submitFeedback (file:///Users/pascalwelsch/Projects/wiredash/wiredash-sdk/test/util/robot.dart:242:11)
#22     main.<anonymous closure>.<anonymous closure> (file:///Users/pascalwelsch/Projects/wiredash/wiredash-sdk/test/email_validation_test.dart:69:19)
<asynchronous suspension>
<asynchronous suspension>
(elided one frame from package:stack_trace)
```

caused by a widget selector parent that also has parents

```dart
    final step = _spotPageView.spotSingle<Step6Submit>()..existsOnce();
    await _tap(
      step.spot<TronButton>(
        children: [step.spotSingleText('l10n.feedbackStep6SubmitSubmitButton')],
      ).last(),
    );
```

--- 

Fixed multiple minor bugs along the line
- widget tree is now cached. Recreating it cause comparison checks of both trees to fail
- same happened with children
- elements matched children selectors when only one of them matched. Now all must match