### PR TITLE
[Breaking] Make act.tap() async

### DIFF
--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -19,8 +19,8 @@ class Act {
   const Act._();
 
   /// Triggers a tap event on a given widget.
-  void tap(SingleWidgetSelector selector) {
-    return _alwaysPropagateDevicePointerEvents(() {
+  Future<void> tap(SingleWidgetSelector selector) async {
+    return _alwaysPropagateDevicePointerEvents(() async {
       final snapshot = selector.snapshot();
 
       // Check if widget is in the widget tree. Throws if not.

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -507,6 +507,7 @@ class SingleWidgetSelector<W extends Widget> extends WidgetSelector<W> {
   }) : super(expectedQuantity: ExpectedQuantity.single);
 
   SingleWidgetSnapshot<W> snapshot() {
+    TestAsyncUtils.guardSync();
     return snapshot_file.snapshot(this).single;
   }
 }
@@ -520,6 +521,7 @@ class MultiWidgetSelector<W extends Widget> extends WidgetSelector<W> {
   }) : super(expectedQuantity: ExpectedQuantity.multi);
 
   MultiWidgetSnapshot<W> snapshot() {
+    TestAsyncUtils.guardSync();
     return snapshot_file.snapshot(this);
   }
 }
@@ -971,26 +973,32 @@ extension SelectorToSnapshot<W extends Widget> on WidgetSelector<W> {
   }
 
   MultiWidgetSnapshot<W> snapshot() {
+    TestAsyncUtils.guardSync();
     return snapshot_file.snapshot(this);
   }
 
   MultiWidgetSnapshot<W> existsAtLeastOnce() {
+    TestAsyncUtils.guardSync();
     return snapshot().existsAtLeastOnce();
   }
 
   void doesNotExist() {
+    TestAsyncUtils.guardSync();
     snapshot().doesNotExist();
   }
 
   SingleWidgetSnapshot<W> existsOnce() {
+    TestAsyncUtils.guardSync();
     return snapshot().existsOnce();
   }
 
   MultiWidgetSnapshot<W> existsExactlyNTimes(int n) {
+    TestAsyncUtils.guardSync();
     return snapshot().existsExactlyNTimes(n);
   }
 
   MultiWidgetSnapshot<W> existsAtLeastNTimes(int n) {
+    TestAsyncUtils.guardSync();
     return snapshot().existsAtLeastNTimes(n);
   }
 }
@@ -1005,6 +1013,7 @@ extension SingleSnapshotSelector<W extends Widget> on SingleWidgetSelector<W> {
   }
 
   SingleWidgetSnapshot<W> snapshot() {
+    TestAsyncUtils.guardSync();
     return snapshot_file.snapshot(this).single;
   }
 }
@@ -1021,6 +1030,7 @@ extension AssertionMatcher<W extends Widget> on MultiWidgetSnapshot<W> {
 
 extension MutliMatchers<W extends Widget> on MultiWidgetSnapshot<W> {
   MultiWidgetSnapshot<W> any(void Function(WidgetMatcher<W>) matcher) {
+    TestAsyncUtils.guardSync();
     if (discovered.isEmpty) {
       throw Exception('Expected at least one match for $this, but found none');
     }
@@ -1050,6 +1060,7 @@ extension MutliMatchers<W extends Widget> on MultiWidgetSnapshot<W> {
   }
 
   MultiWidgetSnapshot<W> all(void Function(WidgetMatcher<W>) matcher) {
+    TestAsyncUtils.guardSync();
     if (discovered.isEmpty) {
       throw Exception('Expected at least one match for $this, but found none');
     }

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -6,6 +6,7 @@ import 'package:spot/src/spot/selectors.dart';
 import 'package:spot/src/spot/tree_snapshot.dart';
 
 MultiWidgetSnapshot<W> snapshot<W extends Widget>(WidgetSelector<W> selector) {
+  TestAsyncUtils.guardSync();
   final treeSnapshot = currentWidgetTreeSnapshot();
 
   if (selector.parents.isEmpty) {

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -37,6 +37,31 @@ void actTests() {
     expect(i, 2);
   });
 
+  testWidgets('tap must be awaited', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: ElevatedButton(
+            onPressed: () {},
+            child: const Text('Home'),
+          ),
+        ),
+      ),
+    );
+    final future = act.tap(spotSingle<ElevatedButton>());
+
+    try {
+      TestAsyncUtils.guardSync();
+      fail('Expected to throw');
+    } catch (e) {
+      check(e).isA<FlutterError>().has((it) => it.message, 'message')
+        ..contains('You must use "await" with all Future-returning test APIs.')
+        ..contains('The guarded method "tap" from class Act was called from')
+        ..contains('act_test.dart');
+    }
+    await future;
+  });
+
   testWidgets('tap throws if widget not in widget tree', (tester) async {
     await tester.pumpWidget(const MaterialApp());
     final button = spotSingle<ElevatedButton>()..doesNotExist();

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -31,9 +31,9 @@ void actTests() {
     final button = spotSingle<ElevatedButton>()..existsOnce();
 
     expect(i, 0);
-    act.tap(button);
+    await act.tap(button);
     expect(i, 1);
-    act.tap(button);
+    await act.tap(button);
     expect(i, 2);
   });
 
@@ -41,7 +41,7 @@ void actTests() {
     await tester.pumpWidget(const MaterialApp());
     final button = spotSingle<ElevatedButton>()..doesNotExist();
 
-    expect(
+    await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
         "Could not find 'ElevatedButton' in widget tree",
@@ -68,7 +68,7 @@ void actTests() {
 
     final button = spotSingle<ElevatedButton>()..existsOnce();
 
-    expect(
+    await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
         "Widget 'ElevatedButton' is located outside the viewport",
@@ -100,7 +100,7 @@ void actTests() {
     );
 
     final button = spotSingle<ElevatedButton>()..existsOnce();
-    expect(
+    await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
         "Widget 'ElevatedButton' is covered by 'ColoredBox'",
@@ -125,7 +125,7 @@ void actTests() {
     );
 
     final button = spotSingle<ElevatedButton>()..existsOnce();
-    expect(
+    await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
         "Widget 'ElevatedButton' is wrapped in AbsorbPointer and doesn't receive taps.",
@@ -153,7 +153,7 @@ void actTests() {
     );
 
     final button = spotSingle<ElevatedButton>()..existsOnce();
-    expect(
+    await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
         "Widget 'ElevatedButton' is wrapped in IgnorePointer and doesn't receive taps",
@@ -166,7 +166,7 @@ void actTests() {
   testWidgets('tapping throws for non cartesian widgets', (tester) async {
     await tester.pumpWidget(_NonCartesianWidget());
     final button = spotSingle<_NonCartesianWidget>()..existsOnce();
-    expect(
+    await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
         "Widget '_NonCartesianWidget' is associated to _CustomRenderObject",
@@ -180,7 +180,7 @@ void actTests() {
       (tester) async {
     await tester.pumpWidget(_NoRenderObjectWidget());
     final button = spotSingle<_NoRenderObjectWidget>()..existsOnce();
-    expect(
+    await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
         "Widget '_NoRenderObjectWidget' has no associated RenderObject",

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -221,7 +221,7 @@ void main() {
   testWidgets('warning when screenshot is bigger than target', (tester) async {
     tester.view.physicalSize = const Size(1000, 1000);
     tester.view.devicePixelRatio = 1.0;
-    tester.pumpWidget(
+    await tester.pumpWidget(
       MaterialApp(
         home: Center(
           child: ColoredBox(


### PR DESCRIPTION
Not required right now, but in the future `tap` and other gestures might become much more powerful, requiring an async API.

Now `act.tap()` becomes `await act.tap()`. If you forget it, it will throw an error.

Features I'd like to add in the future:
- automatic screenshots at every interaction with `act`
- logging
- automatic scrolling 