### PR TITLE
Detect AbsorbPointer/IgnorePointer

### DIFF
--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -139,8 +139,11 @@ class Act {
     if (childElement?.widget is AbsorbPointer) {
       final absorbPointer = childElement!.widget as AbsorbPointer;
       if (absorbPointer.absorbing) {
+        final location = getCreationLocation(childElement) ??
+            childElement.debugGetCreatorChain(100);
         throw TestFailure(
-            "Widget '${snapshot.selector.toStringWithoutParents()}' is wrapped in AbsorbPointer and doesn't receive taps. "
+            "Widget '${snapshot.selector.toStringWithoutParents()}' is wrapped in AbsorbPointer and doesn't receive taps.\n"
+            "AbsorbPointer is created at $location\n"
             "The closest widget reacting to the touch event is:\n"
             "${hitTarget.toStringDeep()}");
       }

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -1,5 +1,7 @@
 import 'package:dartx/dartx.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/src/gestures/hit_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
@@ -95,29 +97,14 @@ class Act {
     required SingleWidgetSnapshot snapshot,
   }) {
     final binding = WidgetsBinding.instance;
+
+    // do the tap, hit test the position of [target]
     final HitTestResult result = HitTestResult();
     // ignore: deprecated_member_use
     binding.hitTest(result, position);
     final hitTestEntries = result.path.toList();
 
-    final firstResponder = hitTestEntries.first.target;
-    if (firstResponder is RenderObject) {
-      final firstResponderElement =
-          (firstResponder.debugCreator as DebugCreator?)?.element;
-      if (firstResponderElement != null) {
-        final childElement = firstResponderElement.children.firstOrNull;
-        if (childElement?.widget is AbsorbPointer) {
-          final absorbPointer = childElement!.widget as AbsorbPointer;
-          if (absorbPointer.absorbing) {
-            throw TestFailure(
-                "Widget '${snapshot.selector.toStringWithoutParents()}' is wrapped in AbsorbPointer and doesn't receive taps. "
-                "The closest widget reacting to the touch event is:\n"
-                "${firstResponderElement.toStringDeep()}");
-          }
-        }
-      }
-    }
-
+    // Check if [target] received the tap event
     for (final HitTestEntry entry in hitTestEntries) {
       if (entry.target == target) {
         // Success, target was hit by hitTest
@@ -125,28 +112,75 @@ class Act {
       }
     }
 
-    // did not hit RenderObject, it is either covered by another widget
-    final elements = hitTestEntries.mapNotNull((e) {
-      if (e.target is RenderObject) {
-        final renderObject = e.target as RenderObject;
-        if (renderObject.debugCreator is DebugCreator?) {
-          final debugCreator = renderObject.debugCreator as DebugCreator?;
-          if (debugCreator != null) {
-            return debugCreator.element;
-          }
-        }
-      }
-      return null;
-    }).toList();
+    final List<Element> hitTargetElements =
+        hitTestEntries.mapNotNull((e) => e.element).toList();
 
-    final Element commonAncestor =
-        findCommonAncestor([elements.first, snapshot.discoveredElement!]);
+    _detectAbsorbPointer(hitTargetElements.first, snapshot);
+    _detectIgnorePointer(target, snapshot);
+
+    final Element commonAncestor = findCommonAncestor(
+      [hitTargetElements.first, snapshot.discoveredElement!],
+    );
 
     throw TestFailure(
-      "Widget '${snapshot.selector.toStringWithoutParents()}' is covered by '${elements.first.widget.toStringShort()}' and can't be tapped.\n"
+      "Widget '${snapshot.selector.toStringWithoutParents()}' is covered by '${hitTargetElements.first.widget.toStringShort()}' and can't be tapped.\n"
       "The common ancestor of both widgets is:\n"
       "${commonAncestor.toStringDeep()}",
     );
+  }
+
+  /// Throws when the widget is wrapped in an AbsorbPointer that is absorbing
+  /// the taps and doesn't forward them to the child
+  void _detectAbsorbPointer(
+    Element hitTarget,
+    SingleWidgetSnapshot<Widget> snapshot,
+  ) {
+    final childElement = hitTarget.children.firstOrNull;
+    if (childElement?.widget is AbsorbPointer) {
+      final absorbPointer = childElement!.widget as AbsorbPointer;
+      if (absorbPointer.absorbing) {
+        throw TestFailure(
+            "Widget '${snapshot.selector.toStringWithoutParents()}' is wrapped in AbsorbPointer and doesn't receive taps. "
+            "The closest widget reacting to the touch event is:\n"
+            "${hitTarget.toStringDeep()}");
+      }
+    }
+  }
+
+  /// Throws if the widget is wrapped in an IgnorePointer that is not forwarding events
+  void _detectIgnorePointer(
+    RenderObject target,
+    SingleWidgetSnapshot<Widget> snapshot,
+  ) {
+    final targetElement = (target.debugCreator as DebugCreator?)!.element;
+    // sorted from root to target
+    final parents = targetElement.parents.reversed.toList();
+    // the first IgnorePointer that is not forwarding events
+    final ignorePointer = parents.firstOrNullWhere(
+      (element) {
+        if (element.widget is! IgnorePointer) return false;
+        final ignorePointer = element.widget as IgnorePointer;
+        return ignorePointer.ignoring;
+      },
+    );
+    if (ignorePointer != null) {
+      final location = getCreationLocation(ignorePointer) ??
+          targetElement.debugGetCreatorChain(100);
+      throw TestFailure(
+        "Widget '${snapshot.selector.toStringWithoutParents()}' is wrapped in IgnorePointer and doesn't receive taps. "
+        "The IgnorePointer is located at $location",
+      );
+    }
+  }
+}
+
+extension on HitTestEntry {
+  Element? get element {
+    if (target is! RenderObject) return null;
+    final t = target as RenderObject;
+    if (t.debugCreator is! DebugCreator?) return null;
+    final debugCreator = t.debugCreator as DebugCreator?;
+    return debugCreator?.element;
   }
 }
 
@@ -174,4 +208,26 @@ T _alwaysPropagateDevicePointerEvents<T>(T Function() block) {
       binding.shouldPropagateDevicePointerEvents = previousPropagateValue;
     }
   }
