### PR TITLE
takeScreenshot()

### DIFF
--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -14,6 +14,7 @@ export 'package:checks/checks.dart'
         it;
 
 export 'package:spot/src/act/act.dart';
+export 'package:spot/src/screenshot/screenshot.dart';
 export 'package:spot/src/spot/default_selectors.dart';
 export 'package:spot/src/spot/effective/effective_text.dart';
 export 'package:spot/src/spot/finder_interop.dart';

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -1,0 +1,95 @@
+import 'dart:core';
+import 'dart:core' as core;
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:dartx/dartx_io.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stack_trace/stack_trace.dart';
+import 'package:test_api/hooks.dart';
+import 'package:ulid/ulid.dart';
+
+Future<File> takeScreenshot({String? name, bool print = true}) async {
+  final frame = _caller();
+  final callerFileName = () {
+    final file = frame?.uri.pathSegments.last
+        .replaceFirst('_test.dart', '')
+        .replaceFirst('.dart', '');
+    final line = frame?.line;
+    if (file != null && line != null) {
+      return '$file:$line';
+    }
+    if (file != null) {
+      return file;
+    }
+    return 'unknown';
+  }();
+
+  final String screenshotFileName = () {
+    final n = name ?? callerFileName;
+    final uniqueId = Ulid().toCanonical().substring(0, 5); // nanoid(5)
+    return '$n-$uniqueId.png';
+  }();
+
+  final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.instance;
+
+  late final Uint8List bytes;
+  await binding.runAsync(() async {
+    final element = binding.renderViewElement!;
+    final image = await _captureImage(element);
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    if (byteData == null) {
+      return 'Could not take screenshot';
+    }
+    bytes = byteData.buffer.asUint8List();
+    image.dispose();
+  });
+
+  final spotTempDir = Directory.systemTemp.directory('spot');
+  if (!spotTempDir.existsSync()) {
+    spotTempDir.createSync();
+  }
+  final file = spotTempDir.file(screenshotFileName);
+  file.writeAsBytesSync(bytes);
+  if (print) {
+    // ignore: avoid_print
+    core.print(
+      'Screenshot file://${file.path}\n'
+      '  taken at ${frame?.member} ${frame?.uri}:${frame?.line}:${frame?.column}',
+    );
+  }
+  return file;
+}
+
+/// Render the closest [RepaintBoundary] of the [element] into an image.
+///
+/// See also:
+///
+///  * [OffsetLayer.toImage] which is the actual method being called.
+Future<ui.Image> _captureImage(Element element) {
+  assert(element.renderObject != null);
+  RenderObject renderObject = element.renderObject!;
+  while (!renderObject.isRepaintBoundary) {
+    renderObject = renderObject.parent! as RenderObject;
+  }
+  assert(!renderObject.debugNeedsPaint);
+  final OffsetLayer layer = renderObject.debugLayer! as OffsetLayer;
+  return layer.toImage(renderObject.paintBounds);
+}
+
+/// Returns the frame in the call stack that is most useful for identifying for
+/// humans
+Frame? _caller({StackTrace? stack}) {
+  final trace = stack != null ? Trace.parse(stack.toString()) : Trace.current();
+  final relevantLines = trace.frames.where((line) {
+    if (line.isCore) return false;
+    final url = line.uri.toString();
+    if (url.contains('package:spot')) return false;
+    return true;
+  }).toList();
+  final Frame? bestGuess = relevantLines.firstOrNull;
+  return bestGuess;
+}

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -119,7 +119,14 @@ Future<Screenshot> takeScreenshot({
   }
 
   final String screenshotFileName = () {
-    final n = name ?? callerFileName();
+    final String n;
+    if (name != null) {
+      // escape /
+      n = Uri.encodeQueryComponent(name);
+    } else {
+      n = callerFileName();
+    }
+
     // always append a unique id to avoid name collisions
     final uniqueId = nanoid(length: 5);
     return '$n-$uniqueId.png';

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -12,11 +12,28 @@ import 'package:nanoid2/nanoid2.dart';
 import 'package:spot/spot.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+/// A screenshot taken from a widget test.
+///
+/// May also be just a single widget, not the entire screen
 class Screenshot {
-  Screenshot({required this.file});
+  Screenshot({
+    required this.file,
+    this.initiator,
+  });
+
+  /// The file where the screenshot was saved to
   final File file;
+
+  /// Call stack of the code that initiated the screenshot
+  final Frame? initiator;
 }
 
+/// Takes a screenshot of the entire screen or a single widget.
+///
+/// Provide a [selector], [snapshot] or [element] to take a screenshot of.
+/// When the screenshot is taken from a larger than just your widget, wrap your
+/// widget with a [RepaintBoundary] to indicate where the screenshot should be
+/// taken.
 Future<Screenshot> takeScreenshot({
   Element? element,
   SingleWidgetSnapshot? snapshot,
@@ -25,7 +42,7 @@ Future<Screenshot> takeScreenshot({
   bool print = true,
 }) async {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.instance;
-  final frame = _caller();
+  final Frame? frame = _caller();
 
   // Element that is currently active in the widget tree, to take a screenshot of
   final Element liveElement = () {
@@ -63,6 +80,8 @@ Future<Screenshot> takeScreenshot({
     }
 
     // fallback to screenshotting the entire app
+    // Deprecated, but as of today there is no multi window support for widget tests
+    // ignore: deprecated_member_use
     return binding.renderViewElement!;
   }();
 

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -10,6 +10,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nanoid2/nanoid2.dart';
 import 'package:spot/spot.dart';
+import 'package:spot/src/screenshot/screenshot.dart' as self
+    show takeScreenshot;
 import 'package:stack_trace/stack_trace.dart';
 
 /// A screenshot taken from a widget test.
@@ -130,6 +132,33 @@ Future<Screenshot> takeScreenshot({
     );
   }
   return Screenshot(file: file);
+}
+
+extension SelectorScreenshotExtension<W extends Widget>
+    on SingleWidgetSelector<W> {
+  /// Takes as screenshot of the widget that can be found by this selector.
+  Future<Screenshot> takeScreenshot({String? name, bool print = true}) {
+    return self.takeScreenshot(selector: this, name: name, print: print);
+  }
+}
+
+extension SnapshotScreenshotExtension<W extends Widget>
+    on SingleWidgetSnapshot<W> {
+  /// Takes as screenshot of the widget that was captured in this snapshot.
+  ///
+  /// The snapshot must have been taken at the same frame
+  Future<Screenshot> takeScreenshot({String? name, bool print = true}) {
+    return self.takeScreenshot(snapshot: this, name: name, print: print);
+  }
+}
+
+extension ElementScreenshotExtension on Element {
+  /// Takes as screenshot of this element
+  ///
+  /// The element must be mounted
+  Future<Screenshot> takeScreenshot({String? name, bool print = true}) {
+    return self.takeScreenshot(element: this, name: name, print: print);
+  }
 }
 
 /// Render the closest [RepaintBoundary] of the [element] into an image.

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -8,10 +8,9 @@ import 'package:dartx/dartx_io.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nanoid2/nanoid2.dart';
 import 'package:spot/spot.dart';
 import 'package:stack_trace/stack_trace.dart';
-import 'package:test_api/hooks.dart';
-import 'package:ulid/ulid.dart';
 
 class Screenshot {
   Screenshot({required this.file});
@@ -99,7 +98,7 @@ Future<Screenshot> takeScreenshot({
   final String screenshotFileName = () {
     final n = name ?? callerFileName();
     // always append a unique id to avoid name collisions
-    final uniqueId = Ulid().toCanonical().substring(0, 5); // nanoid(5)
+    final uniqueId = nanoid(length: 5);
     return '$n-$uniqueId.png';
   }();
   final file = spotTempDir.file(screenshotFileName);

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -36,6 +36,10 @@ class Screenshot {
 /// When the screenshot is taken from a larger than just your widget, wrap your
 /// widget with a [RepaintBoundary] to indicate where the screenshot should be
 /// taken.
+///
+/// Use [name] to make it easier to identify the screenshot in the file system.
+/// By default, a random name is generated prefixed with the test file name and
+/// line number.
 Future<Screenshot> takeScreenshot({
   Element? element,
   SingleWidgetSnapshot? snapshot,
@@ -103,9 +107,7 @@ Future<Screenshot> takeScreenshot({
     spotTempDir.createSync();
   }
   String callerFileName() {
-    final file = frame?.uri.pathSegments.last
-        .replaceFirst('_test.dart', '')
-        .replaceFirst('.dart', '');
+    final file = frame?.uri.pathSegments.last.replaceFirst('.dart', '');
     final line = frame?.line;
     if (file != null && line != null) {
       return '$file:$line';

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -8,38 +8,68 @@ import 'package:dartx/dartx_io.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:test_api/hooks.dart';
 import 'package:ulid/ulid.dart';
 
-Future<File> takeScreenshot({String? name, bool print = true}) async {
-  final frame = _caller();
-  final callerFileName = () {
-    final file = frame?.uri.pathSegments.last
-        .replaceFirst('_test.dart', '')
-        .replaceFirst('.dart', '');
-    final line = frame?.line;
-    if (file != null && line != null) {
-      return '$file:$line';
-    }
-    if (file != null) {
-      return file;
-    }
-    return 'unknown';
-  }();
+class Screenshot {
+  Screenshot({required this.file});
+  final File file;
+}
 
-  final String screenshotFileName = () {
-    final n = name ?? callerFileName;
-    final uniqueId = Ulid().toCanonical().substring(0, 5); // nanoid(5)
-    return '$n-$uniqueId.png';
-  }();
-
+Future<Screenshot> takeScreenshot({
+  Element? element,
+  SingleWidgetSnapshot? snapshot,
+  SingleWidgetSelector? selector,
+  String? name,
+  bool print = true,
+}) async {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.instance;
+  final frame = _caller();
+
+  // Element that is currently active in the widget tree, to take a screenshot of
+  final Element liveElement = () {
+    if (selector != null) {
+      // taking a fresh snapshot guarantees an element that is currently in the
+      // tree and can be screenshotted
+      final snapshot = selector.snapshot().existsOnce();
+      return snapshot.element;
+    }
+
+    if (snapshot != null) {
+      if (!snapshot.element.mounted) {
+        throw StateError(
+          'Can not take a screenshot of snapshot $snapshot, because it is not mounted anymore. '
+          'Only Elements that are currently mounted can be screenshotted.',
+        );
+      }
+      if (snapshot.widget != snapshot.element.widget) {
+        throw StateError(
+          'Can not take a screenshot of snapshot $snapshot, because the Element has been updated since the snapshot was taken. '
+          'This happens when the widget tree is rebuilt.',
+        );
+      }
+      return snapshot.element;
+    }
+
+    if (element != null) {
+      if (!element.mounted) {
+        throw StateError(
+          'Can not take a screenshot of Element $element, because it is not mounted anymore. '
+          'Only Elements that are currently mounted can be screenshotted.',
+        );
+      }
+      return element;
+    }
+
+    // fallback to screenshotting the entire app
+    return binding.renderViewElement!;
+  }();
 
   late final Uint8List bytes;
   await binding.runAsync(() async {
-    final element = binding.renderViewElement!;
-    final image = await _captureImage(element);
+    final image = await _captureImage(liveElement);
     final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
     if (byteData == null) {
       return 'Could not take screenshot';
@@ -52,6 +82,26 @@ Future<File> takeScreenshot({String? name, bool print = true}) async {
   if (!spotTempDir.existsSync()) {
     spotTempDir.createSync();
   }
+  String callerFileName() {
+    final file = frame?.uri.pathSegments.last
+        .replaceFirst('_test.dart', '')
+        .replaceFirst('.dart', '');
+    final line = frame?.line;
+    if (file != null && line != null) {
+      return '$file:$line';
+    }
+    if (file != null) {
+      return file;
+    }
+    return 'unknown';
+  }
+
+  final String screenshotFileName = () {
+    final n = name ?? callerFileName();
+    // always append a unique id to avoid name collisions
+    final uniqueId = Ulid().toCanonical().substring(0, 5); // nanoid(5)
+    return '$n-$uniqueId.png';
+  }();
   final file = spotTempDir.file(screenshotFileName);
   file.writeAsBytesSync(bytes);
   if (print) {
@@ -61,7 +111,7 @@ Future<File> takeScreenshot({String? name, bool print = true}) async {
       '  taken at ${frame?.member} ${frame?.uri}:${frame?.line}:${frame?.column}',
     );
   }
-  return file;
+  return Screenshot(file: file);
 }
 
 /// Render the closest [RepaintBoundary] of the [element] into an image.

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -179,6 +179,19 @@ Future<ui.Image> _captureImage(Element element) {
     renderObject = renderObject.parent! as RenderObject;
   }
   assert(!renderObject.debugNeedsPaint);
+
+  if (element.renderObject is RenderBox && renderObject is RenderBox) {
+    final expectedSize = (element.renderObject as RenderBox?)!.size;
+    final layerSize = renderObject.size;
+    if (expectedSize.width != layerSize.width ||
+        expectedSize.height != layerSize.height) {
+      // ignore: avoid_print
+      print(
+        'Warning: The screenshot captured ($layerSize) of ${element.toStringShort()} is larger than then Element $expectedSize itself.\n'
+        'Wrap the ${element.toStringShort()} in a RepaintBoundary to capture only that layer. ',
+      );
+    }
+  }
   final OffsetLayer layer = renderObject.debugLayer! as OffsetLayer;
   return layer.toImage(renderObject.paintBounds);
 }

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -14,6 +14,8 @@ import 'package:spot/src/screenshot/screenshot.dart' as self
     show takeScreenshot;
 import 'package:stack_trace/stack_trace.dart';
 
+export 'package:stack_trace/stack_trace.dart' show Frame;
+
 /// A screenshot taken from a widget test.
 ///
 /// May also be just a single widget, not the entire screen

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -45,7 +45,6 @@ Future<Screenshot> takeScreenshot({
   SingleWidgetSnapshot? snapshot,
   SingleWidgetSelector? selector,
   String? name,
-  bool print = true,
 }) async {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.instance;
   final Frame? frame = _caller();
@@ -133,21 +132,19 @@ Future<Screenshot> takeScreenshot({
   }();
   final file = spotTempDir.file(screenshotFileName);
   file.writeAsBytesSync(bytes);
-  if (print) {
-    // ignore: avoid_print
-    core.print(
-      'Screenshot file://${file.path}\n'
-      '  taken at ${frame?.member} ${frame?.uri}:${frame?.line}:${frame?.column}',
-    );
-  }
+  // ignore: avoid_print
+  core.print(
+    'Screenshot file://${file.path}\n'
+    '  taken at ${frame?.member} ${frame?.uri}:${frame?.line}:${frame?.column}',
+  );
   return Screenshot(file: file);
 }
 
 extension SelectorScreenshotExtension<W extends Widget>
     on SingleWidgetSelector<W> {
   /// Takes as screenshot of the widget that can be found by this selector.
-  Future<Screenshot> takeScreenshot({String? name, bool print = true}) {
-    return self.takeScreenshot(selector: this, name: name, print: print);
+  Future<Screenshot> takeScreenshot({String? name}) {
+    return self.takeScreenshot(selector: this, name: name);
   }
 }
 
@@ -156,8 +153,8 @@ extension SnapshotScreenshotExtension<W extends Widget>
   /// Takes as screenshot of the widget that was captured in this snapshot.
   ///
   /// The snapshot must have been taken at the same frame
-  Future<Screenshot> takeScreenshot({String? name, bool print = true}) {
-    return self.takeScreenshot(snapshot: this, name: name, print: print);
+  Future<Screenshot> takeScreenshot({String? name}) {
+    return self.takeScreenshot(snapshot: this, name: name);
   }
 }
 
@@ -165,8 +162,8 @@ extension ElementScreenshotExtension on Element {
   /// Takes as screenshot of this element
   ///
   /// The element must be mounted
-  Future<Screenshot> takeScreenshot({String? name, bool print = true}) {
-    return self.takeScreenshot(element: this, name: name, print: print);
+  Future<Screenshot> takeScreenshot({String? name}) {
+    return self.takeScreenshot(element: this, name: name);
   }
 }
 

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -137,7 +137,7 @@ Future<Screenshot> takeScreenshot({
     'Screenshot file://${file.path}\n'
     '  taken at ${frame?.member} ${frame?.uri}:${frame?.line}:${frame?.column}',
   );
-  return Screenshot(file: file);
+  return Screenshot(file: file, initiator: frame);
 }
 
 extension SelectorScreenshotExtension<W extends Widget>

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -847,6 +847,23 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
 
 /// A collection of [discovered] elements that match [selector]
 class MultiWidgetSnapshot<W extends Widget> {
+  MultiWidgetSnapshot({
+    required this.selector,
+    required this.discovered,
+    required this.debugCandidates,
+    required this.scope,
+  }) : _widgets = Map.fromEntries(
+          discovered.map((e) => MapEntry(e, e.element.widget as W)),
+        );
+
+  /// The widgets at the point when the snapshot was taken
+  ///
+  /// [Element] is a mutable object that might have changed since the snapshot
+  /// was taken. This is a reference to the widget that was found at the time
+  /// the snapshot was taken. This allows to compare the widget with the current
+  /// widget in the tree.
+  final Map<WidgetTreeNode, W> _widgets;
+
   final WidgetSelector<W> selector;
 
   final ScopedWidgetTreeSnapshot scope;
@@ -861,18 +878,10 @@ class MultiWidgetSnapshot<W extends Widget> {
   /// The parent nodes from where the node has been found
   // final List<MultiWidgetSnapshot> parents;
 
-  List<W> get discoveredWidgets =>
-      discovered.map((e) => e.element.widget as W).toList();
+  List<W> get discoveredWidgets => _widgets.values.toList();
 
   List<Element> get discoveredElements =>
       discovered.map((e) => e.element).toList();
-
-  MultiWidgetSnapshot({
-    required this.selector,
-    required this.discovered,
-    required this.debugCandidates,
-    required this.scope,
-  });
 
   @override
   String toString() {
@@ -915,7 +924,15 @@ class SingleWidgetSnapshot<W extends Widget> implements WidgetMatcher<W> {
     required this.selector,
     required this.discovered,
     required this.debugCandidates,
-  });
+  }) : _widget = discovered?.element.widget;
+
+  /// The widget at the point when the snapshot was taken
+  ///
+  /// [Element] is a mutable object that might have changed since the snapshot
+  /// was taken. This is a reference to the widget that was found at the time
+  /// the snapshot was taken. This allows to compare the widget with the current
+  /// widget in the tree.
+  final Widget? _widget;
 
   @override
   final WidgetSelector<W> selector;
@@ -930,20 +947,18 @@ class SingleWidgetSnapshot<W extends Widget> implements WidgetMatcher<W> {
 
   @override
   String toString() {
-    return 'SingleSpotSnapshot of $selector (${discovered == null ? 'no' : '1'} match)}';
+    return 'SingleSpotSnapshot{widget: $_widget, selector: $selector, element: ${discovered?.element}}';
   }
 
   @override
-  Element get element {
-    return discovered!.element;
-  }
+  Element get element => discovered!.element;
 
   W? get discoveredWidget => element.widget as W?;
 
   Element? get discoveredElement => element;
 
   @override
-  W get widget => discovered!.element.widget as W;
+  W get widget => _widget! as W;
 }
 
 extension SelectorToSnapshot<W extends Widget> on WidgetSelector<W> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,9 @@ dependencies:
   integration_test:
     sdk: flutter
   test: ^1.24.0
+  stack_trace: ^1.11.0
+  ulid: ^2.0.0
+  test_api: ^0.5.0
 
 dev_dependencies:
   lint: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   test: ^1.24.0
   stack_trace: ^1.11.0
-  ulid: ^2.0.0
+  nanoid2: ^2.0.0
   test_api: ^0.5.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,4 +24,5 @@ dependencies:
   test_api: ^0.5.0
 
 dev_dependencies:
+  image: ^4.0.0
   lint: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,10 +18,10 @@ dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  test: ^1.24.0
-  stack_trace: ^1.11.0
   nanoid2: ^2.0.0
-  test_api: ^0.5.0
+  test: ^1.24.0
+  test_api: '>=0.5.0 <0.7.0'
+  stack_trace: ^1.11.0
 
 dev_dependencies:
   image: ^4.0.0

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -2,6 +2,7 @@
 
 import 'dart:io';
 
+import 'package:dartx/dartx_io.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
@@ -169,6 +170,35 @@ void main() {
         await spotSingle<Container>().snapshot().element.takeScreenshot();
     expect(screenshot3.file.existsSync(), isTrue);
   });
+
+  testWidgets('Take screenshot with custom name', (tester) async {
+    tester.view.physicalSize = const Size(210, 210);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: Container(height: 200, width: 200, color: red),
+      ),
+    );
+
+    final shot = await takeScreenshot(name: 'custom_name');
+    expect(shot.file.name, contains('custom_name'));
+  });
+
+  testWidgets('screenshot file name contains test file name', (tester) async {
+    tester.view.physicalSize = const Size(210, 210);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: Container(height: 200, width: 200, color: red),
+      ),
+    );
+
+    final shot = await takeScreenshot();
+    final lineNumber = _currentLineNumber() - 1;
+    expect(shot.file.name, contains('screenshot_test:$lineNumber'));
+  });
 }
 
 /// Parses an png image file and reads the percentage of pixels of a given [color].
@@ -198,4 +228,12 @@ Future<double> percentageOfPixelsWithColor(File file, Color color) async {
   // Calculate the red pixel coverage percentage
   final double redPixelCoverage = redPixelCount / totalPixelCount;
   return redPixelCoverage;
+}
+
+int _currentLineNumber() {
+  final lines = StackTrace.current.toString().split('\n');
+  final callerLine = lines[1];
+  final parts = callerLine.split(':');
+  // parts[parts.length - 1] is the column number
+  return parts[parts.length - 2].toInt();
 }

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -247,14 +247,13 @@ void main() {
     expect(
       text,
       contains(
-        'Warning: The screenshot captured (Size(800.0, 600.0)) '
-        'of Text is larger than then Element Size(84.0, 14.0) itself.',
+        'Warning: The screenshot captured of Text is larger (800, 600) than Text (84.0, 14.0) itself.',
       ),
     );
     expect(
       text,
       contains(
-        'Wrap the Text in a RepaintBoundary to capture only that layer.',
+        'Wrap the Text in a RepaintBoundary to be able to capture only that layer.',
       ),
     );
   });

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dartx/dartx_io.dart';
@@ -213,6 +214,28 @@ void main() {
     final shot = await takeScreenshot(name: 'path/to/name');
     expect(shot.file.name, isNot(contains('path/to/name')));
     expect(shot.file.name, contains('path%2Fto%2Fname'));
+  });
+
+  testWidgets('prints name to console', (tester) async {
+    final log = <String>[];
+    int line = 0;
+    await runZoned(
+      () async {
+        await takeScreenshot();
+        line = _currentLineNumber() - 1;
+      },
+      zoneSpecification: ZoneSpecification(
+        print: (self, parent, zone, message) {
+          log.add(message);
+        },
+      ),
+    );
+    final text = log.join('\n');
+    expect(text, contains('Screenshot file://'));
+    expect(text, contains('screenshot_test'));
+    expect(text, contains('.png'));
+    expect(text, contains('taken at main'));
+    expect(text, contains('screenshot_test.dart:$line'));
   });
 }
 

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:dartx/dartx_io.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 import 'package:spot/spot.dart';
@@ -217,6 +217,46 @@ void main() {
     expect(text, contains('.png'));
     expect(text, contains('taken at main'));
     expect(text, contains('screenshot_test.dart:$line'));
+  });
+
+  testWidgets('warning when screenshot is bigger than target', (tester) async {
+    tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: ElevatedButton(
+            child: Text('button'),
+            onPressed: () {},
+          ),
+        ),
+      ),
+    );
+
+    final log = <String>[];
+    await runZoned(
+      () async {
+        await takeScreenshot(selector: spotSingleText('button'));
+      },
+      zoneSpecification: ZoneSpecification(
+        print: (self, parent, zone, message) {
+          log.add(message);
+        },
+      ),
+    );
+
+    final text = log.join('\n');
+    expect(
+      text,
+      contains(
+        'Warning: The screenshot captured (Size(800.0, 600.0)) '
+        'of Text is larger than then Element Size(84.0, 14.0) itself.',
+      ),
+    );
+    expect(
+      text,
+      contains(
+        'Wrap the Text in a RepaintBoundary to capture only that layer.',
+      ),
+    );
   });
 }
 

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -199,6 +199,21 @@ void main() {
     final lineNumber = _currentLineNumber() - 1;
     expect(shot.file.name, contains('screenshot_test:$lineNumber'));
   });
+
+  testWidgets('name gets escaped to prevent slashes', (tester) async {
+    tester.view.physicalSize = const Size(210, 210);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: Container(height: 200, width: 200, color: red),
+      ),
+    );
+
+    final shot = await takeScreenshot(name: 'path/to/name');
+    expect(shot.file.name, isNot(contains('path/to/name')));
+    expect(shot.file.name, contains('path%2Fto%2Fname'));
+  });
 }
 
 /// Parses an png image file and reads the percentage of pixels of a given [color].

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -146,6 +146,29 @@ void main() {
       ]),
     );
   });
