### PR TITLE
Do not throw when the child selector quantity constratins don't match

### DIFF
--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -2,10 +2,14 @@ import 'package:collection/collection.dart';
 import 'package:dartx/dartx.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
 import 'package:spot/src/spot/selectors.dart';
 import 'package:spot/src/spot/tree_snapshot.dart';
 
-MultiWidgetSnapshot<W> snapshot<W extends Widget>(WidgetSelector<W> selector) {
+MultiWidgetSnapshot<W> snapshot<W extends Widget>(
+  WidgetSelector<W> selector, {
+  bool validateQuantity = true,
+}) {
   TestAsyncUtils.guardSync();
   final treeSnapshot = currentWidgetTreeSnapshot();
 
@@ -13,7 +17,8 @@ MultiWidgetSnapshot<W> snapshot<W extends Widget>(WidgetSelector<W> selector) {
     final MultiWidgetSnapshot<W> snapshot =
         findWithinScope(treeSnapshot, selector);
 
-    if (selector.expectedQuantity == ExpectedQuantity.single) {
+    if (validateQuantity &&
+        selector.expectedQuantity == ExpectedQuantity.single) {
       if (snapshot.discovered.length > 1) {
         throw TestFailure(
           'Found ${snapshot.discovered.length} elements matching $selector in widget tree, '
@@ -38,7 +43,8 @@ MultiWidgetSnapshot<W> snapshot<W extends Widget>(WidgetSelector<W> selector) {
     return filter.filter(list);
   }).toList();
 
-  if (selector.expectedQuantity == ExpectedQuantity.single) {
+  if (validateQuantity &&
+      selector.expectedQuantity == ExpectedQuantity.single) {
     if (discovered.length > 1) {
       throw TestFailure(
         'Found ${discovered.length} elements matching $selector in widget tree, '
@@ -289,12 +295,12 @@ void _tryMatchingLessSpecificCriteria<W extends Widget>(
       );
       errorBuilder.writeln(
           'Please check the ${lessSpecificSnapshot.discoveredElements.length} '
-          'matches for ${lessSpecificSelector.toStringBreadcrumb()} and adjust the constraints of the selector $selector accordingly:');
+          'matches for ${lessSpecificSelector.toStringBreadcrumb()} and adjust the constraints of the selector $selector accordingly:\n');
       int index = 0;
       for (final Element match in lessSpecificSnapshot.discoveredElements) {
         index++;
         errorBuilder
-            .writeln('Possible match #$index: ${match.widget.toStringDeep()}');
+            .writeln('Possible match #$index:\n${match.toStringDeep()}');
       }
       fail(errorBuilder.toString());
     }

--- a/lib/src/spot/tree_snapshot.dart
+++ b/lib/src/spot/tree_snapshot.dart
@@ -6,6 +6,8 @@ import 'package:spot/src/spot/element_extensions.dart';
 WidgetTreeSnapshot? _cachedTree;
 
 /// Creates a snapshot of the currently pumped widget via [WidgetTester.pumpWidget].
+///
+/// This snapshot is only made once per frame and cached for further use.
 WidgetTreeSnapshot currentWidgetTreeSnapshot() {
   if (_cachedTree != null && _cachedTree!.isFromThisFrame) {
     return _cachedTree!;
@@ -193,5 +195,9 @@ class ScopedWidgetTreeSnapshot {
   @override
   String toString() {
     return 'ScopedWidgetTreeSnapshot{origin: ${origin.element.widget.runtimeType}}';
+  }
+
+  String toStringDeep() {
+    return origin.element.toStringDeep();
   }
 }

--- a/test/spot/existence_comparison_test.dart
+++ b/test/spot/existence_comparison_test.dart
@@ -155,28 +155,28 @@ void main() {
         ),
       );
 
-      final spotter = spotSingle<Center>(
+      final selector = spotSingle<Center>(
         children: [spotSingle<SizedBox>()],
         parents: [spotSingle<Material>()], // <-- does not exist
       );
 
-      expect(spotter.snapshot().discovered, isNull);
+      expect(selector.snapshot().discovered, isNull);
 
       final throwsFailureWithMessage = throwsSpotErrorContaining([
         "but found 1 matches when searching for 'Center",
-        "Possible match #1: Center(alignment: Alignment.center)",
+        "Possible match #1:\nCenter(alignment: Alignment.center",
       ]);
 
-      expect(() => spotter.doesNotExist(), returnsNormally);
-      expect(() => spotter.existsOnce(), throwsFailureWithMessage);
-      expect(() => spotter.existsAtLeastOnce(), throwsFailureWithMessage);
-      expect(() => spotter.existsAtMostOnce(), returnsNormally);
-      expect(() => spotter.existsExactlyNTimes(1), throwsFailureWithMessage);
-      expect(() => spotter.existsExactlyNTimes(2), throwsFailureWithMessage);
-      expect(() => spotter.existsAtLeastNTimes(1), throwsFailureWithMessage);
-      expect(() => spotter.existsAtLeastNTimes(2), throwsFailureWithMessage);
-      expect(() => spotter.existsAtMostNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtMostNTimes(2), returnsNormally);
+      expect(() => selector.doesNotExist(), returnsNormally);
+      expect(() => selector.existsOnce(), throwsFailureWithMessage);
+      expect(() => selector.existsAtLeastOnce(), throwsFailureWithMessage);
+      expect(() => selector.existsAtMostOnce(), returnsNormally);
+      expect(() => selector.existsExactlyNTimes(1), throwsFailureWithMessage);
+      expect(() => selector.existsExactlyNTimes(2), throwsFailureWithMessage);
+      expect(() => selector.existsAtLeastNTimes(1), throwsFailureWithMessage);
+      expect(() => selector.existsAtLeastNTimes(2), throwsFailureWithMessage);
+      expect(() => selector.existsAtMostNTimes(1), returnsNormally);
+      expect(() => selector.existsAtMostNTimes(2), returnsNormally);
     });
   });
 
@@ -256,9 +256,9 @@ void main() {
           [
             "Could not find at least 2 matches for Row > Text in widget tree, but found 3 matches when searching for 'Text'",
             "Please check the 3 matches for Text and adjust the constraints of the selector 'Text with parents: ['Row']' accordingly",
-            'Possible match #1: Text("a")',
-            'Possible match #2: Text("b")',
-            'Possible match #3: Text("c")',
+            'Possible match #1:\nText("a"',
+            'Possible match #2:\nText("b"',
+            'Possible match #3:\nText("c"',
           ],
           not: ['#4'],
         ),


### PR DESCRIPTION
This query would fail when the entire widget tree contains two `Wrap`.

```
spot<Container>(children: [spotSingle<Wrap>]).existsOnce();
```

Now, the child selector does not throw when the quantity doesn't match. Instead in checks that only a single `Wrap` is a child of `Container`. If `Container` would have `2+` or zero `Wrap`s it would not find it instead. (filter it out as possible matching candidate)