+}
+
+/// Workaround to the the location of a widget in code
+///
+/// This method is a workaround to call `_getCreationLocation()` which is private
+String? getCreationLocation(Element element) {
+  final debugCreator = element.renderObject?.debugCreator;
+  if (debugCreator is! DebugCreator) {
+    return null;
+  }
+  final block =
+      debugTransformDebugCreator([DiagnosticsDebugCreator(debugCreator)]).first
+          as DiagnosticsBlock;
+  final description = block.getChildren().first as ErrorDescription;
+  final location = description.value.first.toString();
+  // _Location .toString() looks something like this:
+  // IgnorePointer IgnorePointer:file:///Users/pascalwelsch/Projects/passsy/spot/test/act/act_test.dart:142:18
+
+  final matches = RegExp('.*(file:///.*)').allMatches(location);
+  final filePath = matches.first.group(1);
+
+  return filePath;
 }

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -1,7 +1,6 @@
 import 'package:dartx/dartx.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/src/gestures/hit_test.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -99,6 +99,25 @@ class Act {
     // ignore: deprecated_member_use
     binding.hitTest(result, position);
     final hitTestEntries = result.path.toList();
+
+    final firstResponder = hitTestEntries.first.target;
+    if (firstResponder is RenderObject) {
+      final firstResponderElement =
+          (firstResponder.debugCreator as DebugCreator?)?.element;
+      if (firstResponderElement != null) {
+        final childElement = firstResponderElement.children.firstOrNull;
+        if (childElement?.widget is AbsorbPointer) {
+          final absorbPointer = childElement!.widget as AbsorbPointer;
+          if (absorbPointer.absorbing) {
+            throw TestFailure(
+                "Widget '${snapshot.selector.toStringWithoutParents()}' is wrapped in AbsorbPointer and doesn't receive taps. "
+                "The closest widget reacting to the touch event is:\n"
+                "${firstResponderElement.toStringDeep()}");
+          }
+        }
+      }
+    }
+
     for (final HitTestEntry entry in hitTestEntries) {
       if (entry.target == target) {
         // Success, target was hit by hitTest

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -109,6 +109,31 @@ void actTests() {
     );
   });
 