+
+  testWidgets('takeScreenshot() extensions', (tester) async {
+    tester.view.physicalSize = const Size(1000, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(height: 200, width: 200, color: red),
+        ),
+      ),
+    );
+    final screenshot1 = await spotSingle<Container>().takeScreenshot();
+    expect(screenshot1.file.existsSync(), isTrue);
+
+    final screenshot2 =
+        await spotSingle<Container>().snapshot().takeScreenshot();
+    expect(screenshot2.file.existsSync(), isTrue);
+
+    final screenshot3 =
+        await spotSingle<Container>().snapshot().element.takeScreenshot();
+    expect(screenshot3.file.existsSync(), isTrue);
+  });
 }
 
 /// Parses an png image file and reads the percentage of pixels of a given [color].

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -173,47 +173,28 @@ void main() {
   });
 
   testWidgets('Take screenshot with custom name', (tester) async {
-    tester.view.physicalSize = const Size(210, 210);
-    tester.view.devicePixelRatio = 1.0;
-    const red = Color(0xffff0000);
-    await tester.pumpWidget(
-      Center(
-        child: Container(height: 200, width: 200, color: red),
-      ),
-    );
-
     final shot = await takeScreenshot(name: 'custom_name');
     expect(shot.file.name, contains('custom_name'));
   });
 
   testWidgets('screenshot file name contains test file name', (tester) async {
-    tester.view.physicalSize = const Size(210, 210);
-    tester.view.devicePixelRatio = 1.0;
-    const red = Color(0xffff0000);
-    await tester.pumpWidget(
-      Center(
-        child: Container(height: 200, width: 200, color: red),
-      ),
-    );
-
     final shot = await takeScreenshot();
     final lineNumber = _currentLineNumber() - 1;
     expect(shot.file.name, contains('screenshot_test:$lineNumber'));
   });
 
   testWidgets('name gets escaped to prevent slashes', (tester) async {
-    tester.view.physicalSize = const Size(210, 210);
-    tester.view.devicePixelRatio = 1.0;
-    const red = Color(0xffff0000);
-    await tester.pumpWidget(
-      Center(
-        child: Container(height: 200, width: 200, color: red),
-      ),
-    );
-
     final shot = await takeScreenshot(name: 'path/to/name');
     expect(shot.file.name, isNot(contains('path/to/name')));
     expect(shot.file.name, contains('path%2Fto%2Fname'));
+  });
+
+  testWidgets('initiator frame is attached', (tester) async {
+    final shot = await takeScreenshot();
+    final lineNumber = _currentLineNumber() - 1;
+    expect(shot.initiator!.line, lineNumber);
+    expect(shot.initiator!.uri.toString(), endsWith('screenshot_test.dart'));
+    expect(shot.initiator!.member, 'main.<fn>');
   });
 
   testWidgets('prints name to console', (tester) async {
@@ -268,6 +249,7 @@ Future<double> percentageOfPixelsWithColor(File file, Color color) async {
   return redPixelCoverage;
 }
 
+/// The line number of this function call
 int _currentLineNumber() {
   final lines = StackTrace.current.toString().split('\n');
   final callerLine = lines[1];

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -1,0 +1,178 @@
+// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
+
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:spot/spot.dart';
+import 'package:spot/src/screenshot/screenshot.dart';
+
+import '../util/assert_error.dart';
+
+void main() {
+  testWidgets('Take screenshot of the entire app', (tester) async {
+    tester.view.physicalSize = const Size(210, 210);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: Container(height: 200, width: 200, color: red),
+      ),
+    );
+
+    final shot = await takeScreenshot();
+    expect(shot.file.existsSync(), isTrue);
+
+    final redPixelCoverage = await percentageOfPixelsWithColor(shot.file, red);
+    expect(redPixelCoverage, greaterThan(0.9));
+  });
+
+  testWidgets('Take screenshot from a selector', (tester) async {
+    tester.view.physicalSize = const Size(1000, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(height: 200, width: 200, color: red),
+        ),
+      ),
+    );
+
+    final container = await takeScreenshot(selector: spotSingle<Container>());
+    expect(container.file.existsSync(), isTrue);
+
+    final redPixelCoverage =
+        await percentageOfPixelsWithColor(container.file, red);
+    expect(redPixelCoverage, 1.0);
+  });
+
+  testWidgets('Take screenshot from a snapshot', (tester) async {
+    tester.view.physicalSize = const Size(1000, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(height: 200, width: 200, color: red),
+        ),
+      ),
+    );
+    final containerSnapshot = spotSingle<Container>().snapshot();
+
+    final container = await takeScreenshot(snapshot: containerSnapshot);
+    expect(container.file.existsSync(), isTrue);
+
+    final redPixelCoverage =
+        await percentageOfPixelsWithColor(container.file, red);
+    expect(redPixelCoverage, 1.0);
+  });
+
+  testWidgets(
+      'Take screenshot from a snapshot throws when snapshot is outdated',
+      (tester) async {
+    tester.view.physicalSize = const Size(1000, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(height: 200, width: 200, color: red),
+        ),
+      ),
+    );
+    final containerSnapshot = spotSingle<Container>().snapshot();
+
+    // Remove element that is captured in the snapshot
+    await tester.pumpWidget(Container());
+    expect(containerSnapshot.element.mounted, isFalse);
+
+    await expectLater(
+      takeScreenshot(snapshot: containerSnapshot),
+      throwsErrorContaining<StateError>([
+        'Can not take a screenshot of snapshot',
+        'not mounted anymore',
+        'Only Elements that are currently mounted can be screenshotted.'
+      ]),
+    );
+  });
+
+  testWidgets('Take screenshot from a element', (tester) async {
+    tester.view.physicalSize = const Size(1000, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(height: 200, width: 200, color: red),
+        ),
+      ),
+    );
+    final containerElement = spotSingle<Container>().snapshot().element;
+
+    final container = await takeScreenshot(element: containerElement);
+    expect(container.file.existsSync(), isTrue);
+
+    final redPixelCoverage =
+        await percentageOfPixelsWithColor(container.file, red);
+    expect(redPixelCoverage, 1.0);
+  });
+
+  testWidgets('takeScreenshot throws when element does not exist anymore',
+      (tester) async {
+    tester.view.physicalSize = const Size(1000, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    const red = Color(0xffff0000);
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(height: 200, width: 200, color: red),
+        ),
+      ),
+    );
+    final containerElement = spotSingle<Container>().snapshot().element;
+
+    // Remove containerElement
+    await tester.pumpWidget(Container());
+    expect(containerElement.mounted, isFalse);
+
+    await expectLater(
+      takeScreenshot(element: containerElement),
+      throwsErrorContaining<StateError>([
+        'Can not take a screenshot of Element',
+        'not mounted anymore',
+        'Only Elements that are currently mounted can be screenshotted.'
+      ]),
+    );
+  });
+}
+
+/// Parses an png image file and reads the percentage of pixels of a given [color].
+Future<double> percentageOfPixelsWithColor(File file, Color color) async {
+  final binding = TestWidgetsFlutterBinding.instance;
+  final image =
+      (await binding.runAsync(() => img.decodePngFile(file.absolute.path)))!;
+
+  // Count the number of red pixels in the image
+  int redPixelCount = 0;
+  final int totalPixelCount = image.width * image.height;
+
+  for (int y = 0; y < image.height; y++) {
+    for (int x = 0; x < image.width; x++) {
+      final pixel = image.getPixel(x, y);
+      final color = Color.fromARGB(
+        pixel.a.toInt(),
+        pixel.r.toInt(),
+        pixel.g.toInt(),
+        pixel.b.toInt(),
+      );
+      if (color == Color(0xffff0000)) {
+        redPixelCount++;
+      }
+    }
+  }
+  // Calculate the red pixel coverage percentage
+  final double redPixelCoverage = redPixelCount / totalPixelCount;
+  return redPixelCoverage;
+}

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image/image.dart' as img;
 import 'package:spot/spot.dart';
