### PR TITLE
Add @useResult to all methods that return WidgetSelector

### DIFF
--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -22,6 +22,7 @@ export 'package:checks/context.dart'
         Extracted,
         Rejection,
         Subject;
+export 'package:meta/meta.dart' show useResult;
 export 'package:spot/src/act/act.dart';
 export 'package:spot/src/screenshot/screenshot.dart';
 export 'package:spot/src/spot/default_selectors.dart';
@@ -109,6 +110,7 @@ WidgetSelector<Widget> get allWidgets => WidgetSelector.all;
 /// does not accidentally match a [Center] Widget, that extends [Align].
 ///
 /// If multiple Widgets of type [W] are expected, use [spot] instead.
+@useResult
 SingleWidgetSelector<W> spotSingle<W extends Widget>({
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -131,6 +133,7 @@ SingleWidgetSelector<W> spotSingle<W extends Widget>({
 /// This selector compares the Widgets by runtimeType rather than by super
 /// type (see [WidgetTypeFilter]). This makes sure that e.g. `spot<Align>()`
 /// does not accidentally match a [Center] Widget, that extends [Align].
+@useResult
 WidgetSelector<W> spot<W extends Widget>({
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -143,6 +146,7 @@ WidgetSelector<W> spot<W extends Widget>({
 
 /// Creates a chainable [WidgetSelector] that matches a single [Widget] by
 /// identity
+@useResult
 SingleWidgetSelector<W> spotSingleWidget<W extends Widget>(
   W widget, {
   List<WidgetSelector> parents = const [],
@@ -156,6 +160,7 @@ SingleWidgetSelector<W> spotSingleWidget<W extends Widget>(
 }
 
 /// Creates a chainable [WidgetSelector] that finds all [widget] by identity
+@useResult
 WidgetSelector<W> spotWidgets<W extends Widget>(
   W widget, {
   List<WidgetSelector> parents = const [],
@@ -170,6 +175,7 @@ WidgetSelector<W> spotWidgets<W extends Widget>(
 
 /// Creates a chainable [WidgetSelector] that finds the widget that is currently
 /// associated to the given [element].
+@useResult
 SingleWidgetSelector<W> spotElement<W extends Widget>(
   Element element, {
   List<WidgetSelector> parents = const [],
@@ -193,6 +199,7 @@ SingleWidgetSelector<W> spotElement<W extends Widget>(
 /// final welcome = spot<Text>().whereText((it) => it.equals("Hello"));
 /// welcome.first().snapshot().hasMaxLines(1).hasTextAlign(TextAlign.center);
 /// ```
+@useResult
 SingleWidgetSelector<AnyText> spotText(
   Pattern text, {
   List<WidgetSelector> parents = const [],
@@ -221,6 +228,7 @@ SingleWidgetSelector<AnyText> spotText(
 /// spotTextWhere((it) => it.contains('Wo'));
 /// spotText('Wo');
 /// ```
+@useResult
 SingleWidgetSelector<AnyText> spotTextWhere(
   void Function(Subject<String>) match, {
   List<WidgetSelector> parents = const [],
@@ -243,6 +251,7 @@ SingleWidgetSelector<AnyText> spotTextWhere(
   'Use spotText("Hello") or '
   'spot<Text>().whereText((it) => it.equals("Hello")).first() instead',
 )
+@useResult
 SingleWidgetSelector<W> spotSingleText<W extends Widget>(
   String text, {
   List<WidgetSelector> parents = const [],
@@ -267,6 +276,7 @@ SingleWidgetSelector<W> spotSingleText<W extends Widget>(
   'Use spotText("Hello") or '
   'spot<Text>().whereText((it) => it.equals("Hello")) instead',
 )
+@useResult
 WidgetSelector<W> spotTexts<W extends Widget>(
   String text, {
   List<WidgetSelector> parents = const [],
@@ -283,6 +293,7 @@ WidgetSelector<W> spotTexts<W extends Widget>(
 
 /// Creates a chainable [WidgetSelector] that finds a [Icon] based on [IconData]
 /// [icon]
+@useResult
 SingleWidgetSelector<Icon> spotSingleIcon(
   IconData icon, {
   bool skipOffstage = true,
@@ -298,6 +309,7 @@ SingleWidgetSelector<Icon> spotSingleIcon(
 
 /// Creates a chainable [WidgetSelector] that finds all widgets of type [Icon]
 /// that have [icon] as [IconData]
+@useResult
 WidgetSelector<Icon> spotIcons(
   IconData icon, {
   bool skipOffstage = true,
@@ -312,6 +324,7 @@ WidgetSelector<Icon> spotIcons(
 }
 
 /// Creates a chainable [WidgetSelector] that finds a widget with the given [key].
+@useResult
 SingleWidgetSelector<W> spotSingleKey<W extends Widget>(
   Key key, {
   List<WidgetSelector> parents = const [],
@@ -326,6 +339,7 @@ SingleWidgetSelector<W> spotSingleKey<W extends Widget>(
 
 /// Creates a chainable [WidgetSelector] that finds all widgets with the given
 /// [key].
+@useResult
 MultiWidgetSelector<W> spotKeys<W extends Widget>(
   Key key, {
   List<WidgetSelector> parents = const [],

--- a/lib/src/spot/default_selectors.dart
+++ b/lib/src/spot/default_selectors.dart
@@ -29,14 +29,17 @@ extension DefaultWidgetMatchers<W extends Widget> on WidgetMatcher<W> {
 }
 
 extension DefaultWidgetSelectors<W extends Widget> on WidgetSelector<W> {
+  @useResult
   WidgetSelector<W> whereDepth(MatchProp<int> match) {
     return withDiagnosticProp<int>('depth', match);
   }
 
+  @useResult
   WidgetSelector<W> withDepth(int value) {
     return withDiagnosticProp<int>('depth', (it) => it.equals(value));
   }
 
+  @useResult
   WidgetSelector<W> whereKey(MatchProp<Key> match) {
     return withProp(
       widgetSelector: (subject) => subject.context.nest<Key?>(
@@ -47,6 +50,7 @@ extension DefaultWidgetSelectors<W extends Widget> on WidgetSelector<W> {
     );
   }
 
+  @useResult
   WidgetSelector<W> withKey(Key? value) {
     return whereKey((it) => value == null ? it.isNull() : it.equals(value));
   }

--- a/lib/src/spot/finder_interop.dart
+++ b/lib/src/spot/finder_interop.dart
@@ -11,6 +11,7 @@ extension FinderToSpot on Finder {
   /// concrete type is [MultiWidgetSelector]. Use [SelectorToSnapshot.single] to
   /// convert the [Finder] to a [SingleWidgetSelector] when the intention is to
   /// only match a single [Widget].
+  @useResult
   MultiWidgetSelector<W> spot<W extends Widget>() {
     return _FinderSelector<W>(this);
   }
@@ -28,6 +29,7 @@ extension SpotToFinder<W extends Widget> on WidgetSelector<W> {
   /// Finds all elements that match [finder] and converts them to a [WidgetSelector].
   ///
   /// Use [T] to specify the type of [Widget] to match.
+  @useResult
   WidgetSelector<T> spotFinder<T extends Widget>(Finder finder) {
     return _FinderSelector<T>(finder, parent: this);
   }

--- a/lib/src/spot/matcher_generator.dart
+++ b/lib/src/spot/matcher_generator.dart
@@ -150,7 +150,7 @@ extension ${widgetType}Selector on WidgetSelector<$widgetType> {
 
       addedMethods = true;
       matcherSb.writeln('''
-  /// Expects that $humanPropName of [$widgetType] matches the condition in [match]    
+  /// Expects that $humanPropName of [$widgetType] matches the condition in [match]
   WidgetMatcher<$widgetType> $matcherVerb${humanPropName.capitalize()}Where(MatchProp<$propType> match) {
     return hasDiagnosticProp<$propType>('$diagnosticPropName', match);
   }
@@ -162,12 +162,14 @@ extension ${widgetType}Selector on WidgetSelector<$widgetType> {
 ''');
 
       selectorSb.writeln('''
-  /// Creates a [WidgetSelector] that finds all [$widgetType] where $humanPropName matches the condition   
+  /// Creates a [WidgetSelector] that finds all [$widgetType] where $humanPropName matches the condition
+  @useResult
   WidgetSelector<$widgetType> where${humanPropName.capitalize()}(MatchProp<$propType> match) {
     return withDiagnosticProp<$propType>('$diagnosticPropName', match);
   }
   
   /// Creates a [WidgetSelector] that finds all [$widgetType] where $humanPropName equals (==) [value]
+  @useResult
   WidgetSelector<$widgetType> with${humanPropName.capitalize()}($propTypeNullable value) {
     return withDiagnosticProp<$propType>('$diagnosticPropName', (it) => value == null ? it.isNull() : it.equals(value));
   }

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -47,6 +47,7 @@ mixin Selectors<T extends Widget> {
   ///    .spotSingle<Scaffold>()
   ///    .spotSingle<AppBar>()
   /// ```
+  @useResult
   SingleWidgetSelector<W> spotSingle<W extends Widget>({
     List<WidgetSelector> parents = const [],
     List<WidgetSelector> children = const [],
@@ -64,6 +65,7 @@ mixin Selectors<T extends Widget> {
   /// ```dart
   /// final appbar = spot<MaterialApp>().spot<Scaffold>().spot<AppBar>()
   /// ```
+  @useResult
   MultiWidgetSelector<W> spot<W extends Widget>({
     List<WidgetSelector> parents = const [],
     List<WidgetSelector> children = const [],
@@ -83,6 +85,7 @@ mixin Selectors<T extends Widget> {
   /// only that widget
   ///
   /// The comparison happens by identity (===)
+  @useResult
   SingleWidgetSelector<W> spotSingleWidget<W extends Widget>(
     W widget, {
     List<WidgetSelector> parents = const [],
@@ -98,6 +101,7 @@ mixin Selectors<T extends Widget> {
   /// Creates a [WidgetSelector] that finds all [widget] by identity
   ///
   /// The comparison happens by identity (===)
+  @useResult
   MultiWidgetSelector<W> spotWidgets<W extends Widget>(
     W widget, {
     List<WidgetSelector> parents = const [],
@@ -120,6 +124,7 @@ mixin Selectors<T extends Widget> {
   /// [element]
   ///
   /// The comparison happens by identity (===)
+  @useResult
   SingleWidgetSelector<W> spotElement<W extends Widget>(
     Element element, {
     List<WidgetSelector> parents = const [],
@@ -153,6 +158,7 @@ mixin Selectors<T extends Widget> {
   /// final welcome = spot<Text>().whereText((it) => it.equals("Hello"));
   /// welcome.first().snapshot().hasMaxLines(1).hasTextAlign(TextAlign.center);
   /// ```
+  @useResult
   SingleWidgetSelector<AnyText> spotText(
     Pattern text, {
     List<WidgetSelector> parents = const [],
@@ -194,6 +200,7 @@ mixin Selectors<T extends Widget> {
   /// spotTextWhere((it) => it.contains('Wo'));
   /// spotText('Wo');
   /// ```
+  @useResult
   SingleWidgetSelector<AnyText> spotTextWhere(
     void Function(Subject<String>) match, {
     List<WidgetSelector> parents = const [],
@@ -224,6 +231,7 @@ mixin Selectors<T extends Widget> {
     'Use spotText("Hello") or '
     'spot<Text>().whereText((it) => it.equals("Hello")).first() instead',
   )
+  @useResult
   SingleWidgetSelector<W> spotSingleText<W extends Widget>(
     String text, {
     List<WidgetSelector> parents = const [],
@@ -244,6 +252,7 @@ mixin Selectors<T extends Widget> {
     'Use spotText("Hello") or '
     'spot<Text>().whereText((it) => it.equals("Hello")) instead',
   )
+  @useResult
   MultiWidgetSelector<W> spotTexts<W extends Widget>(
     String text, {
     List<WidgetSelector> parents = const [],
@@ -282,6 +291,7 @@ mixin Selectors<T extends Widget> {
   }
 
   /// Creates a [WidgetSelector] that finds a single [Icon] based on the [icon]
+  @useResult
   SingleWidgetSelector<Icon> spotSingleIcon(
     IconData icon, {
     bool skipOffstage = true,
@@ -296,6 +306,7 @@ mixin Selectors<T extends Widget> {
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] widgets based on the [icon]
+  @useResult
   MultiWidgetSelector<Icon> spotIcons(
     IconData icon, {
     bool skipOffstage = true,
@@ -321,6 +332,7 @@ mixin Selectors<T extends Widget> {
   }
 
   /// Creates a [WidgetSelector] that finds a single widget with the given [key]
+  @useResult
   SingleWidgetSelector<W> spotSingleKey<W extends Widget>(
     Key key, {
     List<WidgetSelector> parents = const [],
@@ -334,6 +346,7 @@ mixin Selectors<T extends Widget> {
   }
 
   /// Creates a [WidgetSelector] that finds all widgets with the given [key]
+  @useResult
   MultiWidgetSelector<W> spotKeys<W extends Widget>(
     Key key, {
     List<WidgetSelector> parents = const [],
@@ -352,6 +365,7 @@ mixin Selectors<T extends Widget> {
     );
   }
 
+  @useResult
   WidgetSelector<W> cast<W extends Widget>() {
     return WidgetSelector<W>(
       props: self!.props,
@@ -366,6 +380,7 @@ mixin Selectors<T extends Widget> {
   /// "first" is neither the top-most or the bottom-most widget. Instead, it is
   /// the widget that was found first during a depth-first search of the widget
   /// tree
+  @useResult
   SingleWidgetSelector<T> first() {
     return FirstWidgetSelector<T>(
       props: self!.props,
@@ -379,6 +394,7 @@ mixin Selectors<T extends Widget> {
   /// "last" is neither the top-most or the bottom-most widget. Instead, it is
   /// the widget that was found last during a depth-first search of the widget
   /// tree
+  @useResult
   SingleWidgetSelector<T> last() {
     return LastWidgetSelector<T>(
       props: self!.props,
@@ -465,6 +481,7 @@ extension SelectorQueries<W extends Widget> on Selectors<W> {
   /// [Selector] is snapshotted
   ///
   /// The [description] is required to make error messages understandable
+  @useResult
   WidgetSelector<W> whereElement(
     bool Function(Element element) predicate, {
     required String description,
@@ -493,6 +510,7 @@ extension SelectorQueries<W extends Widget> on Selectors<W> {
   ///    )
   ///    .existsOnce();
   /// ```
+  @useResult
   WidgetSelector<W> whereWidget(
     bool Function(W widget) predicate, {
     required String description,
@@ -522,6 +540,7 @@ extension SelectorQueries<W extends Widget> on Selectors<W> {
   ///   )
   ///   .existsOnce();
   ///   ```
+  @useResult
   WidgetSelector<W> whereWidgetProp<T>(
     NamedWidgetProp<W, T> prop,
     bool Function(T value) match,
@@ -541,6 +560,7 @@ extension SelectorQueries<W extends Widget> on Selectors<W> {
     );
   }
 
+  @useResult
   WidgetSelector<W> whereElementProp<T>(
     NamedElementProp<T> prop,
     bool Function(T value) match,
@@ -559,6 +579,7 @@ extension SelectorQueries<W extends Widget> on Selectors<W> {
     );
   }
 
+  @useResult
   WidgetSelector<W> whereRenderObjectProp<T, R extends RenderObject>(
     NamedRenderObjectProp<R, T> prop,
     bool Function(T value) match,
@@ -1147,6 +1168,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
   @override
   WidgetSelector<W> get self => this;
 
+  @useResult
   WidgetSelector<W> copyWith({
     List<PredicateWithDescription>? props,
     List<WidgetSelector>? parents,
@@ -1174,6 +1196,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
   ///   match: (maxLines) => maxLines.equals(1),
   /// );
   /// ```
+  @useResult
   WidgetSelector<W> withProp<T>({
     @Deprecated('use elementSelector instead')
     Subject<T> Function(ConditionSubject<Element>)? selector,
@@ -1225,6 +1248,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
 
   /// Finds the diagnostic property (from [Element.toDiagnosticsNode]) with
   /// [propName] and returns the value as type [T]
+  @useResult
   WidgetSelector<W> withDiagnosticProp<T>(
     String propName,
     MatchProp<T> match,
@@ -1284,10 +1308,12 @@ extension SelectorToSnapshot<W extends Widget> on WidgetSelector<W> {
     return snapshot_file.snapshot(this);
   }
 
+  @useResult
   MultiWidgetSelector<W> get multi {
     return MultiWidgetSelector<W>.fromWidgetSelector(this);
   }
 
+  @useResult
   SingleWidgetSelector<W> get single {
     return SingleWidgetSelector<W>.fromWidgetSelector(this);
   }
@@ -1339,6 +1365,7 @@ class MultiWidgetSnapshot<W extends Widget> {
     return 'SpotSnapshot of $selector (${discoveredElements.length} matches)}';
   }
 
+  @useResult
   SingleWidgetSnapshot<W> get single {
     if (discovered.length > 1) {
       final errorBuilder = StringBuffer();
@@ -1464,24 +1491,28 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
 extension RelativeSelectors<W extends Widget> on WidgetSelector<W> {
   /// Returns a [WidgetSelector] that requires [parent] to be a parent of
   /// the to be matched widget
+  @useResult
   WidgetSelector<W> withParent(WidgetSelector parent) {
     return copyWith(parents: [...parents, parent]);
   }
 
   /// Returns a [WidgetSelector] that requires [parents] to be parents of
   /// the to be matched widget
+  @useResult
   WidgetSelector<W> withParents(List<WidgetSelector> parents) {
     return copyWith(parents: [...this.parents, ...parents]);
   }
 
   /// Returns a [WidgetSelector] that requires [child] to be a child of the to
   /// be matched widget
+  @useResult
   WidgetSelector<W> withChild(WidgetSelector child) {
     return copyWith(children: [...children, child]);
   }
 
   /// Returns a [WidgetSelector] that requires [children] to be children of the
   /// to be matched widget
+  @useResult
   WidgetSelector<W> withChildren(List<WidgetSelector> children) {
     return copyWith(children: [...this.children, ...children]);
   }

--- a/lib/src/widgets/align.g.dart
+++ b/lib/src/widgets/align.g.dart
@@ -61,45 +61,53 @@ extension AlignMatcher on WidgetMatcher<Align> {
 /// Allows filtering [Align] by the properties provided via [Diagnosticable.debugFillProperties]
 extension AlignSelector on WidgetSelector<Align> {
   /// Creates a [WidgetSelector] that finds all [Align] where alignment matches the condition
+  @useResult
   WidgetSelector<Align> whereAlignment(MatchProp<AlignmentGeometry> match) {
     return withDiagnosticProp<AlignmentGeometry>('alignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Align] where alignment equals (==) [value]
+  @useResult
   WidgetSelector<Align> withAlignment(AlignmentGeometry? value) {
     return withDiagnosticProp<AlignmentGeometry>(
         'alignment', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Align] where widthFactor matches the condition
+  @useResult
   WidgetSelector<Align> whereWidthFactor(MatchProp<double> match) {
     return withDiagnosticProp<double>('widthFactor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Align] where widthFactor equals (==) [value]
+  @useResult
   WidgetSelector<Align> withWidthFactor(double? value) {
     return withDiagnosticProp<double>(
         'widthFactor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Align] where heightFactor matches the condition
+  @useResult
   WidgetSelector<Align> whereHeightFactor(MatchProp<double> match) {
     return withDiagnosticProp<double>('heightFactor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Align] where heightFactor equals (==) [value]
+  @useResult
   WidgetSelector<Align> withHeightFactor(double? value) {
     return withDiagnosticProp<double>(
         'heightFactor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Align] where renderObject matches the condition
+  @useResult
   WidgetSelector<Align> whereRenderObject(
       MatchProp<RenderPositionedBox> match) {
     return withDiagnosticProp<RenderPositionedBox>('renderObject', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Align] where renderObject equals (==) [value]
+  @useResult
   WidgetSelector<Align> withRenderObject(RenderPositionedBox? value) {
     return withDiagnosticProp<RenderPositionedBox>(
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/anytext.g.dart
+++ b/lib/src/widgets/anytext.g.dart
@@ -305,226 +305,267 @@ extension AnyTextMatcher on WidgetMatcher<AnyText> {
 /// Allows filtering [AnyText] by the properties provided via [Diagnosticable.debugFillProperties]
 extension AnyTextSelector on WidgetSelector<AnyText> {
   /// Creates a [WidgetSelector] that finds all [AnyText] where text matches the condition
+  @useResult
   WidgetSelector<AnyText> whereText(MatchProp<String> match) {
     return withDiagnosticProp<String>('text', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where text equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withText(String? value) {
     return withDiagnosticProp<String>(
         'text', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where textDirection matches the condition
+  @useResult
   WidgetSelector<AnyText> whereTextDirection(MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where textAlign matches the condition
+  @useResult
   WidgetSelector<AnyText> whereTextAlign(MatchProp<TextAlign> match) {
     return withDiagnosticProp<TextAlign>('textAlign', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where textAlign equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withTextAlign(TextAlign? value) {
     return withDiagnosticProp<TextAlign>(
         'textAlign', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where selectionColor matches the condition
+  @useResult
   WidgetSelector<AnyText> whereSelectionColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('selectionColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where selectionColor equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withSelectionColor(Color? value) {
     return withDiagnosticProp<Color>('selectionColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where softWrap matches the condition
+  @useResult
   WidgetSelector<AnyText> whereSoftWrap(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('softWrap', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where softWrap equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withSoftWrap(bool? value) {
     return withDiagnosticProp<bool>(
         'softWrap', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where overflow matches the condition
+  @useResult
   WidgetSelector<AnyText> whereOverflow(MatchProp<TextOverflow> match) {
     return withDiagnosticProp<TextOverflow>('overflow', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where overflow equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withOverflow(TextOverflow? value) {
     return withDiagnosticProp<TextOverflow>(
         'overflow', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where maxLines matches the condition
+  @useResult
   WidgetSelector<AnyText> whereMaxLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('maxLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where maxLines equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withMaxLines(int? value) {
     return withDiagnosticProp<int>(
         'maxLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where locale matches the condition
+  @useResult
   WidgetSelector<AnyText> whereLocale(MatchProp<Locale> match) {
     return withDiagnosticProp<Locale>('locale', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where locale equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withLocale(Locale? value) {
     return withDiagnosticProp<Locale>(
         'locale', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where minLines matches the condition
+  @useResult
   WidgetSelector<AnyText> whereMinLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('minLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where minLines equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withMinLines(int? value) {
     return withDiagnosticProp<int>(
         'minLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontInherit matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontInherit(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('font_inherit', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontInherit equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontInherit(bool? value) {
     return withDiagnosticProp<bool>(
         'font_inherit', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontColor matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('font_color', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontColor equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontColor(Color? value) {
     return withDiagnosticProp<Color>(
         'font_color', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontBackgroundColor matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontBackgroundColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('font_backgroundColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontBackgroundColor equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontBackgroundColor(Color? value) {
     return withDiagnosticProp<Color>('font_backgroundColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontFamily matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontFamily(MatchProp<String> match) {
     return withDiagnosticProp<String>('font_family', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontFamily equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontFamily(String? value) {
     return withDiagnosticProp<String>(
         'font_family', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontFamilyFallback matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontFamilyFallback(MatchProp<String> match) {
     return withDiagnosticProp<String>('font_familyFallback', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontFamilyFallback equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontFamilyFallback(String? value) {
     return withDiagnosticProp<String>('font_familyFallback',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontWeight matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontWeight(MatchProp<FontWeight> match) {
     return withDiagnosticProp<FontWeight>('font_weight', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontWeight equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontWeight(FontWeight? value) {
     return withDiagnosticProp<FontWeight>(
         'font_weight', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontStyle matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontStyle(MatchProp<FontStyle> match) {
     return withDiagnosticProp<FontStyle>('font_style', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontStyle equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontStyle(FontStyle? value) {
     return withDiagnosticProp<FontStyle>(
         'font_style', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontLetterSpacing matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontLetterSpacing(MatchProp<double> match) {
     return withDiagnosticProp<double>('font_letterSpacing', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontLetterSpacing equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontLetterSpacing(double? value) {
     return withDiagnosticProp<double>('font_letterSpacing',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontWordSpacing matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontWordSpacing(MatchProp<double> match) {
     return withDiagnosticProp<double>('font_wordSpacing', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontWordSpacing equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontWordSpacing(double? value) {
     return withDiagnosticProp<double>('font_wordSpacing',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontBaseline matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontBaseline(MatchProp<TextBaseline> match) {
     return withDiagnosticProp<TextBaseline>('font_baseline', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontBaseline equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontBaseline(TextBaseline? value) {
     return withDiagnosticProp<TextBaseline>('font_baseline',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontHeight matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontHeight(MatchProp<double> match) {
     return withDiagnosticProp<double>('font_height', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontHeight equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontHeight(double? value) {
     return withDiagnosticProp<double>(
         'font_height', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontLeadingDistribution matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontLeadingDistribution(
       MatchProp<TextLeadingDistribution> match) {
     return withDiagnosticProp<TextLeadingDistribution>(
@@ -532,6 +573,7 @@ extension AnyTextSelector on WidgetSelector<AnyText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontLeadingDistribution equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontLeadingDistribution(
       TextLeadingDistribution? value) {
     return withDiagnosticProp<TextLeadingDistribution>(
@@ -540,55 +582,65 @@ extension AnyTextSelector on WidgetSelector<AnyText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontLocale matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontLocale(MatchProp<Locale> match) {
     return withDiagnosticProp<Locale>('font_locale', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontLocale equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontLocale(Locale? value) {
     return withDiagnosticProp<Locale>(
         'font_locale', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontForeground matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontForeground(MatchProp<Paint> match) {
     return withDiagnosticProp<Paint>('font_foreground', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontForeground equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontForeground(Paint? value) {
     return withDiagnosticProp<Paint>('font_foreground',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontBackground matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontBackground(MatchProp<Paint> match) {
     return withDiagnosticProp<Paint>('font_background', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontBackground equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontBackground(Paint? value) {
     return withDiagnosticProp<Paint>('font_background',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where inherit matches the condition
+  @useResult
   WidgetSelector<AnyText> whereInherit(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('inherit', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where inherit equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withInherit(bool? value) {
     return withDiagnosticProp<bool>(
         'inherit', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontSize matches the condition
+  @useResult
   WidgetSelector<AnyText> whereFontSize(MatchProp<double> match) {
     return withDiagnosticProp<double>('font_size', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [AnyText] where fontSize equals (==) [value]
+  @useResult
   WidgetSelector<AnyText> withFontSize(double? value) {
     return withDiagnosticProp<double>(
         'font_size', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/circularprogressindicator.g.dart
+++ b/lib/src/widgets/circularprogressindicator.g.dart
@@ -29,12 +29,14 @@ extension CircularProgressIndicatorMatcher
 extension CircularProgressIndicatorSelector
     on WidgetSelector<CircularProgressIndicator> {
   /// Creates a [WidgetSelector] that finds all [CircularProgressIndicator] where value matches the condition
+  @useResult
   WidgetSelector<CircularProgressIndicator> whereValue(
       MatchProp<double> match) {
     return withDiagnosticProp<double>('value', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [CircularProgressIndicator] where value equals (==) [value]
+  @useResult
   WidgetSelector<CircularProgressIndicator> withValue(double? value) {
     return withDiagnosticProp<double>(
         'value', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/column.g.dart
+++ b/lib/src/widgets/column.g.dart
@@ -107,91 +107,107 @@ extension ColumnMatcher on WidgetMatcher<Column> {
 /// Allows filtering [Column] by the properties provided via [Diagnosticable.debugFillProperties]
 extension ColumnSelector on WidgetSelector<Column> {
   /// Creates a [WidgetSelector] that finds all [Column] where direction matches the condition
+  @useResult
   WidgetSelector<Column> whereDirection(MatchProp<Axis> match) {
     return withDiagnosticProp<Axis>('direction', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where direction equals (==) [value]
+  @useResult
   WidgetSelector<Column> withDirection(Axis? value) {
     return withDiagnosticProp<Axis>(
         'direction', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where mainAxisAlignment matches the condition
+  @useResult
   WidgetSelector<Column> whereMainAxisAlignment(
       MatchProp<MainAxisAlignment> match) {
     return withDiagnosticProp<MainAxisAlignment>('mainAxisAlignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where mainAxisAlignment equals (==) [value]
+  @useResult
   WidgetSelector<Column> withMainAxisAlignment(MainAxisAlignment? value) {
     return withDiagnosticProp<MainAxisAlignment>('mainAxisAlignment',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where mainAxisSize matches the condition
+  @useResult
   WidgetSelector<Column> whereMainAxisSize(MatchProp<MainAxisSize> match) {
     return withDiagnosticProp<MainAxisSize>('mainAxisSize', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where mainAxisSize equals (==) [value]
+  @useResult
   WidgetSelector<Column> withMainAxisSize(MainAxisSize? value) {
     return withDiagnosticProp<MainAxisSize>(
         'mainAxisSize', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where crossAxisAlignment matches the condition
+  @useResult
   WidgetSelector<Column> whereCrossAxisAlignment(
       MatchProp<CrossAxisAlignment> match) {
     return withDiagnosticProp<CrossAxisAlignment>('crossAxisAlignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where crossAxisAlignment equals (==) [value]
+  @useResult
   WidgetSelector<Column> withCrossAxisAlignment(CrossAxisAlignment? value) {
     return withDiagnosticProp<CrossAxisAlignment>('crossAxisAlignment',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where textDirection matches the condition
+  @useResult
   WidgetSelector<Column> whereTextDirection(MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<Column> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where verticalDirection matches the condition
+  @useResult
   WidgetSelector<Column> whereVerticalDirection(
       MatchProp<VerticalDirection> match) {
     return withDiagnosticProp<VerticalDirection>('verticalDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where verticalDirection equals (==) [value]
+  @useResult
   WidgetSelector<Column> withVerticalDirection(VerticalDirection? value) {
     return withDiagnosticProp<VerticalDirection>('verticalDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where textBaseline matches the condition
+  @useResult
   WidgetSelector<Column> whereTextBaseline(MatchProp<TextBaseline> match) {
     return withDiagnosticProp<TextBaseline>('textBaseline', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where textBaseline equals (==) [value]
+  @useResult
   WidgetSelector<Column> withTextBaseline(TextBaseline? value) {
     return withDiagnosticProp<TextBaseline>(
         'textBaseline', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where renderObject matches the condition
+  @useResult
   WidgetSelector<Column> whereRenderObject(MatchProp<RenderFlex> match) {
     return withDiagnosticProp<RenderFlex>('renderObject', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Column] where renderObject equals (==) [value]
+  @useResult
   WidgetSelector<Column> withRenderObject(RenderFlex? value) {
     return withDiagnosticProp<RenderFlex>(
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/constrainedbox.g.dart
+++ b/lib/src/widgets/constrainedbox.g.dart
@@ -40,24 +40,28 @@ extension ConstrainedBoxMatcher on WidgetMatcher<ConstrainedBox> {
 /// Allows filtering [ConstrainedBox] by the properties provided via [Diagnosticable.debugFillProperties]
 extension ConstrainedBoxSelector on WidgetSelector<ConstrainedBox> {
   /// Creates a [WidgetSelector] that finds all [ConstrainedBox] where constraints matches the condition
+  @useResult
   WidgetSelector<ConstrainedBox> whereConstraints(
       MatchProp<BoxConstraints> match) {
     return withDiagnosticProp<BoxConstraints>('constraints', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ConstrainedBox] where constraints equals (==) [value]
+  @useResult
   WidgetSelector<ConstrainedBox> withConstraints(BoxConstraints? value) {
     return withDiagnosticProp<BoxConstraints>(
         'constraints', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ConstrainedBox] where renderObject matches the condition
+  @useResult
   WidgetSelector<ConstrainedBox> whereRenderObject(
       MatchProp<RenderConstrainedBox> match) {
     return withDiagnosticProp<RenderConstrainedBox>('renderObject', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ConstrainedBox] where renderObject equals (==) [value]
+  @useResult
   WidgetSelector<ConstrainedBox> withRenderObject(RenderConstrainedBox? value) {
     return withDiagnosticProp<RenderConstrainedBox>(
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/container.g.dart
+++ b/lib/src/widgets/container.g.dart
@@ -106,88 +106,104 @@ extension ContainerMatcher on WidgetMatcher<Container> {
 /// Allows filtering [Container] by the properties provided via [Diagnosticable.debugFillProperties]
 extension ContainerSelector on WidgetSelector<Container> {
   /// Creates a [WidgetSelector] that finds all [Container] where alignment matches the condition
+  @useResult
   WidgetSelector<Container> whereAlignment(MatchProp<AlignmentGeometry> match) {
     return withDiagnosticProp<AlignmentGeometry>('alignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where alignment equals (==) [value]
+  @useResult
   WidgetSelector<Container> withAlignment(AlignmentGeometry? value) {
     return withDiagnosticProp<AlignmentGeometry>(
         'alignment', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where padding matches the condition
+  @useResult
   WidgetSelector<Container> wherePadding(MatchProp<EdgeInsetsGeometry> match) {
     return withDiagnosticProp<EdgeInsetsGeometry>('padding', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where padding equals (==) [value]
+  @useResult
   WidgetSelector<Container> withPadding(EdgeInsetsGeometry? value) {
     return withDiagnosticProp<EdgeInsetsGeometry>(
         'padding', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where clipBehavior matches the condition
+  @useResult
   WidgetSelector<Container> whereClipBehavior(MatchProp<Clip> match) {
     return withDiagnosticProp<Clip>('clipBehavior', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where clipBehavior equals (==) [value]
+  @useResult
   WidgetSelector<Container> withClipBehavior(Clip? value) {
     return withDiagnosticProp<Clip>(
         'clipBehavior', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where background matches the condition
+  @useResult
   WidgetSelector<Container> whereBackground(MatchProp<Decoration> match) {
     return withDiagnosticProp<Decoration>('bg', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where background equals (==) [value]
+  @useResult
   WidgetSelector<Container> withBackground(Decoration? value) {
     return withDiagnosticProp<Decoration>(
         'bg', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where foreground matches the condition
+  @useResult
   WidgetSelector<Container> whereForeground(MatchProp<Decoration> match) {
     return withDiagnosticProp<Decoration>('fg', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where foreground equals (==) [value]
+  @useResult
   WidgetSelector<Container> withForeground(Decoration? value) {
     return withDiagnosticProp<Decoration>(
         'fg', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where constraints matches the condition
+  @useResult
   WidgetSelector<Container> whereConstraints(MatchProp<BoxConstraints> match) {
     return withDiagnosticProp<BoxConstraints>('constraints', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where constraints equals (==) [value]
+  @useResult
   WidgetSelector<Container> withConstraints(BoxConstraints? value) {
     return withDiagnosticProp<BoxConstraints>(
         'constraints', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where margin matches the condition
+  @useResult
   WidgetSelector<Container> whereMargin(MatchProp<EdgeInsetsGeometry> match) {
     return withDiagnosticProp<EdgeInsetsGeometry>('margin', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where margin equals (==) [value]
+  @useResult
   WidgetSelector<Container> withMargin(EdgeInsetsGeometry? value) {
     return withDiagnosticProp<EdgeInsetsGeometry>(
         'margin', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where transform matches the condition
+  @useResult
   WidgetSelector<Container> whereTransform(MatchProp<Matrix4> match) {
     return withDiagnosticProp<Matrix4>('transform', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Container] where transform equals (==) [value]
+  @useResult
   WidgetSelector<Container> withTransform(Matrix4? value) {
     return withDiagnosticProp<Matrix4>(
         'transform', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/editabletext.g.dart
+++ b/lib/src/widgets/editabletext.g.dart
@@ -496,229 +496,270 @@ extension EditableTextMatcher on WidgetMatcher<EditableText> {
 /// Allows filtering [EditableText] by the properties provided via [Diagnosticable.debugFillProperties]
 extension EditableTextSelector on WidgetSelector<EditableText> {
   /// Creates a [WidgetSelector] that finds all [EditableText] where controller matches the condition
+  @useResult
   WidgetSelector<EditableText> whereController(
       MatchProp<TextEditingController> match) {
     return withDiagnosticProp<TextEditingController>('controller', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where controller equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withController(TextEditingController? value) {
     return withDiagnosticProp<TextEditingController>(
         'controller', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where focusNode matches the condition
+  @useResult
   WidgetSelector<EditableText> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where obscureText matches the condition
+  @useResult
   WidgetSelector<EditableText> whereObscureText(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('obscureText', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where obscureText equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withObscureText(bool? value) {
     return withDiagnosticProp<bool>(
         'obscureText', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where readOnly matches the condition
+  @useResult
   WidgetSelector<EditableText> whereReadOnly(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('readOnly', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where readOnly equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withReadOnly(bool? value) {
     return withDiagnosticProp<bool>(
         'readOnly', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where autocorrect matches the condition
+  @useResult
   WidgetSelector<EditableText> whereAutocorrect(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('autocorrect', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where autocorrect equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withAutocorrect(bool? value) {
     return withDiagnosticProp<bool>(
         'autocorrect', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where smartDashesType matches the condition
+  @useResult
   WidgetSelector<EditableText> whereSmartDashesType(
       MatchProp<SmartDashesType> match) {
     return withDiagnosticProp<SmartDashesType>('smartDashesType', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where smartDashesType equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withSmartDashesType(SmartDashesType? value) {
     return withDiagnosticProp<SmartDashesType>('smartDashesType',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where smartQuotesType matches the condition
+  @useResult
   WidgetSelector<EditableText> whereSmartQuotesType(
       MatchProp<SmartQuotesType> match) {
     return withDiagnosticProp<SmartQuotesType>('smartQuotesType', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where smartQuotesType equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withSmartQuotesType(SmartQuotesType? value) {
     return withDiagnosticProp<SmartQuotesType>('smartQuotesType',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where enableSuggestions matches the condition
+  @useResult
   WidgetSelector<EditableText> whereEnableSuggestions(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enableSuggestions', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where enableSuggestions equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withEnableSuggestions(bool? value) {
     return withDiagnosticProp<bool>('enableSuggestions',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where inherit matches the condition
+  @useResult
   WidgetSelector<EditableText> whereInherit(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('inherit', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where inherit equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withInherit(bool? value) {
     return withDiagnosticProp<bool>(
         'inherit', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where color matches the condition
+  @useResult
   WidgetSelector<EditableText> whereColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('color', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where color equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withColor(Color? value) {
     return withDiagnosticProp<Color>(
         'color', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where backgroundColor matches the condition
+  @useResult
   WidgetSelector<EditableText> whereBackgroundColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('backgroundColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where backgroundColor equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withBackgroundColor(Color? value) {
     return withDiagnosticProp<Color>('backgroundColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where family matches the condition
+  @useResult
   WidgetSelector<EditableText> whereFamily(MatchProp<String> match) {
     return withDiagnosticProp<String>('family', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where family equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withFamily(String? value) {
     return withDiagnosticProp<String>(
         'family', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where familyFallback matches the condition
+  @useResult
   WidgetSelector<EditableText> whereFamilyFallback(MatchProp<String> match) {
     return withDiagnosticProp<String>('familyFallback', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where familyFallback equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withFamilyFallback(String? value) {
     return withDiagnosticProp<String>('familyFallback',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where size matches the condition
+  @useResult
   WidgetSelector<EditableText> whereSize(MatchProp<double> match) {
     return withDiagnosticProp<double>('size', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where size equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withSize(double? value) {
     return withDiagnosticProp<double>(
         'size', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where weight matches the condition
+  @useResult
   WidgetSelector<EditableText> whereWeight(MatchProp<FontWeight> match) {
     return withDiagnosticProp<FontWeight>('weight', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where weight equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withWeight(FontWeight? value) {
     return withDiagnosticProp<FontWeight>(
         'weight', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where style matches the condition
+  @useResult
   WidgetSelector<EditableText> whereStyle(MatchProp<FontStyle> match) {
     return withDiagnosticProp<FontStyle>('style', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where style equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withStyle(FontStyle? value) {
     return withDiagnosticProp<FontStyle>(
         'style', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where letterSpacing matches the condition
+  @useResult
   WidgetSelector<EditableText> whereLetterSpacing(MatchProp<double> match) {
     return withDiagnosticProp<double>('letterSpacing', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where letterSpacing equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withLetterSpacing(double? value) {
     return withDiagnosticProp<double>('letterSpacing',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where wordSpacing matches the condition
+  @useResult
   WidgetSelector<EditableText> whereWordSpacing(MatchProp<double> match) {
     return withDiagnosticProp<double>('wordSpacing', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where wordSpacing equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withWordSpacing(double? value) {
     return withDiagnosticProp<double>(
         'wordSpacing', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where baseline matches the condition
+  @useResult
   WidgetSelector<EditableText> whereBaseline(MatchProp<TextBaseline> match) {
     return withDiagnosticProp<TextBaseline>('baseline', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where baseline equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withBaseline(TextBaseline? value) {
     return withDiagnosticProp<TextBaseline>(
         'baseline', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where height matches the condition
+  @useResult
   WidgetSelector<EditableText> whereHeight(MatchProp<double> match) {
     return withDiagnosticProp<double>('height', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where height equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withHeight(double? value) {
     return withDiagnosticProp<double>(
         'height', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where leadingDistribution matches the condition
+  @useResult
   WidgetSelector<EditableText> whereLeadingDistribution(
       MatchProp<TextLeadingDistribution> match) {
     return withDiagnosticProp<TextLeadingDistribution>(
@@ -726,6 +767,7 @@ extension EditableTextSelector on WidgetSelector<EditableText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where leadingDistribution equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withLeadingDistribution(
       TextLeadingDistribution? value) {
     return withDiagnosticProp<TextLeadingDistribution>('leadingDistribution',
@@ -733,171 +775,201 @@ extension EditableTextSelector on WidgetSelector<EditableText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where locale matches the condition
+  @useResult
   WidgetSelector<EditableText> whereLocale(MatchProp<Locale> match) {
     return withDiagnosticProp<Locale>('locale', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where locale equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withLocale(Locale? value) {
     return withDiagnosticProp<Locale>(
         'locale', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where foreground matches the condition
+  @useResult
   WidgetSelector<EditableText> whereForeground(MatchProp<Paint> match) {
     return withDiagnosticProp<Paint>('foreground', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where foreground equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withForeground(Paint? value) {
     return withDiagnosticProp<Paint>(
         'foreground', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where background matches the condition
+  @useResult
   WidgetSelector<EditableText> whereBackground(MatchProp<Paint> match) {
     return withDiagnosticProp<Paint>('background', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where background equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withBackground(Paint? value) {
     return withDiagnosticProp<Paint>(
         'background', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where textAlign matches the condition
+  @useResult
   WidgetSelector<EditableText> whereTextAlign(MatchProp<TextAlign> match) {
     return withDiagnosticProp<TextAlign>('textAlign', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where textAlign equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withTextAlign(TextAlign? value) {
     return withDiagnosticProp<TextAlign>(
         'textAlign', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where textDirection matches the condition
+  @useResult
   WidgetSelector<EditableText> whereTextDirection(
       MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where textScaleFactor matches the condition
+  @useResult
   WidgetSelector<EditableText> whereTextScaleFactor(MatchProp<double> match) {
     return withDiagnosticProp<double>('textScaleFactor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where textScaleFactor equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withTextScaleFactor(double? value) {
     return withDiagnosticProp<double>('textScaleFactor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where maxLines matches the condition
+  @useResult
   WidgetSelector<EditableText> whereMaxLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('maxLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where maxLines equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withMaxLines(int? value) {
     return withDiagnosticProp<int>(
         'maxLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where minLines matches the condition
+  @useResult
   WidgetSelector<EditableText> whereMinLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('minLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where minLines equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withMinLines(int? value) {
     return withDiagnosticProp<int>(
         'minLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where expands matches the condition
+  @useResult
   WidgetSelector<EditableText> whereExpands(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('expands', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where expands equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withExpands(bool? value) {
     return withDiagnosticProp<bool>(
         'expands', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where autofocus matches the condition
+  @useResult
   WidgetSelector<EditableText> whereAutofocus(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('autofocus', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where autofocus equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withAutofocus(bool? value) {
     return withDiagnosticProp<bool>(
         'autofocus', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where keyboardType matches the condition
+  @useResult
   WidgetSelector<EditableText> whereKeyboardType(
       MatchProp<TextInputType> match) {
     return withDiagnosticProp<TextInputType>('keyboardType', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where keyboardType equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withKeyboardType(TextInputType? value) {
     return withDiagnosticProp<TextInputType>(
         'keyboardType', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where scrollController matches the condition
+  @useResult
   WidgetSelector<EditableText> whereScrollController(
       MatchProp<ScrollController> match) {
     return withDiagnosticProp<ScrollController>('scrollController', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where scrollController equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withScrollController(ScrollController? value) {
     return withDiagnosticProp<ScrollController>('scrollController',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where scrollPhysics matches the condition
+  @useResult
   WidgetSelector<EditableText> whereScrollPhysics(
       MatchProp<ScrollPhysics> match) {
     return withDiagnosticProp<ScrollPhysics>('scrollPhysics', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where scrollPhysics equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withScrollPhysics(ScrollPhysics? value) {
     return withDiagnosticProp<ScrollPhysics>('scrollPhysics',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where autofillHints matches the condition
+  @useResult
   WidgetSelector<EditableText> whereAutofillHints(
       MatchProp<Iterable<String>> match) {
     return withDiagnosticProp<Iterable<String>>('autofillHints', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where autofillHints equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withAutofillHints(Iterable<String>? value) {
     return withDiagnosticProp<Iterable<String>>('autofillHints',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where textHeightBehavior matches the condition
+  @useResult
   WidgetSelector<EditableText> whereTextHeightBehavior(
       MatchProp<TextHeightBehavior> match) {
     return withDiagnosticProp<TextHeightBehavior>('textHeightBehavior', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where textHeightBehavior equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withTextHeightBehavior(
       TextHeightBehavior? value) {
     return withDiagnosticProp<TextHeightBehavior>('textHeightBehavior',
@@ -905,47 +977,55 @@ extension EditableTextSelector on WidgetSelector<EditableText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where scribbleEnabled matches the condition
+  @useResult
   WidgetSelector<EditableText> whereScribbleEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('scribbleEnabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where scribbleEnabled equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withScribbleEnabled(bool? value) {
     return withDiagnosticProp<bool>('scribbleEnabled',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where enableIMEPersonalizedLearning matches the condition
+  @useResult
   WidgetSelector<EditableText> whereEnableIMEPersonalizedLearning(
       MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enableIMEPersonalizedLearning', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where enableIMEPersonalizedLearning equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withEnableIMEPersonalizedLearning(bool? value) {
     return withDiagnosticProp<bool>('enableIMEPersonalizedLearning',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where enableInteractiveSelection matches the condition
+  @useResult
   WidgetSelector<EditableText> whereEnableInteractiveSelection(
       MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enableInteractiveSelection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where enableInteractiveSelection equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withEnableInteractiveSelection(bool? value) {
     return withDiagnosticProp<bool>('enableInteractiveSelection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where undoController matches the condition
+  @useResult
   WidgetSelector<EditableText> whereUndoController(
       MatchProp<UndoHistoryController> match) {
     return withDiagnosticProp<UndoHistoryController>('undoController', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where undoController equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withUndoController(
       UndoHistoryController? value) {
     return withDiagnosticProp<UndoHistoryController>('undoController',
@@ -953,6 +1033,7 @@ extension EditableTextSelector on WidgetSelector<EditableText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where spellCheckConfiguration matches the condition
+  @useResult
   WidgetSelector<EditableText> whereSpellCheckConfiguration(
       MatchProp<SpellCheckConfiguration> match) {
     return withDiagnosticProp<SpellCheckConfiguration>(
@@ -960,6 +1041,7 @@ extension EditableTextSelector on WidgetSelector<EditableText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where spellCheckConfiguration equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withSpellCheckConfiguration(
       SpellCheckConfiguration? value) {
     return withDiagnosticProp<SpellCheckConfiguration>(
@@ -968,12 +1050,14 @@ extension EditableTextSelector on WidgetSelector<EditableText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where contentCommitMimeTypes matches the condition
+  @useResult
   WidgetSelector<EditableText> whereContentCommitMimeTypes(
       MatchProp<List<String>> match) {
     return withDiagnosticProp<List<String>>('contentCommitMimeTypes', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where contentCommitMimeTypes equals (==) [value]
+  @useResult
   WidgetSelector<EditableText> withContentCommitMimeTypes(List<String>? value) {
     return withDiagnosticProp<List<String>>('contentCommitMimeTypes',
         (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/elevatedbutton.g.dart
+++ b/lib/src/widgets/elevatedbutton.g.dart
@@ -48,33 +48,39 @@ extension ElevatedButtonMatcher on WidgetMatcher<ElevatedButton> {
 /// Allows filtering [ElevatedButton] by the properties provided via [Diagnosticable.debugFillProperties]
 extension ElevatedButtonSelector on WidgetSelector<ElevatedButton> {
   /// Creates a [WidgetSelector] that finds all [ElevatedButton] where enabled matches the condition
+  @useResult
   WidgetSelector<ElevatedButton> whereEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ElevatedButton] where enabled equals (==) [value]
+  @useResult
   WidgetSelector<ElevatedButton> withEnabled(bool? value) {
     return withDiagnosticProp<bool>(
         'enabled', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ElevatedButton] where style matches the condition
+  @useResult
   WidgetSelector<ElevatedButton> whereStyle(MatchProp<ButtonStyle> match) {
     return withDiagnosticProp<ButtonStyle>('style', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ElevatedButton] where style equals (==) [value]
+  @useResult
   WidgetSelector<ElevatedButton> withStyle(ButtonStyle? value) {
     return withDiagnosticProp<ButtonStyle>(
         'style', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ElevatedButton] where focusNode matches the condition
+  @useResult
   WidgetSelector<ElevatedButton> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ElevatedButton] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<ElevatedButton> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/floatingactionbutton.g.dart
+++ b/lib/src/widgets/floatingactionbutton.g.dart
@@ -207,180 +207,211 @@ extension FloatingActionButtonMatcher on WidgetMatcher<FloatingActionButton> {
 /// Allows filtering [FloatingActionButton] by the properties provided via [Diagnosticable.debugFillProperties]
 extension FloatingActionButtonSelector on WidgetSelector<FloatingActionButton> {
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where tooltip matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereTooltip(MatchProp<String> match) {
     return withDiagnosticProp<String>('tooltip', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where tooltip equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withTooltip(String? value) {
     return withDiagnosticProp<String>(
         'tooltip', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where foregroundColor matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereForegroundColor(
       MatchProp<Color> match) {
     return withDiagnosticProp<Color>('foregroundColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where foregroundColor equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withForegroundColor(Color? value) {
     return withDiagnosticProp<Color>('foregroundColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where backgroundColor matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereBackgroundColor(
       MatchProp<Color> match) {
     return withDiagnosticProp<Color>('backgroundColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where backgroundColor equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withBackgroundColor(Color? value) {
     return withDiagnosticProp<Color>('backgroundColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where focusColor matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereFocusColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('focusColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where focusColor equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withFocusColor(Color? value) {
     return withDiagnosticProp<Color>(
         'focusColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where hoverColor matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereHoverColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('hoverColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where hoverColor equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withHoverColor(Color? value) {
     return withDiagnosticProp<Color>(
         'hoverColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where splashColor matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereSplashColor(
       MatchProp<Color> match) {
     return withDiagnosticProp<Color>('splashColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where splashColor equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withSplashColor(Color? value) {
     return withDiagnosticProp<Color>(
         'splashColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where heroTag matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereHeroTag(MatchProp<Object> match) {
     return withDiagnosticProp<Object>('heroTag', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where heroTag equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withHeroTag(Object? value) {
     return withDiagnosticProp<Object>(
         'heroTag', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where elevation matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereElevation(MatchProp<double> match) {
     return withDiagnosticProp<double>('elevation', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where elevation equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withElevation(double? value) {
     return withDiagnosticProp<double>(
         'elevation', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where focusElevation matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereFocusElevation(
       MatchProp<double> match) {
     return withDiagnosticProp<double>('focusElevation', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where focusElevation equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withFocusElevation(double? value) {
     return withDiagnosticProp<double>('focusElevation',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where hoverElevation matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereHoverElevation(
       MatchProp<double> match) {
     return withDiagnosticProp<double>('hoverElevation', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where hoverElevation equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withHoverElevation(double? value) {
     return withDiagnosticProp<double>('hoverElevation',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where highlightElevation matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereHighlightElevation(
       MatchProp<double> match) {
     return withDiagnosticProp<double>('highlightElevation', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where highlightElevation equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withHighlightElevation(double? value) {
     return withDiagnosticProp<double>('highlightElevation',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where disabledElevation matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereDisabledElevation(
       MatchProp<double> match) {
     return withDiagnosticProp<double>('disabledElevation', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where disabledElevation equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withDisabledElevation(double? value) {
     return withDiagnosticProp<double>('disabledElevation',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where shape matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereShape(
       MatchProp<ShapeBorder> match) {
     return withDiagnosticProp<ShapeBorder>('shape', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where shape equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withShape(ShapeBorder? value) {
     return withDiagnosticProp<ShapeBorder>(
         'shape', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where focusNode matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereFocusNode(
       MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where isExtended matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereIsExtended(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('isExtended', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where isExtended equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withIsExtended(bool? value) {
     return withDiagnosticProp<bool>(
         'isExtended', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where materialTapTargetSize matches the condition
+  @useResult
   WidgetSelector<FloatingActionButton> whereMaterialTapTargetSize(
       MatchProp<MaterialTapTargetSize> match) {
     return withDiagnosticProp<MaterialTapTargetSize>(
@@ -388,6 +419,7 @@ extension FloatingActionButtonSelector on WidgetSelector<FloatingActionButton> {
   }
 
   /// Creates a [WidgetSelector] that finds all [FloatingActionButton] where materialTapTargetSize equals (==) [value]
+  @useResult
   WidgetSelector<FloatingActionButton> withMaterialTapTargetSize(
       MaterialTapTargetSize? value) {
     return withDiagnosticProp<MaterialTapTargetSize>('materialTapTargetSize',

--- a/lib/src/widgets/gridview.g.dart
+++ b/lib/src/widgets/gridview.g.dart
@@ -93,77 +93,91 @@ extension GridViewMatcher on WidgetMatcher<GridView> {
 /// Allows filtering [GridView] by the properties provided via [Diagnosticable.debugFillProperties]
 extension GridViewSelector on WidgetSelector<GridView> {
   /// Creates a [WidgetSelector] that finds all [GridView] where scrollDirection matches the condition
+  @useResult
   WidgetSelector<GridView> whereScrollDirection(MatchProp<Axis> match) {
     return withDiagnosticProp<Axis>('scrollDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where scrollDirection equals (==) [value]
+  @useResult
   WidgetSelector<GridView> withScrollDirection(Axis? value) {
     return withDiagnosticProp<Axis>('scrollDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where reverse matches the condition
+  @useResult
   WidgetSelector<GridView> whereReverse(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('reverse', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where reverse equals (==) [value]
+  @useResult
   WidgetSelector<GridView> withReverse(bool? value) {
     return withDiagnosticProp<bool>(
         'reverse', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where controller matches the condition
+  @useResult
   WidgetSelector<GridView> whereController(MatchProp<ScrollController> match) {
     return withDiagnosticProp<ScrollController>('controller', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where controller equals (==) [value]
+  @useResult
   WidgetSelector<GridView> withController(ScrollController? value) {
     return withDiagnosticProp<ScrollController>(
         'controller', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where primary matches the condition
+  @useResult
   WidgetSelector<GridView> wherePrimary(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('primary', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where primary equals (==) [value]
+  @useResult
   WidgetSelector<GridView> withPrimary(bool? value) {
     return withDiagnosticProp<bool>(
         'primary', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where physics matches the condition
+  @useResult
   WidgetSelector<GridView> wherePhysics(MatchProp<ScrollPhysics> match) {
     return withDiagnosticProp<ScrollPhysics>('physics', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where physics equals (==) [value]
+  @useResult
   WidgetSelector<GridView> withPhysics(ScrollPhysics? value) {
     return withDiagnosticProp<ScrollPhysics>(
         'physics', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where shrinkWrap matches the condition
+  @useResult
   WidgetSelector<GridView> whereShrinkWrap(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('shrinkWrap', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where shrinkWrap equals (==) [value]
+  @useResult
   WidgetSelector<GridView> withShrinkWrap(bool? value) {
     return withDiagnosticProp<bool>(
         'shrinkWrap', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where padding matches the condition
+  @useResult
   WidgetSelector<GridView> wherePadding(MatchProp<EdgeInsetsGeometry> match) {
     return withDiagnosticProp<EdgeInsetsGeometry>('padding', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [GridView] where padding equals (==) [value]
+  @useResult
   WidgetSelector<GridView> withPadding(EdgeInsetsGeometry? value) {
     return withDiagnosticProp<EdgeInsetsGeometry>(
         'padding', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/icon.g.dart
+++ b/lib/src/widgets/icon.g.dart
@@ -120,139 +120,137 @@ extension IconMatcher on WidgetMatcher<Icon> {
     return hasDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
-
-  /// Expects that applyTextScaling of [Icon] matches the condition in [match]
-  WidgetMatcher<Icon> hasApplyTextScalingWhere(MatchProp<bool> match) {
-    return hasDiagnosticProp<bool>('applyTextScaling', match);
-  }
-
-  /// Expects that applyTextScaling of [Icon] equals (==) [value]
-  WidgetMatcher<Icon> hasApplyTextScaling(bool? value) {
-    return hasDiagnosticProp<bool>('applyTextScaling',
-        (it) => value == null ? it.isNull() : it.equals(value));
-  }
 }
 
 /// Allows filtering [Icon] by the properties provided via [Diagnosticable.debugFillProperties]
 extension IconSelector on WidgetSelector<Icon> {
   /// Creates a [WidgetSelector] that finds all [Icon] where icon matches the condition
+  @useResult
   WidgetSelector<Icon> whereIcon(MatchProp<IconData> match) {
     return withDiagnosticProp<IconData>('icon', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where icon equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withIcon(IconData? value) {
     return withDiagnosticProp<IconData>(
         'icon', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where size matches the condition
+  @useResult
   WidgetSelector<Icon> whereSize(MatchProp<double> match) {
     return withDiagnosticProp<double>('size', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where size equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withSize(double? value) {
     return withDiagnosticProp<double>(
         'size', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where fill matches the condition
+  @useResult
   WidgetSelector<Icon> whereFill(MatchProp<double> match) {
     return withDiagnosticProp<double>('fill', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where fill equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withFill(double? value) {
     return withDiagnosticProp<double>(
         'fill', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where weight matches the condition
+  @useResult
   WidgetSelector<Icon> whereWeight(MatchProp<double> match) {
     return withDiagnosticProp<double>('weight', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where weight equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withWeight(double? value) {
     return withDiagnosticProp<double>(
         'weight', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where grade matches the condition
+  @useResult
   WidgetSelector<Icon> whereGrade(MatchProp<double> match) {
     return withDiagnosticProp<double>('grade', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where grade equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withGrade(double? value) {
     return withDiagnosticProp<double>(
         'grade', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where opticalSize matches the condition
+  @useResult
   WidgetSelector<Icon> whereOpticalSize(MatchProp<double> match) {
     return withDiagnosticProp<double>('opticalSize', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where opticalSize equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withOpticalSize(double? value) {
     return withDiagnosticProp<double>(
         'opticalSize', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where color matches the condition
+  @useResult
   WidgetSelector<Icon> whereColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('color', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where color equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withColor(Color? value) {
     return withDiagnosticProp<Color>(
         'color', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where shadows matches the condition
+  @useResult
   WidgetSelector<Icon> whereShadows(MatchProp<Shadow> match) {
     return withDiagnosticProp<Shadow>('shadows', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where shadows equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withShadows(Shadow? value) {
     return withDiagnosticProp<Shadow>(
         'shadows', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where semanticLabel matches the condition
+  @useResult
   WidgetSelector<Icon> whereSemanticLabel(MatchProp<String> match) {
     return withDiagnosticProp<String>('semanticLabel', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where semanticLabel equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withSemanticLabel(String? value) {
     return withDiagnosticProp<String>('semanticLabel',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where textDirection matches the condition
+  @useResult
   WidgetSelector<Icon> whereTextDirection(MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<Icon> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
-        (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
-  /// Creates a [WidgetSelector] that finds all [Icon] where applyTextScaling matches the condition
-  WidgetSelector<Icon> whereApplyTextScaling(MatchProp<bool> match) {
-    return withDiagnosticProp<bool>('applyTextScaling', match);
-  }
-
-  /// Creates a [WidgetSelector] that finds all [Icon] where applyTextScaling equals (==) [value]
-  WidgetSelector<Icon> withApplyTextScaling(bool? value) {
-    return withDiagnosticProp<bool>('applyTextScaling',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }

--- a/lib/src/widgets/iconbutton.g.dart
+++ b/lib/src/widgets/iconbutton.g.dart
@@ -126,110 +126,130 @@ extension IconButtonMatcher on WidgetMatcher<IconButton> {
 /// Allows filtering [IconButton] by the properties provided via [Diagnosticable.debugFillProperties]
 extension IconButtonSelector on WidgetSelector<IconButton> {
   /// Creates a [WidgetSelector] that finds all [IconButton] where icon matches the condition
+  @useResult
   WidgetSelector<IconButton> whereIcon(MatchProp<Widget> match) {
     return withDiagnosticProp<Widget>('icon', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where icon equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withIcon(Widget? value) {
     return withDiagnosticProp<Widget>(
         'icon', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where tooltip matches the condition
+  @useResult
   WidgetSelector<IconButton> whereTooltip(MatchProp<String> match) {
     return withDiagnosticProp<String>('tooltip', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where tooltip equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withTooltip(String? value) {
     return withDiagnosticProp<String>(
         'tooltip', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where color matches the condition
+  @useResult
   WidgetSelector<IconButton> whereColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('color', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where color equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withColor(Color? value) {
     return withDiagnosticProp<Color>(
         'color', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where disabledColor matches the condition
+  @useResult
   WidgetSelector<IconButton> whereDisabledColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('disabledColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where disabledColor equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withDisabledColor(Color? value) {
     return withDiagnosticProp<Color>('disabledColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where focusColor matches the condition
+  @useResult
   WidgetSelector<IconButton> whereFocusColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('focusColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where focusColor equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withFocusColor(Color? value) {
     return withDiagnosticProp<Color>(
         'focusColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where hoverColor matches the condition
+  @useResult
   WidgetSelector<IconButton> whereHoverColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('hoverColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where hoverColor equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withHoverColor(Color? value) {
     return withDiagnosticProp<Color>(
         'hoverColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where highlightColor matches the condition
+  @useResult
   WidgetSelector<IconButton> whereHighlightColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('highlightColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where highlightColor equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withHighlightColor(Color? value) {
     return withDiagnosticProp<Color>('highlightColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where splashColor matches the condition
+  @useResult
   WidgetSelector<IconButton> whereSplashColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('splashColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where splashColor equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withSplashColor(Color? value) {
     return withDiagnosticProp<Color>(
         'splashColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where padding matches the condition
+  @useResult
   WidgetSelector<IconButton> wherePadding(MatchProp<EdgeInsetsGeometry> match) {
     return withDiagnosticProp<EdgeInsetsGeometry>('padding', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where padding equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withPadding(EdgeInsetsGeometry? value) {
     return withDiagnosticProp<EdgeInsetsGeometry>(
         'padding', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where focusNode matches the condition
+  @useResult
   WidgetSelector<IconButton> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [IconButton] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<IconButton> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/image.g.dart
+++ b/lib/src/widgets/image.g.dart
@@ -191,176 +191,208 @@ extension ImageMatcher on WidgetMatcher<Image> {
 /// Allows filtering [Image] by the properties provided via [Diagnosticable.debugFillProperties]
 extension ImageSelector on WidgetSelector<Image> {
   /// Creates a [WidgetSelector] that finds all [Image] where image matches the condition
+  @useResult
   WidgetSelector<Image> whereImage(MatchProp<ImageProvider<Object>> match) {
     return withDiagnosticProp<ImageProvider<Object>>('image', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where image equals (==) [value]
+  @useResult
   WidgetSelector<Image> withImage(ImageProvider<Object>? value) {
     return withDiagnosticProp<ImageProvider<Object>>(
         'image', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where frameBuilder matches the condition
+  @useResult
   WidgetSelector<Image> whereFrameBuilder(MatchProp<Function> match) {
     return withDiagnosticProp<Function>('frameBuilder', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where frameBuilder equals (==) [value]
+  @useResult
   WidgetSelector<Image> withFrameBuilder(Function? value) {
     return withDiagnosticProp<Function>(
         'frameBuilder', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where loadingBuilder matches the condition
+  @useResult
   WidgetSelector<Image> whereLoadingBuilder(MatchProp<Function> match) {
     return withDiagnosticProp<Function>('loadingBuilder', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where loadingBuilder equals (==) [value]
+  @useResult
   WidgetSelector<Image> withLoadingBuilder(Function? value) {
     return withDiagnosticProp<Function>('loadingBuilder',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where width matches the condition
+  @useResult
   WidgetSelector<Image> whereWidth(MatchProp<double> match) {
     return withDiagnosticProp<double>('width', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where width equals (==) [value]
+  @useResult
   WidgetSelector<Image> withWidth(double? value) {
     return withDiagnosticProp<double>(
         'width', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where height matches the condition
+  @useResult
   WidgetSelector<Image> whereHeight(MatchProp<double> match) {
     return withDiagnosticProp<double>('height', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where height equals (==) [value]
+  @useResult
   WidgetSelector<Image> withHeight(double? value) {
     return withDiagnosticProp<double>(
         'height', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where color matches the condition
+  @useResult
   WidgetSelector<Image> whereColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('color', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where color equals (==) [value]
+  @useResult
   WidgetSelector<Image> withColor(Color? value) {
     return withDiagnosticProp<Color>(
         'color', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where opacity matches the condition
+  @useResult
   WidgetSelector<Image> whereOpacity(MatchProp<Animation<double>?> match) {
     return withDiagnosticProp<Animation<double>?>('opacity', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where opacity equals (==) [value]
+  @useResult
   WidgetSelector<Image> withOpacity(Animation<double>? value) {
     return withDiagnosticProp<Animation<double>?>(
         'opacity', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where colorBlendMode matches the condition
+  @useResult
   WidgetSelector<Image> whereColorBlendMode(MatchProp<BlendMode> match) {
     return withDiagnosticProp<BlendMode>('colorBlendMode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where colorBlendMode equals (==) [value]
+  @useResult
   WidgetSelector<Image> withColorBlendMode(BlendMode? value) {
     return withDiagnosticProp<BlendMode>('colorBlendMode',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where fit matches the condition
+  @useResult
   WidgetSelector<Image> whereFit(MatchProp<BoxFit> match) {
     return withDiagnosticProp<BoxFit>('fit', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where fit equals (==) [value]
+  @useResult
   WidgetSelector<Image> withFit(BoxFit? value) {
     return withDiagnosticProp<BoxFit>(
         'fit', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where alignment matches the condition
+  @useResult
   WidgetSelector<Image> whereAlignment(MatchProp<AlignmentGeometry> match) {
     return withDiagnosticProp<AlignmentGeometry>('alignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where alignment equals (==) [value]
+  @useResult
   WidgetSelector<Image> withAlignment(AlignmentGeometry? value) {
     return withDiagnosticProp<AlignmentGeometry>(
         'alignment', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where repeat matches the condition
+  @useResult
   WidgetSelector<Image> whereRepeat(MatchProp<ImageRepeat> match) {
     return withDiagnosticProp<ImageRepeat>('repeat', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where repeat equals (==) [value]
+  @useResult
   WidgetSelector<Image> withRepeat(ImageRepeat? value) {
     return withDiagnosticProp<ImageRepeat>(
         'repeat', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where centerSlice matches the condition
+  @useResult
   WidgetSelector<Image> whereCenterSlice(MatchProp<Rect> match) {
     return withDiagnosticProp<Rect>('centerSlice', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where centerSlice equals (==) [value]
+  @useResult
   WidgetSelector<Image> withCenterSlice(Rect? value) {
     return withDiagnosticProp<Rect>(
         'centerSlice', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where matchTextDirection matches the condition
+  @useResult
   WidgetSelector<Image> whereMatchTextDirection(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('matchTextDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where matchTextDirection equals (==) [value]
+  @useResult
   WidgetSelector<Image> withMatchTextDirection(bool? value) {
     return withDiagnosticProp<bool>('matchTextDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where semanticLabel matches the condition
+  @useResult
   WidgetSelector<Image> whereSemanticLabel(MatchProp<String> match) {
     return withDiagnosticProp<String>('semanticLabel', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where semanticLabel equals (==) [value]
+  @useResult
   WidgetSelector<Image> withSemanticLabel(String? value) {
     return withDiagnosticProp<String>('semanticLabel',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where excludeFromSemantics matches the condition
+  @useResult
   WidgetSelector<Image> whereExcludeFromSemantics(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('this.excludeFromSemantics', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where excludeFromSemantics equals (==) [value]
+  @useResult
   WidgetSelector<Image> withExcludeFromSemantics(bool? value) {
     return withDiagnosticProp<bool>('this.excludeFromSemantics',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where filterQuality matches the condition
+  @useResult
   WidgetSelector<Image> whereFilterQuality(MatchProp<FilterQuality> match) {
     return withDiagnosticProp<FilterQuality>('filterQuality', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Image] where filterQuality equals (==) [value]
+  @useResult
   WidgetSelector<Image> withFilterQuality(FilterQuality? value) {
     return withDiagnosticProp<FilterQuality>('filterQuality',
         (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/linearprogressindicator.g.dart
+++ b/lib/src/widgets/linearprogressindicator.g.dart
@@ -29,11 +29,13 @@ extension LinearProgressIndicatorMatcher
 extension LinearProgressIndicatorSelector
     on WidgetSelector<LinearProgressIndicator> {
   /// Creates a [WidgetSelector] that finds all [LinearProgressIndicator] where value matches the condition
+  @useResult
   WidgetSelector<LinearProgressIndicator> whereValue(MatchProp<double> match) {
     return withDiagnosticProp<double>('value', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [LinearProgressIndicator] where value equals (==) [value]
+  @useResult
   WidgetSelector<LinearProgressIndicator> withValue(double? value) {
     return withDiagnosticProp<double>(
         'value', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/listtile.g.dart
+++ b/lib/src/widgets/listtile.g.dart
@@ -372,355 +372,419 @@ extension ListTileMatcher on WidgetMatcher<ListTile> {
 /// Allows filtering [ListTile] by the properties provided via [Diagnosticable.debugFillProperties]
 extension ListTileSelector on WidgetSelector<ListTile> {
   /// Creates a [WidgetSelector] that finds all [ListTile] where leading matches the condition
+  @useResult
   WidgetSelector<ListTile> whereLeading(MatchProp<Widget> match) {
     return withDiagnosticProp<Widget>('leading', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where leading equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withLeading(Widget? value) {
     return withDiagnosticProp<Widget>(
         'leading', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where title matches the condition
+  @useResult
   WidgetSelector<ListTile> whereTitle(MatchProp<Widget> match) {
     return withDiagnosticProp<Widget>('title', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where title equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withTitle(Widget? value) {
     return withDiagnosticProp<Widget>(
         'title', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where subtitle matches the condition
+  @useResult
   WidgetSelector<ListTile> whereSubtitle(MatchProp<Widget> match) {
     return withDiagnosticProp<Widget>('subtitle', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where subtitle equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withSubtitle(Widget? value) {
     return withDiagnosticProp<Widget>(
         'subtitle', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where trailing matches the condition
+  @useResult
   WidgetSelector<ListTile> whereTrailing(MatchProp<Widget> match) {
     return withDiagnosticProp<Widget>('trailing', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where trailing equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withTrailing(Widget? value) {
     return withDiagnosticProp<Widget>(
         'trailing', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where isThreeLine matches the condition
+  @useResult
   WidgetSelector<ListTile> whereIsThreeLine(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('isThreeLine', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where isThreeLine equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withIsThreeLine(bool? value) {
     return withDiagnosticProp<bool>(
         'isThreeLine', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where dense matches the condition
+  @useResult
   WidgetSelector<ListTile> whereDense(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('dense', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where dense equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withDense(bool? value) {
     return withDiagnosticProp<bool>(
         'dense', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where visualDensity matches the condition
+  @useResult
   WidgetSelector<ListTile> whereVisualDensity(MatchProp<VisualDensity> match) {
     return withDiagnosticProp<VisualDensity>('visualDensity', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where visualDensity equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withVisualDensity(VisualDensity? value) {
     return withDiagnosticProp<VisualDensity>('visualDensity',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where shape matches the condition
+  @useResult
   WidgetSelector<ListTile> whereShape(MatchProp<ShapeBorder> match) {
     return withDiagnosticProp<ShapeBorder>('shape', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where shape equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withShape(ShapeBorder? value) {
     return withDiagnosticProp<ShapeBorder>(
         'shape', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where style matches the condition
+  @useResult
   WidgetSelector<ListTile> whereStyle(MatchProp<ListTileStyle> match) {
     return withDiagnosticProp<ListTileStyle>('style', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where style equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withStyle(ListTileStyle? value) {
     return withDiagnosticProp<ListTileStyle>(
         'style', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where selectedColor matches the condition
+  @useResult
   WidgetSelector<ListTile> whereSelectedColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('selectedColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where selectedColor equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withSelectedColor(Color? value) {
     return withDiagnosticProp<Color>('selectedColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where iconColor matches the condition
+  @useResult
   WidgetSelector<ListTile> whereIconColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('iconColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where iconColor equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withIconColor(Color? value) {
     return withDiagnosticProp<Color>(
         'iconColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where textColor matches the condition
+  @useResult
   WidgetSelector<ListTile> whereTextColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('textColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where textColor equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withTextColor(Color? value) {
     return withDiagnosticProp<Color>(
         'textColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where titleTextStyle matches the condition
+  @useResult
   WidgetSelector<ListTile> whereTitleTextStyle(MatchProp<TextStyle> match) {
     return withDiagnosticProp<TextStyle>('titleTextStyle', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where titleTextStyle equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withTitleTextStyle(TextStyle? value) {
     return withDiagnosticProp<TextStyle>('titleTextStyle',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where subtitleTextStyle matches the condition
+  @useResult
   WidgetSelector<ListTile> whereSubtitleTextStyle(MatchProp<TextStyle> match) {
     return withDiagnosticProp<TextStyle>('subtitleTextStyle', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where subtitleTextStyle equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withSubtitleTextStyle(TextStyle? value) {
     return withDiagnosticProp<TextStyle>('subtitleTextStyle',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where leadingAndTrailingTextStyle matches the condition
+  @useResult
   WidgetSelector<ListTile> whereLeadingAndTrailingTextStyle(
       MatchProp<TextStyle> match) {
     return withDiagnosticProp<TextStyle>('leadingAndTrailingTextStyle', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where leadingAndTrailingTextStyle equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withLeadingAndTrailingTextStyle(TextStyle? value) {
     return withDiagnosticProp<TextStyle>('leadingAndTrailingTextStyle',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where contentPadding matches the condition
+  @useResult
   WidgetSelector<ListTile> whereContentPadding(
       MatchProp<EdgeInsetsGeometry> match) {
     return withDiagnosticProp<EdgeInsetsGeometry>('contentPadding', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where contentPadding equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withContentPadding(EdgeInsetsGeometry? value) {
     return withDiagnosticProp<EdgeInsetsGeometry>('contentPadding',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where enabled matches the condition
+  @useResult
   WidgetSelector<ListTile> whereEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where enabled equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withEnabled(bool? value) {
     return withDiagnosticProp<bool>(
         'enabled', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where onTap matches the condition
+  @useResult
   WidgetSelector<ListTile> whereOnTap(MatchProp<Function> match) {
     return withDiagnosticProp<Function>('onTap', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where onTap equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withOnTap(Function? value) {
     return withDiagnosticProp<Function>(
         'onTap', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where onLongPress matches the condition
+  @useResult
   WidgetSelector<ListTile> whereOnLongPress(MatchProp<Function> match) {
     return withDiagnosticProp<Function>('onLongPress', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where onLongPress equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withOnLongPress(Function? value) {
     return withDiagnosticProp<Function>(
         'onLongPress', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where mouseCursor matches the condition
+  @useResult
   WidgetSelector<ListTile> whereMouseCursor(MatchProp<MouseCursor> match) {
     return withDiagnosticProp<MouseCursor>('mouseCursor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where mouseCursor equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withMouseCursor(MouseCursor? value) {
     return withDiagnosticProp<MouseCursor>(
         'mouseCursor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where selected matches the condition
+  @useResult
   WidgetSelector<ListTile> whereSelected(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('selected', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where selected equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withSelected(bool? value) {
     return withDiagnosticProp<bool>(
         'selected', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where focusColor matches the condition
+  @useResult
   WidgetSelector<ListTile> whereFocusColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('focusColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where focusColor equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withFocusColor(Color? value) {
     return withDiagnosticProp<Color>(
         'focusColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where hoverColor matches the condition
+  @useResult
   WidgetSelector<ListTile> whereHoverColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('hoverColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where hoverColor equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withHoverColor(Color? value) {
     return withDiagnosticProp<Color>(
         'hoverColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where focusNode matches the condition
+  @useResult
   WidgetSelector<ListTile> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where autofocus matches the condition
+  @useResult
   WidgetSelector<ListTile> whereAutofocus(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('autofocus', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where autofocus equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withAutofocus(bool? value) {
     return withDiagnosticProp<bool>(
         'autofocus', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where tileColor matches the condition
+  @useResult
   WidgetSelector<ListTile> whereTileColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('tileColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where tileColor equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withTileColor(Color? value) {
     return withDiagnosticProp<Color>(
         'tileColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where selectedTileColor matches the condition
+  @useResult
   WidgetSelector<ListTile> whereSelectedTileColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('selectedTileColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where selectedTileColor equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withSelectedTileColor(Color? value) {
     return withDiagnosticProp<Color>('selectedTileColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where enableFeedback matches the condition
+  @useResult
   WidgetSelector<ListTile> whereEnableFeedback(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enableFeedback', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where enableFeedback equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withEnableFeedback(bool? value) {
     return withDiagnosticProp<bool>('enableFeedback',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where horizontalTitleGap matches the condition
+  @useResult
   WidgetSelector<ListTile> whereHorizontalTitleGap(MatchProp<double> match) {
     return withDiagnosticProp<double>('horizontalTitleGap', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where horizontalTitleGap equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withHorizontalTitleGap(double? value) {
     return withDiagnosticProp<double>('horizontalTitleGap',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where minVerticalPadding matches the condition
+  @useResult
   WidgetSelector<ListTile> whereMinVerticalPadding(MatchProp<double> match) {
     return withDiagnosticProp<double>('minVerticalPadding', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where minVerticalPadding equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withMinVerticalPadding(double? value) {
     return withDiagnosticProp<double>('minVerticalPadding',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where minLeadingWidth matches the condition
+  @useResult
   WidgetSelector<ListTile> whereMinLeadingWidth(MatchProp<double> match) {
     return withDiagnosticProp<double>('minLeadingWidth', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where minLeadingWidth equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withMinLeadingWidth(double? value) {
     return withDiagnosticProp<double>('minLeadingWidth',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where titleAlignment matches the condition
+  @useResult
   WidgetSelector<ListTile> whereTitleAlignment(
       MatchProp<ListTileTitleAlignment> match) {
     return withDiagnosticProp<ListTileTitleAlignment>('titleAlignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [ListTile] where titleAlignment equals (==) [value]
+  @useResult
   WidgetSelector<ListTile> withTitleAlignment(ListTileTitleAlignment? value) {
     return withDiagnosticProp<ListTileTitleAlignment>('titleAlignment',
         (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/opacity.g.dart
+++ b/lib/src/widgets/opacity.g.dart
@@ -49,33 +49,39 @@ extension OpacityMatcher on WidgetMatcher<Opacity> {
 /// Allows filtering [Opacity] by the properties provided via [Diagnosticable.debugFillProperties]
 extension OpacitySelector on WidgetSelector<Opacity> {
   /// Creates a [WidgetSelector] that finds all [Opacity] where opacity matches the condition
+  @useResult
   WidgetSelector<Opacity> whereOpacity(MatchProp<double> match) {
     return withDiagnosticProp<double>('opacity', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Opacity] where opacity equals (==) [value]
+  @useResult
   WidgetSelector<Opacity> withOpacity(double? value) {
     return withDiagnosticProp<double>(
         'opacity', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Opacity] where alwaysIncludeSemantics matches the condition
+  @useResult
   WidgetSelector<Opacity> whereAlwaysIncludeSemantics(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('alwaysIncludeSemantics', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Opacity] where alwaysIncludeSemantics equals (==) [value]
+  @useResult
   WidgetSelector<Opacity> withAlwaysIncludeSemantics(bool? value) {
     return withDiagnosticProp<bool>('alwaysIncludeSemantics',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Opacity] where renderObject matches the condition
+  @useResult
   WidgetSelector<Opacity> whereRenderObject(MatchProp<RenderOpacity> match) {
     return withDiagnosticProp<RenderOpacity>('renderObject', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Opacity] where renderObject equals (==) [value]
+  @useResult
   WidgetSelector<Opacity> withRenderObject(RenderOpacity? value) {
     return withDiagnosticProp<RenderOpacity>(
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/outlinedbutton.g.dart
+++ b/lib/src/widgets/outlinedbutton.g.dart
@@ -48,33 +48,39 @@ extension OutlinedButtonMatcher on WidgetMatcher<OutlinedButton> {
 /// Allows filtering [OutlinedButton] by the properties provided via [Diagnosticable.debugFillProperties]
 extension OutlinedButtonSelector on WidgetSelector<OutlinedButton> {
   /// Creates a [WidgetSelector] that finds all [OutlinedButton] where enabled matches the condition
+  @useResult
   WidgetSelector<OutlinedButton> whereEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [OutlinedButton] where enabled equals (==) [value]
+  @useResult
   WidgetSelector<OutlinedButton> withEnabled(bool? value) {
     return withDiagnosticProp<bool>(
         'enabled', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [OutlinedButton] where style matches the condition
+  @useResult
   WidgetSelector<OutlinedButton> whereStyle(MatchProp<ButtonStyle> match) {
     return withDiagnosticProp<ButtonStyle>('style', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [OutlinedButton] where style equals (==) [value]
+  @useResult
   WidgetSelector<OutlinedButton> withStyle(ButtonStyle? value) {
     return withDiagnosticProp<ButtonStyle>(
         'style', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [OutlinedButton] where focusNode matches the condition
+  @useResult
   WidgetSelector<OutlinedButton> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [OutlinedButton] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<OutlinedButton> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/row.g.dart
+++ b/lib/src/widgets/row.g.dart
@@ -107,91 +107,107 @@ extension RowMatcher on WidgetMatcher<Row> {
 /// Allows filtering [Row] by the properties provided via [Diagnosticable.debugFillProperties]
 extension RowSelector on WidgetSelector<Row> {
   /// Creates a [WidgetSelector] that finds all [Row] where direction matches the condition
+  @useResult
   WidgetSelector<Row> whereDirection(MatchProp<Axis> match) {
     return withDiagnosticProp<Axis>('direction', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where direction equals (==) [value]
+  @useResult
   WidgetSelector<Row> withDirection(Axis? value) {
     return withDiagnosticProp<Axis>(
         'direction', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where mainAxisAlignment matches the condition
+  @useResult
   WidgetSelector<Row> whereMainAxisAlignment(
       MatchProp<MainAxisAlignment> match) {
     return withDiagnosticProp<MainAxisAlignment>('mainAxisAlignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where mainAxisAlignment equals (==) [value]
+  @useResult
   WidgetSelector<Row> withMainAxisAlignment(MainAxisAlignment? value) {
     return withDiagnosticProp<MainAxisAlignment>('mainAxisAlignment',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where mainAxisSize matches the condition
+  @useResult
   WidgetSelector<Row> whereMainAxisSize(MatchProp<MainAxisSize> match) {
     return withDiagnosticProp<MainAxisSize>('mainAxisSize', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where mainAxisSize equals (==) [value]
+  @useResult
   WidgetSelector<Row> withMainAxisSize(MainAxisSize? value) {
     return withDiagnosticProp<MainAxisSize>(
         'mainAxisSize', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where crossAxisAlignment matches the condition
+  @useResult
   WidgetSelector<Row> whereCrossAxisAlignment(
       MatchProp<CrossAxisAlignment> match) {
     return withDiagnosticProp<CrossAxisAlignment>('crossAxisAlignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where crossAxisAlignment equals (==) [value]
+  @useResult
   WidgetSelector<Row> withCrossAxisAlignment(CrossAxisAlignment? value) {
     return withDiagnosticProp<CrossAxisAlignment>('crossAxisAlignment',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where textDirection matches the condition
+  @useResult
   WidgetSelector<Row> whereTextDirection(MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<Row> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where verticalDirection matches the condition
+  @useResult
   WidgetSelector<Row> whereVerticalDirection(
       MatchProp<VerticalDirection> match) {
     return withDiagnosticProp<VerticalDirection>('verticalDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where verticalDirection equals (==) [value]
+  @useResult
   WidgetSelector<Row> withVerticalDirection(VerticalDirection? value) {
     return withDiagnosticProp<VerticalDirection>('verticalDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where textBaseline matches the condition
+  @useResult
   WidgetSelector<Row> whereTextBaseline(MatchProp<TextBaseline> match) {
     return withDiagnosticProp<TextBaseline>('textBaseline', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where textBaseline equals (==) [value]
+  @useResult
   WidgetSelector<Row> withTextBaseline(TextBaseline? value) {
     return withDiagnosticProp<TextBaseline>(
         'textBaseline', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where renderObject matches the condition
+  @useResult
   WidgetSelector<Row> whereRenderObject(MatchProp<RenderFlex> match) {
     return withDiagnosticProp<RenderFlex>('renderObject', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Row] where renderObject equals (==) [value]
+  @useResult
   WidgetSelector<Row> withRenderObject(RenderFlex? value) {
     return withDiagnosticProp<RenderFlex>(
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/safearea.g.dart
+++ b/lib/src/widgets/safearea.g.dart
@@ -59,44 +59,52 @@ extension SafeAreaMatcher on WidgetMatcher<SafeArea> {
 /// Allows filtering [SafeArea] by the properties provided via [Diagnosticable.debugFillProperties]
 extension SafeAreaSelector on WidgetSelector<SafeArea> {
   /// Creates a [WidgetSelector] that finds all [SafeArea] where left matches the condition
+  @useResult
   WidgetSelector<SafeArea> whereLeft(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('left', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SafeArea] where left equals (==) [value]
+  @useResult
   WidgetSelector<SafeArea> withLeft(bool? value) {
     return withDiagnosticProp<bool>(
         'left', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SafeArea] where top matches the condition
+  @useResult
   WidgetSelector<SafeArea> whereTop(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('top', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SafeArea] where top equals (==) [value]
+  @useResult
   WidgetSelector<SafeArea> withTop(bool? value) {
     return withDiagnosticProp<bool>(
         'top', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SafeArea] where right matches the condition
+  @useResult
   WidgetSelector<SafeArea> whereRight(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('right', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SafeArea] where right equals (==) [value]
+  @useResult
   WidgetSelector<SafeArea> withRight(bool? value) {
     return withDiagnosticProp<bool>(
         'right', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SafeArea] where bottom matches the condition
+  @useResult
   WidgetSelector<SafeArea> whereBottom(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('bottom', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SafeArea] where bottom equals (==) [value]
+  @useResult
   WidgetSelector<SafeArea> withBottom(bool? value) {
     return withDiagnosticProp<bool>(
         'bottom', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/selectabletext.g.dart
+++ b/lib/src/widgets/selectabletext.g.dart
@@ -233,183 +233,216 @@ extension SelectableTextMatcher on WidgetMatcher<SelectableText> {
 /// Allows filtering [SelectableText] by the properties provided via [Diagnosticable.debugFillProperties]
 extension SelectableTextSelector on WidgetSelector<SelectableText> {
   /// Creates a [WidgetSelector] that finds all [SelectableText] where text matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereText(MatchProp<String> match) {
     return withDiagnosticProp<String>('data', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where text equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withText(String? value) {
     return withDiagnosticProp<String>(
         'data', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where semanticsLabel matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereSemanticsLabel(MatchProp<String> match) {
     return withDiagnosticProp<String>('semanticsLabel', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where semanticsLabel equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withSemanticsLabel(String? value) {
     return withDiagnosticProp<String>('semanticsLabel',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where focusNode matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where style matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereStyle(MatchProp<TextStyle> match) {
     return withDiagnosticProp<TextStyle>('style', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where style equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withStyle(TextStyle? value) {
     return withDiagnosticProp<TextStyle>(
         'style', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where autofocus matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereAutofocus(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('autofocus', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where autofocus equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withAutofocus(bool? value) {
     return withDiagnosticProp<bool>(
         'autofocus', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where showCursor matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereShowCursor(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('showCursor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where showCursor equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withShowCursor(bool? value) {
     return withDiagnosticProp<bool>(
         'showCursor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where minLines matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereMinLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('minLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where minLines equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withMinLines(int? value) {
     return withDiagnosticProp<int>(
         'minLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where maxLines matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereMaxLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('maxLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where maxLines equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withMaxLines(int? value) {
     return withDiagnosticProp<int>(
         'maxLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where textAlign matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereTextAlign(MatchProp<TextAlign> match) {
     return withDiagnosticProp<TextAlign>('textAlign', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where textAlign equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withTextAlign(TextAlign? value) {
     return withDiagnosticProp<TextAlign>(
         'textAlign', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where textDirection matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereTextDirection(
       MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where textScaleFactor matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereTextScaleFactor(MatchProp<double> match) {
     return withDiagnosticProp<double>('textScaleFactor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where textScaleFactor equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withTextScaleFactor(double? value) {
     return withDiagnosticProp<double>('textScaleFactor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorWidth matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereCursorWidth(MatchProp<double> match) {
     return withDiagnosticProp<double>('cursorWidth', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorWidth equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withCursorWidth(double? value) {
     return withDiagnosticProp<double>(
         'cursorWidth', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorHeight matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereCursorHeight(MatchProp<double> match) {
     return withDiagnosticProp<double>('cursorHeight', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorHeight equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withCursorHeight(double? value) {
     return withDiagnosticProp<double>(
         'cursorHeight', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorRadius matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereCursorRadius(MatchProp<Radius> match) {
     return withDiagnosticProp<Radius>('cursorRadius', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorRadius equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withCursorRadius(Radius? value) {
     return withDiagnosticProp<Radius>(
         'cursorRadius', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorColor matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereCursorColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('cursorColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorColor equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withCursorColor(Color? value) {
     return withDiagnosticProp<Color>(
         'cursorColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where selectionEnabled matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereSelectionEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('selectionEnabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where selectionEnabled equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withSelectionEnabled(bool? value) {
     return withDiagnosticProp<bool>('selectionEnabled',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where selectionControls matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereSelectionControls(
       MatchProp<TextSelectionControls> match) {
     return withDiagnosticProp<TextSelectionControls>(
@@ -417,6 +450,7 @@ extension SelectableTextSelector on WidgetSelector<SelectableText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where selectionControls equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withSelectionControls(
       TextSelectionControls? value) {
     return withDiagnosticProp<TextSelectionControls>('selectionControls',
@@ -424,24 +458,28 @@ extension SelectableTextSelector on WidgetSelector<SelectableText> {
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where scrollPhysics matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereScrollPhysics(
       MatchProp<ScrollPhysics> match) {
     return withDiagnosticProp<ScrollPhysics>('scrollPhysics', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where scrollPhysics equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withScrollPhysics(ScrollPhysics? value) {
     return withDiagnosticProp<ScrollPhysics>('scrollPhysics',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where textHeightBehavior matches the condition
+  @useResult
   WidgetSelector<SelectableText> whereTextHeightBehavior(
       MatchProp<TextHeightBehavior> match) {
     return withDiagnosticProp<TextHeightBehavior>('textHeightBehavior', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SelectableText] where textHeightBehavior equals (==) [value]
+  @useResult
   WidgetSelector<SelectableText> withTextHeightBehavior(
       TextHeightBehavior? value) {
     return withDiagnosticProp<TextHeightBehavior>('textHeightBehavior',

--- a/lib/src/widgets/semantics.g.dart
+++ b/lib/src/widgets/semantics.g.dart
@@ -58,17 +58,6 @@ extension SemanticsMatcher on WidgetMatcher<Semantics> {
         'mixed', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Expects that expanded of [Semantics] matches the condition in [match]
-  WidgetMatcher<Semantics> hasExpandedWhere(MatchProp<bool> match) {
-    return hasDiagnosticProp<bool>('expanded', match);
-  }
-
-  /// Expects that expanded of [Semantics] equals (==) [value]
-  WidgetMatcher<Semantics> hasExpanded(bool? value) {
-    return hasDiagnosticProp<bool>(
-        'expanded', (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
   /// Expects that selected of [Semantics] matches the condition in [match]
   WidgetMatcher<Semantics> hasSelectedWhere(MatchProp<bool> match) {
     return hasDiagnosticProp<bool>('selected', match);
@@ -254,230 +243,258 @@ extension SemanticsMatcher on WidgetMatcher<Semantics> {
 /// Allows filtering [Semantics] by the properties provided via [Diagnosticable.debugFillProperties]
 extension SemanticsSelector on WidgetSelector<Semantics> {
   /// Creates a [WidgetSelector] that finds all [Semantics] where container matches the condition
+  @useResult
   WidgetSelector<Semantics> whereContainer(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('container', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where container equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withContainer(bool? value) {
     return withDiagnosticProp<bool>(
         'container', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where properties matches the condition
+  @useResult
   WidgetSelector<Semantics> whereProperties(
       MatchProp<SemanticsProperties> match) {
     return withDiagnosticProp<SemanticsProperties>('properties', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where properties equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withProperties(SemanticsProperties? value) {
     return withDiagnosticProp<SemanticsProperties>(
         'properties', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where checked matches the condition
+  @useResult
   WidgetSelector<Semantics> whereChecked(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('checked', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where checked equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withChecked(bool? value) {
     return withDiagnosticProp<bool>(
         'checked', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where mixed matches the condition
+  @useResult
   WidgetSelector<Semantics> whereMixed(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('mixed', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where mixed equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withMixed(bool? value) {
     return withDiagnosticProp<bool>(
         'mixed', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Creates a [WidgetSelector] that finds all [Semantics] where expanded matches the condition
-  WidgetSelector<Semantics> whereExpanded(MatchProp<bool> match) {
-    return withDiagnosticProp<bool>('expanded', match);
-  }
-
-  /// Creates a [WidgetSelector] that finds all [Semantics] where expanded equals (==) [value]
-  WidgetSelector<Semantics> withExpanded(bool? value) {
-    return withDiagnosticProp<bool>(
-        'expanded', (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
   /// Creates a [WidgetSelector] that finds all [Semantics] where selected matches the condition
+  @useResult
   WidgetSelector<Semantics> whereSelected(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('selected', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where selected equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withSelected(bool? value) {
     return withDiagnosticProp<bool>(
         'selected', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where label matches the condition
+  @useResult
   WidgetSelector<Semantics> whereLabel(MatchProp<String> match) {
     return withDiagnosticProp<String>('label', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where label equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withLabel(String? value) {
     return withDiagnosticProp<String>(
         'label', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedLabel matches the condition
+  @useResult
   WidgetSelector<Semantics> whereAttributedLabel(MatchProp<String> match) {
     return withDiagnosticProp<String>('attributedLabel', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedLabel equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withAttributedLabel(String? value) {
     return withDiagnosticProp<String>('attributedLabel',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where value matches the condition
+  @useResult
   WidgetSelector<Semantics> whereValue(MatchProp<String> match) {
     return withDiagnosticProp<String>('value', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where value equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withValue(String? value) {
     return withDiagnosticProp<String>(
         'value', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedValue matches the condition
+  @useResult
   WidgetSelector<Semantics> whereAttributedValue(MatchProp<String> match) {
     return withDiagnosticProp<String>('attributedValue', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedValue equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withAttributedValue(String? value) {
     return withDiagnosticProp<String>('attributedValue',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where increasedValue matches the condition
+  @useResult
   WidgetSelector<Semantics> whereIncreasedValue(MatchProp<String> match) {
     return withDiagnosticProp<String>('increasedValue', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where increasedValue equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withIncreasedValue(String? value) {
     return withDiagnosticProp<String>('increasedValue',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedIncreasedValue matches the condition
+  @useResult
   WidgetSelector<Semantics> whereAttributedIncreasedValue(
       MatchProp<String> match) {
     return withDiagnosticProp<String>('attributedIncreasedValue', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedIncreasedValue equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withAttributedIncreasedValue(String? value) {
     return withDiagnosticProp<String>('attributedIncreasedValue',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where decreasedValue matches the condition
+  @useResult
   WidgetSelector<Semantics> whereDecreasedValue(MatchProp<String> match) {
     return withDiagnosticProp<String>('decreasedValue', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where decreasedValue equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withDecreasedValue(String? value) {
     return withDiagnosticProp<String>('decreasedValue',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedDecreasedValue matches the condition
+  @useResult
   WidgetSelector<Semantics> whereAttributedDecreasedValue(
       MatchProp<String> match) {
     return withDiagnosticProp<String>('attributedDecreasedValue', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedDecreasedValue equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withAttributedDecreasedValue(String? value) {
     return withDiagnosticProp<String>('attributedDecreasedValue',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where hint matches the condition
+  @useResult
   WidgetSelector<Semantics> whereHint(MatchProp<String> match) {
     return withDiagnosticProp<String>('hint', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where hint equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withHint(String? value) {
     return withDiagnosticProp<String>(
         'hint', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedHint matches the condition
+  @useResult
   WidgetSelector<Semantics> whereAttributedHint(MatchProp<String> match) {
     return withDiagnosticProp<String>('attributedHint', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where attributedHint equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withAttributedHint(String? value) {
     return withDiagnosticProp<String>('attributedHint',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where tooltip matches the condition
+  @useResult
   WidgetSelector<Semantics> whereTooltip(MatchProp<String> match) {
     return withDiagnosticProp<String>('tooltip', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where tooltip equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withTooltip(String? value) {
     return withDiagnosticProp<String>(
         'tooltip', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where textDirection matches the condition
+  @useResult
   WidgetSelector<Semantics> whereTextDirection(MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where sortKey matches the condition
+  @useResult
   WidgetSelector<Semantics> whereSortKey(MatchProp<SemanticsSortKey> match) {
     return withDiagnosticProp<SemanticsSortKey>('sortKey', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where sortKey equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withSortKey(SemanticsSortKey? value) {
     return withDiagnosticProp<SemanticsSortKey>(
         'sortKey', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where hintOverrides matches the condition
+  @useResult
   WidgetSelector<Semantics> whereHintOverrides(
       MatchProp<SemanticsHintOverrides> match) {
     return withDiagnosticProp<SemanticsHintOverrides>('hintOverrides', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where hintOverrides equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withHintOverrides(SemanticsHintOverrides? value) {
     return withDiagnosticProp<SemanticsHintOverrides>('hintOverrides',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where renderObject matches the condition
+  @useResult
   WidgetSelector<Semantics> whereRenderObject(
       MatchProp<RenderSemanticsAnnotations> match) {
     return withDiagnosticProp<RenderSemanticsAnnotations>(
@@ -485,6 +502,7 @@ extension SemanticsSelector on WidgetSelector<Semantics> {
   }
 
   /// Creates a [WidgetSelector] that finds all [Semantics] where renderObject equals (==) [value]
+  @useResult
   WidgetSelector<Semantics> withRenderObject(
       RenderSemanticsAnnotations? value) {
     return withDiagnosticProp<RenderSemanticsAnnotations>(

--- a/lib/src/widgets/sizedbox.g.dart
+++ b/lib/src/widgets/sizedbox.g.dart
@@ -50,34 +50,40 @@ extension SizedBoxMatcher on WidgetMatcher<SizedBox> {
 /// Allows filtering [SizedBox] by the properties provided via [Diagnosticable.debugFillProperties]
 extension SizedBoxSelector on WidgetSelector<SizedBox> {
   /// Creates a [WidgetSelector] that finds all [SizedBox] where width matches the condition
+  @useResult
   WidgetSelector<SizedBox> whereWidth(MatchProp<double> match) {
     return withDiagnosticProp<double>('width', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SizedBox] where width equals (==) [value]
+  @useResult
   WidgetSelector<SizedBox> withWidth(double? value) {
     return withDiagnosticProp<double>(
         'width', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SizedBox] where height matches the condition
+  @useResult
   WidgetSelector<SizedBox> whereHeight(MatchProp<double> match) {
     return withDiagnosticProp<double>('height', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SizedBox] where height equals (==) [value]
+  @useResult
   WidgetSelector<SizedBox> withHeight(double? value) {
     return withDiagnosticProp<double>(
         'height', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [SizedBox] where renderObject matches the condition
+  @useResult
   WidgetSelector<SizedBox> whereRenderObject(
       MatchProp<RenderConstrainedBox> match) {
     return withDiagnosticProp<RenderConstrainedBox>('renderObject', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [SizedBox] where renderObject equals (==) [value]
+  @useResult
   WidgetSelector<SizedBox> withRenderObject(RenderConstrainedBox? value) {
     return withDiagnosticProp<RenderConstrainedBox>(
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/slider.g.dart
+++ b/lib/src/widgets/slider.g.dart
@@ -136,121 +136,143 @@ extension SliderMatcher on WidgetMatcher<Slider> {
 /// Allows filtering [Slider] by the properties provided via [Diagnosticable.debugFillProperties]
 extension SliderSelector on WidgetSelector<Slider> {
   /// Creates a [WidgetSelector] that finds all [Slider] where value matches the condition
+  @useResult
   WidgetSelector<Slider> whereValue(MatchProp<double> match) {
     return withDiagnosticProp<double>('value', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where value equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withValue(double? value) {
     return withDiagnosticProp<double>(
         'value', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where secondaryTrackValue matches the condition
+  @useResult
   WidgetSelector<Slider> whereSecondaryTrackValue(MatchProp<double> match) {
     return withDiagnosticProp<double>('secondaryTrackValue', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where secondaryTrackValue equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withSecondaryTrackValue(double? value) {
     return withDiagnosticProp<double>('secondaryTrackValue',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where min matches the condition
+  @useResult
   WidgetSelector<Slider> whereMin(MatchProp<double> match) {
     return withDiagnosticProp<double>('min', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where min equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withMin(double? value) {
     return withDiagnosticProp<double>(
         'min', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where max matches the condition
+  @useResult
   WidgetSelector<Slider> whereMax(MatchProp<double> match) {
     return withDiagnosticProp<double>('max', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where max equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withMax(double? value) {
     return withDiagnosticProp<double>(
         'max', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where divisions matches the condition
+  @useResult
   WidgetSelector<Slider> whereDivisions(MatchProp<int> match) {
     return withDiagnosticProp<int>('divisions', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where divisions equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withDivisions(int? value) {
     return withDiagnosticProp<int>(
         'divisions', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where label matches the condition
+  @useResult
   WidgetSelector<Slider> whereLabel(MatchProp<String> match) {
     return withDiagnosticProp<String>('label', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where label equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withLabel(String? value) {
     return withDiagnosticProp<String>(
         'label', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where activeColor matches the condition
+  @useResult
   WidgetSelector<Slider> whereActiveColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('activeColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where activeColor equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withActiveColor(Color? value) {
     return withDiagnosticProp<Color>(
         'activeColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where inactiveColor matches the condition
+  @useResult
   WidgetSelector<Slider> whereInactiveColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('inactiveColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where inactiveColor equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withInactiveColor(Color? value) {
     return withDiagnosticProp<Color>('inactiveColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where secondaryActiveColor matches the condition
+  @useResult
   WidgetSelector<Slider> whereSecondaryActiveColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('secondaryActiveColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where secondaryActiveColor equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withSecondaryActiveColor(Color? value) {
     return withDiagnosticProp<Color>('secondaryActiveColor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where focusNode matches the condition
+  @useResult
   WidgetSelector<Slider> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where autofocus matches the condition
+  @useResult
   WidgetSelector<Slider> whereAutofocus(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('autofocus', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Slider] where autofocus equals (==) [value]
+  @useResult
   WidgetSelector<Slider> withAutofocus(bool? value) {
     return withDiagnosticProp<bool>(
         'autofocus', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/switch.g.dart
+++ b/lib/src/widgets/switch.g.dart
@@ -26,11 +26,13 @@ extension SwitchMatcher on WidgetMatcher<Switch> {
 /// Allows filtering [Switch] by the properties provided via [Diagnosticable.debugFillProperties]
 extension SwitchSelector on WidgetSelector<Switch> {
   /// Creates a [WidgetSelector] that finds all [Switch] where value matches the condition
+  @useResult
   WidgetSelector<Switch> whereValue(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('value', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Switch] where value equals (==) [value]
+  @useResult
   WidgetSelector<Switch> withValue(bool? value) {
     return withDiagnosticProp<bool>(
         'value', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/text.g.dart
+++ b/lib/src/widgets/text.g.dart
@@ -126,111 +126,131 @@ extension TextMatcher on WidgetMatcher<Text> {
 /// Allows filtering [Text] by the properties provided via [Diagnosticable.debugFillProperties]
 extension TextSelector on WidgetSelector<Text> {
   /// Creates a [WidgetSelector] that finds all [Text] where text matches the condition
+  @useResult
   WidgetSelector<Text> whereText(MatchProp<String> match) {
     return withDiagnosticProp<String>('data', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where text equals (==) [value]
+  @useResult
   WidgetSelector<Text> withText(String? value) {
     return withDiagnosticProp<String>(
         'data', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textAlign matches the condition
+  @useResult
   WidgetSelector<Text> whereTextAlign(MatchProp<TextAlign> match) {
     return withDiagnosticProp<TextAlign>('textAlign', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textAlign equals (==) [value]
+  @useResult
   WidgetSelector<Text> withTextAlign(TextAlign? value) {
     return withDiagnosticProp<TextAlign>(
         'textAlign', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textDirection matches the condition
+  @useResult
   WidgetSelector<Text> whereTextDirection(MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<Text> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where locale matches the condition
+  @useResult
   WidgetSelector<Text> whereLocale(MatchProp<Locale> match) {
     return withDiagnosticProp<Locale>('locale', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where locale equals (==) [value]
+  @useResult
   WidgetSelector<Text> withLocale(Locale? value) {
     return withDiagnosticProp<Locale>(
         'locale', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where softWrap matches the condition
+  @useResult
   WidgetSelector<Text> whereSoftWrap(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('softWrap', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where softWrap equals (==) [value]
+  @useResult
   WidgetSelector<Text> withSoftWrap(bool? value) {
     return withDiagnosticProp<bool>(
         'softWrap', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where overflow matches the condition
+  @useResult
   WidgetSelector<Text> whereOverflow(MatchProp<TextOverflow> match) {
     return withDiagnosticProp<TextOverflow>('overflow', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where overflow equals (==) [value]
+  @useResult
   WidgetSelector<Text> withOverflow(TextOverflow? value) {
     return withDiagnosticProp<TextOverflow>(
         'overflow', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textScaleFactor matches the condition
+  @useResult
   WidgetSelector<Text> whereTextScaleFactor(MatchProp<double> match) {
     return withDiagnosticProp<double>('textScaleFactor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textScaleFactor equals (==) [value]
+  @useResult
   WidgetSelector<Text> withTextScaleFactor(double? value) {
     return withDiagnosticProp<double>('textScaleFactor',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where maxLines matches the condition
+  @useResult
   WidgetSelector<Text> whereMaxLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('maxLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where maxLines equals (==) [value]
+  @useResult
   WidgetSelector<Text> withMaxLines(int? value) {
     return withDiagnosticProp<int>(
         'maxLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textWidthBasis matches the condition
+  @useResult
   WidgetSelector<Text> whereTextWidthBasis(MatchProp<TextWidthBasis> match) {
     return withDiagnosticProp<TextWidthBasis>('textWidthBasis', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textWidthBasis equals (==) [value]
+  @useResult
   WidgetSelector<Text> withTextWidthBasis(TextWidthBasis? value) {
     return withDiagnosticProp<TextWidthBasis>('textWidthBasis',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textHeightBehavior matches the condition
+  @useResult
   WidgetSelector<Text> whereTextHeightBehavior(
       MatchProp<TextHeightBehavior> match) {
     return withDiagnosticProp<TextHeightBehavior>('textHeightBehavior', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text] where textHeightBehavior equals (==) [value]
+  @useResult
   WidgetSelector<Text> withTextHeightBehavior(TextHeightBehavior? value) {
     return withDiagnosticProp<TextHeightBehavior>('textHeightBehavior',
         (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/textbutton.g.dart
+++ b/lib/src/widgets/textbutton.g.dart
@@ -48,33 +48,39 @@ extension TextButtonMatcher on WidgetMatcher<TextButton> {
 /// Allows filtering [TextButton] by the properties provided via [Diagnosticable.debugFillProperties]
 extension TextButtonSelector on WidgetSelector<TextButton> {
   /// Creates a [WidgetSelector] that finds all [TextButton] where enabled matches the condition
+  @useResult
   WidgetSelector<TextButton> whereEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextButton] where enabled equals (==) [value]
+  @useResult
   WidgetSelector<TextButton> withEnabled(bool? value) {
     return withDiagnosticProp<bool>(
         'enabled', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextButton] where style matches the condition
+  @useResult
   WidgetSelector<TextButton> whereStyle(MatchProp<ButtonStyle> match) {
     return withDiagnosticProp<ButtonStyle>('style', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextButton] where style equals (==) [value]
+  @useResult
   WidgetSelector<TextButton> withStyle(ButtonStyle? value) {
     return withDiagnosticProp<ButtonStyle>(
         'style', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextButton] where focusNode matches the condition
+  @useResult
   WidgetSelector<TextButton> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextButton] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<TextButton> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/textfield.g.dart
+++ b/lib/src/widgets/textfield.g.dart
@@ -345,17 +345,6 @@ extension TextFieldMatcher on WidgetMatcher<TextField> {
         'cursorColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Expects that cursorErrorColor of [TextField] matches the condition in [match]
-  WidgetMatcher<TextField> hasCursorErrorColorWhere(MatchProp<Color> match) {
-    return hasDiagnosticProp<Color>('cursorErrorColor', match);
-  }
-
-  /// Expects that cursorErrorColor of [TextField] equals (==) [value]
-  WidgetMatcher<TextField> hasCursorErrorColor(Color? value) {
-    return hasDiagnosticProp<Color>('cursorErrorColor',
-        (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
   /// Expects that keyboardAppearance of [TextField] matches the condition in [match]
   WidgetMatcher<TextField> hasKeyboardAppearanceWhere(
       MatchProp<Brightness> match) {
@@ -491,208 +480,245 @@ extension TextFieldMatcher on WidgetMatcher<TextField> {
 /// Allows filtering [TextField] by the properties provided via [Diagnosticable.debugFillProperties]
 extension TextFieldSelector on WidgetSelector<TextField> {
   /// Creates a [WidgetSelector] that finds all [TextField] where controller matches the condition
+  @useResult
   WidgetSelector<TextField> whereController(
       MatchProp<TextEditingController> match) {
     return withDiagnosticProp<TextEditingController>('controller', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where controller equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withController(TextEditingController? value) {
     return withDiagnosticProp<TextEditingController>(
         'controller', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where focusNode matches the condition
+  @useResult
   WidgetSelector<TextField> whereFocusNode(MatchProp<FocusNode> match) {
     return withDiagnosticProp<FocusNode>('focusNode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where focusNode equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withFocusNode(FocusNode? value) {
     return withDiagnosticProp<FocusNode>(
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where undoController matches the condition
+  @useResult
   WidgetSelector<TextField> whereUndoController(
       MatchProp<UndoHistoryController> match) {
     return withDiagnosticProp<UndoHistoryController>('undoController', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where undoController equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withUndoController(UndoHistoryController? value) {
     return withDiagnosticProp<UndoHistoryController>('undoController',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where enabled matches the condition
+  @useResult
   WidgetSelector<TextField> whereEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where enabled equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withEnabled(bool? value) {
     return withDiagnosticProp<bool>(
         'enabled', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where decoration matches the condition
+  @useResult
   WidgetSelector<TextField> whereDecoration(MatchProp<InputDecoration> match) {
     return withDiagnosticProp<InputDecoration>('decoration', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where decoration equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withDecoration(InputDecoration? value) {
     return withDiagnosticProp<InputDecoration>(
         'decoration', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where keyboardType matches the condition
+  @useResult
   WidgetSelector<TextField> whereKeyboardType(MatchProp<TextInputType> match) {
     return withDiagnosticProp<TextInputType>('keyboardType', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where keyboardType equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withKeyboardType(TextInputType? value) {
     return withDiagnosticProp<TextInputType>(
         'keyboardType', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where style matches the condition
+  @useResult
   WidgetSelector<TextField> whereStyle(MatchProp<TextStyle> match) {
     return withDiagnosticProp<TextStyle>('style', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where style equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withStyle(TextStyle? value) {
     return withDiagnosticProp<TextStyle>(
         'style', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where autofocus matches the condition
+  @useResult
   WidgetSelector<TextField> whereAutofocus(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('autofocus', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where autofocus equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withAutofocus(bool? value) {
     return withDiagnosticProp<bool>(
         'autofocus', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where obscuringCharacter matches the condition
+  @useResult
   WidgetSelector<TextField> whereObscuringCharacter(MatchProp<String> match) {
     return withDiagnosticProp<String>('obscuringCharacter', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where obscuringCharacter equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withObscuringCharacter(String? value) {
     return withDiagnosticProp<String>('obscuringCharacter',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where obscureText matches the condition
+  @useResult
   WidgetSelector<TextField> whereObscureText(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('obscureText', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where obscureText equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withObscureText(bool? value) {
     return withDiagnosticProp<bool>(
         'obscureText', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where autocorrect matches the condition
+  @useResult
   WidgetSelector<TextField> whereAutocorrect(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('autocorrect', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where autocorrect equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withAutocorrect(bool? value) {
     return withDiagnosticProp<bool>(
         'autocorrect', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where smartDashesType matches the condition
+  @useResult
   WidgetSelector<TextField> whereSmartDashesType(
       MatchProp<SmartDashesType> match) {
     return withDiagnosticProp<SmartDashesType>('smartDashesType', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where smartDashesType equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withSmartDashesType(SmartDashesType? value) {
     return withDiagnosticProp<SmartDashesType>('smartDashesType',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where smartQuotesType matches the condition
+  @useResult
   WidgetSelector<TextField> whereSmartQuotesType(
       MatchProp<SmartQuotesType> match) {
     return withDiagnosticProp<SmartQuotesType>('smartQuotesType', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where smartQuotesType equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withSmartQuotesType(SmartQuotesType? value) {
     return withDiagnosticProp<SmartQuotesType>('smartQuotesType',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where enableSuggestions matches the condition
+  @useResult
   WidgetSelector<TextField> whereEnableSuggestions(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enableSuggestions', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where enableSuggestions equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withEnableSuggestions(bool? value) {
     return withDiagnosticProp<bool>('enableSuggestions',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where maxLines matches the condition
+  @useResult
   WidgetSelector<TextField> whereMaxLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('maxLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where maxLines equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withMaxLines(int? value) {
     return withDiagnosticProp<int>(
         'maxLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where minLines matches the condition
+  @useResult
   WidgetSelector<TextField> whereMinLines(MatchProp<int> match) {
     return withDiagnosticProp<int>('minLines', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where minLines equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withMinLines(int? value) {
     return withDiagnosticProp<int>(
         'minLines', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where expands matches the condition
+  @useResult
   WidgetSelector<TextField> whereExpands(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('expands', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where expands equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withExpands(bool? value) {
     return withDiagnosticProp<bool>(
         'expands', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where maxLength matches the condition
+  @useResult
   WidgetSelector<TextField> whereMaxLength(MatchProp<int> match) {
     return withDiagnosticProp<int>('maxLength', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where maxLength equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withMaxLength(int? value) {
     return withDiagnosticProp<int>(
         'maxLength', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where maxLengthEnforcement matches the condition
+  @useResult
   WidgetSelector<TextField> whereMaxLengthEnforcement(
       MatchProp<MaxLengthEnforcement> match) {
     return withDiagnosticProp<MaxLengthEnforcement>(
@@ -700,6 +726,7 @@ extension TextFieldSelector on WidgetSelector<TextField> {
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where maxLengthEnforcement equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withMaxLengthEnforcement(
       MaxLengthEnforcement? value) {
     return withDiagnosticProp<MaxLengthEnforcement>('maxLengthEnforcement',
@@ -707,165 +734,181 @@ extension TextFieldSelector on WidgetSelector<TextField> {
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textInputAction matches the condition
+  @useResult
   WidgetSelector<TextField> whereTextInputAction(
       MatchProp<TextInputAction> match) {
     return withDiagnosticProp<TextInputAction>('textInputAction', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textInputAction equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withTextInputAction(TextInputAction? value) {
     return withDiagnosticProp<TextInputAction>('textInputAction',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textCapitalization matches the condition
+  @useResult
   WidgetSelector<TextField> whereTextCapitalization(
       MatchProp<TextCapitalization> match) {
     return withDiagnosticProp<TextCapitalization>('textCapitalization', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textCapitalization equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withTextCapitalization(TextCapitalization? value) {
     return withDiagnosticProp<TextCapitalization>('textCapitalization',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textAlign matches the condition
+  @useResult
   WidgetSelector<TextField> whereTextAlign(MatchProp<TextAlign> match) {
     return withDiagnosticProp<TextAlign>('textAlign', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textAlign equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withTextAlign(TextAlign? value) {
     return withDiagnosticProp<TextAlign>(
         'textAlign', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textAlignVertical matches the condition
+  @useResult
   WidgetSelector<TextField> whereTextAlignVertical(
       MatchProp<TextAlignVertical> match) {
     return withDiagnosticProp<TextAlignVertical>('textAlignVertical', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textAlignVertical equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withTextAlignVertical(TextAlignVertical? value) {
     return withDiagnosticProp<TextAlignVertical>('textAlignVertical',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textDirection matches the condition
+  @useResult
   WidgetSelector<TextField> whereTextDirection(MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorWidth matches the condition
+  @useResult
   WidgetSelector<TextField> whereCursorWidth(MatchProp<double> match) {
     return withDiagnosticProp<double>('cursorWidth', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorWidth equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withCursorWidth(double? value) {
     return withDiagnosticProp<double>(
         'cursorWidth', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorHeight matches the condition
+  @useResult
   WidgetSelector<TextField> whereCursorHeight(MatchProp<double> match) {
     return withDiagnosticProp<double>('cursorHeight', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorHeight equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withCursorHeight(double? value) {
     return withDiagnosticProp<double>(
         'cursorHeight', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorRadius matches the condition
+  @useResult
   WidgetSelector<TextField> whereCursorRadius(MatchProp<Radius> match) {
     return withDiagnosticProp<Radius>('cursorRadius', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorRadius equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withCursorRadius(Radius? value) {
     return withDiagnosticProp<Radius>(
         'cursorRadius', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorOpacityAnimates matches the condition
+  @useResult
   WidgetSelector<TextField> whereCursorOpacityAnimates(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('cursorOpacityAnimates', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorOpacityAnimates equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withCursorOpacityAnimates(bool? value) {
     return withDiagnosticProp<bool>('cursorOpacityAnimates',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorColor matches the condition
+  @useResult
   WidgetSelector<TextField> whereCursorColor(MatchProp<Color> match) {
     return withDiagnosticProp<Color>('cursorColor', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where cursorColor equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withCursorColor(Color? value) {
     return withDiagnosticProp<Color>(
         'cursorColor', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Creates a [WidgetSelector] that finds all [TextField] where cursorErrorColor matches the condition
-  WidgetSelector<TextField> whereCursorErrorColor(MatchProp<Color> match) {
-    return withDiagnosticProp<Color>('cursorErrorColor', match);
-  }
-
-  /// Creates a [WidgetSelector] that finds all [TextField] where cursorErrorColor equals (==) [value]
-  WidgetSelector<TextField> withCursorErrorColor(Color? value) {
-    return withDiagnosticProp<Color>('cursorErrorColor',
-        (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
   /// Creates a [WidgetSelector] that finds all [TextField] where keyboardAppearance matches the condition
+  @useResult
   WidgetSelector<TextField> whereKeyboardAppearance(
       MatchProp<Brightness> match) {
     return withDiagnosticProp<Brightness>('keyboardAppearance', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where keyboardAppearance equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withKeyboardAppearance(Brightness? value) {
     return withDiagnosticProp<Brightness>('keyboardAppearance',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where scrollPadding matches the condition
+  @useResult
   WidgetSelector<TextField> whereScrollPadding(
       MatchProp<EdgeInsetsGeometry> match) {
     return withDiagnosticProp<EdgeInsetsGeometry>('scrollPadding', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where scrollPadding equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withScrollPadding(EdgeInsetsGeometry? value) {
     return withDiagnosticProp<EdgeInsetsGeometry>('scrollPadding',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where selectionEnabled matches the condition
+  @useResult
   WidgetSelector<TextField> whereSelectionEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('selectionEnabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where selectionEnabled equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withSelectionEnabled(bool? value) {
     return withDiagnosticProp<bool>('selectionEnabled',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where selectionControls matches the condition
+  @useResult
   WidgetSelector<TextField> whereSelectionControls(
       MatchProp<TextSelectionControls> match) {
     return withDiagnosticProp<TextSelectionControls>(
@@ -873,6 +916,7 @@ extension TextFieldSelector on WidgetSelector<TextField> {
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where selectionControls equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withSelectionControls(
       TextSelectionControls? value) {
     return withDiagnosticProp<TextSelectionControls>('selectionControls',
@@ -880,63 +924,74 @@ extension TextFieldSelector on WidgetSelector<TextField> {
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where scrollController matches the condition
+  @useResult
   WidgetSelector<TextField> whereScrollController(
       MatchProp<ScrollController> match) {
     return withDiagnosticProp<ScrollController>('scrollController', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where scrollController equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withScrollController(ScrollController? value) {
     return withDiagnosticProp<ScrollController>('scrollController',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where scrollPhysics matches the condition
+  @useResult
   WidgetSelector<TextField> whereScrollPhysics(MatchProp<ScrollPhysics> match) {
     return withDiagnosticProp<ScrollPhysics>('scrollPhysics', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where scrollPhysics equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withScrollPhysics(ScrollPhysics? value) {
     return withDiagnosticProp<ScrollPhysics>('scrollPhysics',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where clipBehavior matches the condition
+  @useResult
   WidgetSelector<TextField> whereClipBehavior(MatchProp<Clip> match) {
     return withDiagnosticProp<Clip>('clipBehavior', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where clipBehavior equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withClipBehavior(Clip? value) {
     return withDiagnosticProp<Clip>(
         'clipBehavior', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where scribbleEnabled matches the condition
+  @useResult
   WidgetSelector<TextField> whereScribbleEnabled(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('scribbleEnabled', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where scribbleEnabled equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withScribbleEnabled(bool? value) {
     return withDiagnosticProp<bool>('scribbleEnabled',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where enableIMEPersonalizedLearning matches the condition
+  @useResult
   WidgetSelector<TextField> whereEnableIMEPersonalizedLearning(
       MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enableIMEPersonalizedLearning', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where enableIMEPersonalizedLearning equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withEnableIMEPersonalizedLearning(bool? value) {
     return withDiagnosticProp<bool>('enableIMEPersonalizedLearning',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where spellCheckConfiguration matches the condition
+  @useResult
   WidgetSelector<TextField> whereSpellCheckConfiguration(
       MatchProp<SpellCheckConfiguration> match) {
     return withDiagnosticProp<SpellCheckConfiguration>(
@@ -944,6 +999,7 @@ extension TextFieldSelector on WidgetSelector<TextField> {
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where spellCheckConfiguration equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withSpellCheckConfiguration(
       SpellCheckConfiguration? value) {
     return withDiagnosticProp<SpellCheckConfiguration>(
@@ -952,12 +1008,14 @@ extension TextFieldSelector on WidgetSelector<TextField> {
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where contentCommitMimeTypes matches the condition
+  @useResult
   WidgetSelector<TextField> whereContentCommitMimeTypes(
       MatchProp<List<String>> match) {
     return withDiagnosticProp<List<String>>('contentCommitMimeTypes', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [TextField] where contentCommitMimeTypes equals (==) [value]
+  @useResult
   WidgetSelector<TextField> withContentCommitMimeTypes(List<String>? value) {
     return withDiagnosticProp<List<String>>('contentCommitMimeTypes',
         (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/tooltip.g.dart
+++ b/lib/src/widgets/tooltip.g.dart
@@ -159,144 +159,170 @@ extension TooltipMatcher on WidgetMatcher<Tooltip> {
 /// Allows filtering [Tooltip] by the properties provided via [Diagnosticable.debugFillProperties]
 extension TooltipSelector on WidgetSelector<Tooltip> {
   /// Creates a [WidgetSelector] that finds all [Tooltip] where message matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereMessage(MatchProp<String> match) {
     return withDiagnosticProp<String>('message', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where message equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withMessage(String? value) {
     return withDiagnosticProp<String>(
         'message', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where richMessage matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereRichMessage(MatchProp<String> match) {
     return withDiagnosticProp<String>('richMessage', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where richMessage equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withRichMessage(String? value) {
     return withDiagnosticProp<String>(
         'richMessage', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where height matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereHeight(MatchProp<double> match) {
     return withDiagnosticProp<double>('height', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where height equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withHeight(double? value) {
     return withDiagnosticProp<double>(
         'height', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where padding matches the condition
+  @useResult
   WidgetSelector<Tooltip> wherePadding(MatchProp<EdgeInsetsGeometry> match) {
     return withDiagnosticProp<EdgeInsetsGeometry>('padding', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where padding equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withPadding(EdgeInsetsGeometry? value) {
     return withDiagnosticProp<EdgeInsetsGeometry>(
         'padding', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where margin matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereMargin(MatchProp<EdgeInsetsGeometry> match) {
     return withDiagnosticProp<EdgeInsetsGeometry>('margin', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where margin equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withMargin(EdgeInsetsGeometry? value) {
     return withDiagnosticProp<EdgeInsetsGeometry>(
         'margin', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where verticalOffset matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereVerticalOffset(MatchProp<double> match) {
     return withDiagnosticProp<double>('vertical offset', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where verticalOffset equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withVerticalOffset(double? value) {
     return withDiagnosticProp<double>('vertical offset',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where position matches the condition
+  @useResult
   WidgetSelector<Tooltip> wherePosition(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('position', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where position equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withPosition(bool? value) {
     return withDiagnosticProp<bool>(
         'position', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where semantics matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereSemantics(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('semantics', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where semantics equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withSemantics(bool? value) {
     return withDiagnosticProp<bool>(
         'semantics', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where waitDuration matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereWaitDuration(MatchProp<Duration> match) {
     return withDiagnosticProp<Duration>('wait duration', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where waitDuration equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withWaitDuration(Duration? value) {
     return withDiagnosticProp<Duration>('wait duration',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where showDuration matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereShowDuration(MatchProp<Duration> match) {
     return withDiagnosticProp<Duration>('show duration', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where showDuration equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withShowDuration(Duration? value) {
     return withDiagnosticProp<Duration>('show duration',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where triggerMode matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereTriggerMode(
       MatchProp<TooltipTriggerMode> match) {
     return withDiagnosticProp<TooltipTriggerMode>('triggerMode', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where triggerMode equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withTriggerMode(TooltipTriggerMode? value) {
     return withDiagnosticProp<TooltipTriggerMode>(
         'triggerMode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where enableFeedback matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereEnableFeedback(MatchProp<bool> match) {
     return withDiagnosticProp<bool>('enableFeedback', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where enableFeedback equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withEnableFeedback(bool? value) {
     return withDiagnosticProp<bool>('enableFeedback',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where textAlign matches the condition
+  @useResult
   WidgetSelector<Tooltip> whereTextAlign(MatchProp<TextAlign> match) {
     return withDiagnosticProp<TextAlign>('textAlign', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Tooltip] where textAlign equals (==) [value]
+  @useResult
   WidgetSelector<Tooltip> withTextAlign(TextAlign? value) {
     return withDiagnosticProp<TextAlign>(
         'textAlign', (it) => value == null ? it.isNull() : it.equals(value));

--- a/lib/src/widgets/wrap.g.dart
+++ b/lib/src/widgets/wrap.g.dart
@@ -117,101 +117,119 @@ extension WrapMatcher on WidgetMatcher<Wrap> {
 /// Allows filtering [Wrap] by the properties provided via [Diagnosticable.debugFillProperties]
 extension WrapSelector on WidgetSelector<Wrap> {
   /// Creates a [WidgetSelector] that finds all [Wrap] where direction matches the condition
+  @useResult
   WidgetSelector<Wrap> whereDirection(MatchProp<Axis> match) {
     return withDiagnosticProp<Axis>('direction', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where direction equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withDirection(Axis? value) {
     return withDiagnosticProp<Axis>(
         'direction', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where alignment matches the condition
+  @useResult
   WidgetSelector<Wrap> whereAlignment(MatchProp<WrapAlignment> match) {
     return withDiagnosticProp<WrapAlignment>('alignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where alignment equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withAlignment(WrapAlignment? value) {
     return withDiagnosticProp<WrapAlignment>(
         'alignment', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where spacing matches the condition
+  @useResult
   WidgetSelector<Wrap> whereSpacing(MatchProp<double> match) {
     return withDiagnosticProp<double>('spacing', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where spacing equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withSpacing(double? value) {
     return withDiagnosticProp<double>(
         'spacing', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where runAlignment matches the condition
+  @useResult
   WidgetSelector<Wrap> whereRunAlignment(MatchProp<WrapAlignment> match) {
     return withDiagnosticProp<WrapAlignment>('runAlignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where runAlignment equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withRunAlignment(WrapAlignment? value) {
     return withDiagnosticProp<WrapAlignment>(
         'runAlignment', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where runSpacing matches the condition
+  @useResult
   WidgetSelector<Wrap> whereRunSpacing(MatchProp<double> match) {
     return withDiagnosticProp<double>('runSpacing', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where runSpacing equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withRunSpacing(double? value) {
     return withDiagnosticProp<double>(
         'runSpacing', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where crossAxisAlignment matches the condition
+  @useResult
   WidgetSelector<Wrap> whereCrossAxisAlignment(
       MatchProp<WrapCrossAlignment> match) {
     return withDiagnosticProp<WrapCrossAlignment>('crossAxisAlignment', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where crossAxisAlignment equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withCrossAxisAlignment(WrapCrossAlignment? value) {
     return withDiagnosticProp<WrapCrossAlignment>('crossAxisAlignment',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where textDirection matches the condition
+  @useResult
   WidgetSelector<Wrap> whereTextDirection(MatchProp<TextDirection> match) {
     return withDiagnosticProp<TextDirection>('textDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where textDirection equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withTextDirection(TextDirection? value) {
     return withDiagnosticProp<TextDirection>('textDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where verticalDirection matches the condition
+  @useResult
   WidgetSelector<Wrap> whereVerticalDirection(
       MatchProp<VerticalDirection> match) {
     return withDiagnosticProp<VerticalDirection>('verticalDirection', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where verticalDirection equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withVerticalDirection(VerticalDirection? value) {
     return withDiagnosticProp<VerticalDirection>('verticalDirection',
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where renderObject matches the condition
+  @useResult
   WidgetSelector<Wrap> whereRenderObject(MatchProp<RenderWrap> match) {
     return withDiagnosticProp<RenderWrap>('renderObject', match);
   }
 
   /// Creates a [WidgetSelector] that finds all [Wrap] where renderObject equals (==) [value]
+  @useResult
   WidgetSelector<Wrap> withRenderObject(RenderWrap? value) {
     return withDiagnosticProp<RenderWrap>(
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+  meta: ^1.8.0
   nanoid2: ^2.0.0
   test: ^1.24.0
   test_api: '>=0.5.0 <0.7.0'

--- a/test/spot/exists_once_test.dart
+++ b/test/spot/exists_once_test.dart
@@ -214,6 +214,6 @@ void main() {
         // only finds the single SizedBox in Wrap, not the SizedBox below Center
         wrap.spotSingle<SizedBox>(),
       ],
-    );
+    ).existsOnce();
   });
 }

--- a/test/spot/spotters_test.dart
+++ b/test/spot/spotters_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: deprecated_member_use_from_same_package
+// ignore_for_file: deprecated_member_use_from_same_package, unused_result
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
`WidgetSelectors` do nothing until they are snapshotted. Not using the selector is therefore a mistake or unnecessary

```dart
spot<FloatingActionButtion>(); // does nothing, warning

final fab = spot<FloatingActionButtion>(); // ok
spot<FloatingActionButtion>().existsOnce(); // ok
```