+  testWidgets('tap throws when widget is wrapped in AbsorbPointer',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: AbsorbPointer(
+            child: ElevatedButton(
+              onPressed: () {},
+              child: null,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final button = spotSingle<ElevatedButton>()..existsOnce();
+    expect(
+      () => act.tap(button),
+      throwsSpotErrorContaining([
+        "Widget 'ElevatedButton' is wrapped in AbsorbPointer and doesn't receive taps. The closest widget reacting to the touch event is:",
+        "Center(",
+      ]),
+    );
+  });
+
   testWidgets('tapping throws for non cartesian widgets', (tester) async {
     await tester.pumpWidget(_NonCartesianWidget());
     final button = spotSingle<_NonCartesianWidget>()..existsOnce();

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -134,6 +134,32 @@ void actTests() {
     );
   });
 
+  testWidgets('tap throws when widget is wrapped in IgnorePointer',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: IgnorePointer(
+            child: ElevatedButton(
+              onPressed: () {},
+              child: null,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final button = spotSingle<ElevatedButton>()..existsOnce();
+    expect(
+      () => act.tap(button),
+      throwsSpotErrorContaining([
+        "Widget 'ElevatedButton' is wrapped in IgnorePointer and doesn't receive taps",
+        "The IgnorePointer is located at",
+        "act_test.dart",
+      ]),
+    );
+  });
+
   testWidgets('tapping throws for non cartesian widgets', (tester) async {
     await tester.pumpWidget(_NonCartesianWidget());
     final button = spotSingle<_NonCartesianWidget>()..existsOnce();

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -128,7 +128,10 @@ void actTests() {
     expect(
       () => act.tap(button),
       throwsSpotErrorContaining([
-        "Widget 'ElevatedButton' is wrapped in AbsorbPointer and doesn't receive taps. The closest widget reacting to the touch event is:",
+        "Widget 'ElevatedButton' is wrapped in AbsorbPointer and doesn't receive taps.",
+        "AbsorbPointer is created at",
+        "act_test.dart:",
+        "The closest widget reacting to the touch event is:",
         "Center(",
       ]),
     );
@@ -155,7 +158,7 @@ void actTests() {
       throwsSpotErrorContaining([
         "Widget 'ElevatedButton' is wrapped in IgnorePointer and doesn't receive taps",
         "The IgnorePointer is located at",
-        "act_test.dart",
+        "act_test.dart:",
       ]),
     );
   });

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -219,8 +219,15 @@ void main() {
   });
 
   testWidgets('warning when screenshot is bigger than target', (tester) async {
+    tester.view.physicalSize = const Size(1000, 1000);
+    tester.view.devicePixelRatio = 1.0;
     tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(
+          textTheme: TextTheme(
+            labelLarge: TextStyle(fontSize: 14),
+          ),
+        ),
         home: Center(
           child: ElevatedButton(
             child: Text('button'),

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -223,15 +223,13 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
     tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(
-          textTheme: TextTheme(
-            labelLarge: TextStyle(fontSize: 14),
-          ),
-        ),
         home: Center(
-          child: ElevatedButton(
-            child: Text('button'),
-            onPressed: () {},
+          child: ColoredBox(
+            color: Colors.green,
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Text('button'),
+            ),
           ),
         ),
       ),
@@ -253,7 +251,10 @@ void main() {
     expect(
       text,
       contains(
-        'Warning: The screenshot captured of Text is larger (1000, 1000) than Text (84.0, 14.0) itself.',
+        RegExp(
+          r'Warning: The screenshot captured of Text is larger \(1000, 1000\) '
+          r'than Text \(.*, .*\) itself.',
+        ),
       ),
     );
     expect(


### PR DESCRIPTION
Widgets that are wrapped in `AbsorbPointer` or `IgnorePointer` do not receive tap events.

Tapping on the position where the widget is located always works. But when spot doesn't reach the expected widgets during hit testing, it will search for AbsorbPointer or IgnorePointer widgets in the tree that might prevent the hit test from reaching the expected widget.

The widget creation location in code is logged (if available) or the breadcrumb.

Errors look like this:

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure was thrown running a test:
Widget 'ElevatedButton' is wrapped in AbsorbPointer and doesn't receive taps.
AbsorbPointer is created at
file:///Users/pascalwelsch/Projects/passsy/spot/test/act/act_test.dart:117:18
The closest widget reacting to the touch event is:
Center(alignment: Alignment.center, dependencies: [Directionality], renderObject:
RenderPositionedBox#fcf75)
└AbsorbPointer(absorbing: true, renderObject: RenderAbsorbPointer#c2867 relayoutBoundary=up1)
 └ElevatedButton(dependencies: [MediaQuery, _InheritedTheme, _LocalizationsScope-[GlobalKey#0e78c]],
state: _ButtonStyleState#bc613)
```

```dart
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure was thrown running a test:
Widget 'ElevatedButton' is wrapped in IgnorePointer and doesn't receive taps. The IgnorePointer is
located at file:///Users/pascalwelsch/Projects/passsy/spot/test/act/act_test.dart:145:18

When the exception was thrown, this was the stack:
#0      Act._detectIgnorePointer (package:spot/src/act/act.dart:172:7)
#1      Act._pokeRenderObject (package:spot/src/act/act.dart:119:5)
#2      Act.tap.<anonymous closure> (package:spot/src/act/act.dart:54:7)
#3      _alwaysPropagateDevicePointerEvents (package:spot/src/act/act.dart:208:17)
#4      Act.tap (package:spot/src/act/act.dart:24:12)
#5      actTests.<anonymous closure> (file:///Users/pascalwelsch/Projects/passsy/spot/test/act/act_test.dart:156:9)
```