-import 'package:spot/src/screenshot/screenshot.dart';
 
 import '../util/assert_error.dart';
 

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -246,7 +246,7 @@ void main() {
     expect(
       text,
       contains(
-        'Warning: The screenshot captured of Text is larger (800, 600) than Text (84.0, 14.0) itself.',
+        'Warning: The screenshot captured of Text is larger (1000, 1000) than Text (84.0, 14.0) itself.',
       ),
     );
     expect(

--- a/test/spot/snapshot_test.dart
+++ b/test/spot/snapshot_test.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+import 'package:spot/src/spot/snapshot.dart';
+import 'package:spot/src/spot/tree_snapshot.dart';
+
+void main() {
+  testWidgets('MultiWidgetSnapshot keeps reference to old Widget',
+      (tester) async {
+    await tester.pumpWidget(Center(child: SizedBox(height: 200)));
+    final MultiWidgetSnapshot<SizedBox> oldTree = snapshot(spot<SizedBox>());
+    await tester.pumpWidget(Center(child: SizedBox(height: 100)));
+    final MultiWidgetSnapshot<SizedBox> newTree = snapshot(spot<SizedBox>());
+    expect(oldTree.discoveredWidgets.first.height, 200);
+    expect(newTree.discoveredWidgets.first.height, 100);
+  });
+
+  testWidgets('SingleWidgetSnapshot keeps reference to old Widget',
+      (tester) async {
+    await tester.pumpWidget(Center(child: SizedBox(height: 200)));
+    final SingleWidgetSnapshot<SizedBox> oldTree =
+        snapshot(spot<SizedBox>()).single;
+    await tester.pumpWidget(Center(child: SizedBox(height: 100)));
+    final SingleWidgetSnapshot<SizedBox> newTree =
+        snapshot(spot<SizedBox>()).single;
+    expect(oldTree.widget.height, 200);
+    expect(newTree.widget.height, 100);
+  });
+}

--- a/test/spot/snapshot_test.dart
+++ b/test/spot/snapshot_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
 import 'package:spot/src/spot/snapshot.dart';
-import 'package:spot/src/spot/tree_snapshot.dart';
 
 void main() {
   testWidgets('MultiWidgetSnapshot keeps reference to old Widget',

--- a/test/util/assert_error.dart
+++ b/test/util/assert_error.dart
@@ -4,17 +4,33 @@ Matcher throwsSpotErrorContaining(
   List<String> errorMessageParts, {
   List<String> not = const [],
 }) {
-  final List<TypeMatcher<TestFailure>> failures = [];
+  return throwsErrorContaining<TestFailure>(errorMessageParts);
+}
+
+Matcher throwsErrorContaining<E>(
+  List<String> errorMessageParts, {
+  List<String> not = const [],
+}) {
+  final List<TypeMatcher<E>> failures = [];
   for (final part in errorMessageParts) {
     failures.add(
-      isA<TestFailure>().having((it) => it.message, 'message', contains(part)),
+      isA<E>().having(
+        // ignore: avoid_dynamic_calls
+        (it) => (it as dynamic).message,
+        'message',
+        contains(part),
+      ),
     );
   }
 
   for (final part in not) {
     failures.add(
-      isA<TestFailure>()
-          .having((it) => it.message, 'message', isNot(contains(part))),
+      isA<E>().having(
+        // ignore: avoid_dynamic_calls
+        (it) => (it as dynamic).message,
+        'message',
+        isNot(contains(part)),
+      ),
     );
   }
 


### PR DESCRIPTION
Adds a simple way to take a screenshot

```dart
/// Takes a screenshot of the entire window
await takeScreenshot();

/// Takes a screenshot of a single Screen/Widget
final homePage = spotSingle<HomePage>();
await takeScreenshot(selector: homePage);

/// Use it as extension
await spotSingle<HomePage>().takeScreenshot();
```