### PR TITLE
Allow calling tap with a MultiSelector

### DIFF
--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -19,11 +19,9 @@ class Act {
   const Act._();
 
   /// Triggers a tap event on a given widget.
-  Future<void> tap(SingleWidgetSelector selector) async {
-    final snapshot = selector.snapshot();
-
+  Future<void> tap(WidgetSelector selector) async {
     // Check if widget is in the widget tree. Throws if not.
-    selector.existsOnce();
+    final snapshot = selector.existsOnce();
 
     return TestAsyncUtils.guard<void>(() async {
       return _alwaysPropagateDevicePointerEvents(() async {
@@ -72,7 +70,7 @@ class Act {
   // Validates that the widget is at least partially visible in the viewport.
   void _validateViewBounds(
     RenderBox renderBox, {
-    required SingleWidgetSelector selector,
+    required WidgetSelector selector,
   }) {
     final Rect viewport =
         Offset.zero & WidgetsBinding.instance.renderView.configuration.size;

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -74,6 +74,33 @@ void actTests() {
     );
   });
 
+  testWidgets('tap throws when selector matches multiple widgets',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Row(
+          children: [
+            ElevatedButton(
+              onPressed: () {},
+              child: null,
+            ),
+            ElevatedButton(
+              onPressed: () {},
+              child: null,
+            ),
+          ],
+        ),
+      ),
+    );
+    final button = spot<ElevatedButton>()..existsExactlyNTimes(2);
+    await expectLater(
+      () => act.tap(button),
+      throwsSpotErrorContaining([
+        "Found 2 elements matching 'ElevatedButton' in widget tree",
+      ]),
+    );
+  });
+
   testWidgets('tap throws if widget not in viewport', (tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
This is useful because selector filters that narrow the search always return `WidgetSelector` when called on `SingleWidgetSelector`


<img width="738" alt="Screen-Shot-2023-09-15-16-40-57 97" src="https://github.com/passsy/spot/assets/1096485/a8451df0-d258-4db8-b9cb-96773c6aff44">