### PR TITLE
Rename getter

### DIFF
--- a/lib/src/selectors.dart
+++ b/lib/src/selectors.dart
@@ -939,7 +939,7 @@ class SingleWidgetSnapshot<W extends Widget> implements WidgetMatcher<W> {
 
   W? get discoveredWidget => element.widget as W?;
 
-  Element? get discoveredElements => element;
+  Element? get discoveredElement => element;
 
   @override
   W get widget => discovered!.element.widget as W;


### PR DESCRIPTION
**Breaking**: Rename `SingleWidgetSnapshot.discoveredElements` -> `discoveredElement`