### PR TITLE
Widen test_api constraints to increase pub.dev score

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   # checks deps
   async: ^2.6.0
   meta: ^1.5.0
-  test_api: '>=0.3.0 <0.6.0'
+  test_api: '>=0.3.0 <0.7.0'
 
 dev_dependencies:
   lint: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
To remove the pub.dev warning

```
The constraint `>=0.3.0 <0.6.0` on test_api does not support the stable version `0.6.0`.
```