### PR TITLE
Deprecate spotSingle (0.10.0-beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Eventually **Breaking**, but only the class names. The end user API stays the sa
 - Fix: `.first()` and `.last()` now work after calling `.copyWith()`
 - **Breaking** Quantity assertions like `.doesNotExist()` or `.existsOnce()` now return `WidgetMatcher`/`MultiWidgetMatcher` instead of `WidgetSnapshot`. To get the `WidgetSnapshot` use `snapshot()` instead.
 - `spotText('a')` can now return multiple widgets
+- **Breaking** remove `WidgetSelector.cast` because it lost information and was untested
 
 
 ## 0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.10.0-beta.1
+
+Eventually **Breaking**, but only the class names. The end user API stays the same.
+
+- `spotSingle<W>()` is now deprecated. Use `spot<W>()` instead, or `spot<W>().atMost(1)` to indicate that only a single widget is expected.
+- `WidgetSelector` replaces `SingleWidgetSelector` and `MultiWidgetSelector`
+- `WidgetSelector` now has a `quantityConstraint` property (deprecates `expectedQuantity`) that allows setting the `min` and `max` number of expected widgets.
+- New: `.atIndex(n)` allows to get the widget at a specific index (when multiple are found)
+- Fix: `.first()` and `.last()` now work after calling `.copyWith()`
+- **Breaking** Quantity assertions like `.doesNotExist()` or `.existsOnce()` now return `WidgetMatcher`/`MultiWidgetMatcher` instead of `WidgetSnapshot`. To get the `WidgetSnapshot` use `snapshot()` instead.
+- `spotText('a')` can now return multiple widgets
+
+
 ## 0.7.0
 
 - New prop API with `hasWidgetProp()` makes it easy to filter and assert properties of Widgets.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ void main() {
     
     // Find widgets based on child widgets
     appBar
-        .spot<IconButton>(children: [spotSingleIcon(Icons.home)])
+        .spot<IconButton>(children: [spotIcon(Icons.home)])
         .existsOnce()
         .hasTooltip('home');
 
@@ -39,7 +39,7 @@ void main() {
     });
 
     // Interact with widgets using `act`
-    final button = spotSingle<FloatingActionButton>();
+    final button = spot<FloatingActionButton>();
     await act.tap(button);
   });
 }
@@ -76,13 +76,13 @@ Selectors can be rather complex, it is therefore recommended to **reuse** them.
 You can even save them top-level and reuse them across multiple tests.
 
 ```dart
-spotSingle<ElevatedButton>();
+spot<ElevatedButton>();
 
 final MultiWidgetSelector<TextField> textFields = 
     spot<LoginScreen>().spot<LoginForm>().spot<TextField>();
 
-final SingleWidgetSelector<TextField> usernameTextField =
-    spotSingle<TextField>(
+final WidgetSelector<TextField> usernameTextField =
+    spot<TextField>(
       parents: [
         spot<TextWithLabel>(
           children: [
@@ -93,15 +93,13 @@ final SingleWidgetSelector<TextField> usernameTextField =
     );
 ```
 
-Not that there are two kind of selectors, `SingleWidgetSelector` and `MultiWidgetSelector`. 
-Depending on how many widgets you expect to find, you should use the correct one as it allows you to use different matchers.
+A `WidgetSelector` may return 0, 1 or N widgets.
+Depending on how many widgets you expect to find, you should use the corresponding matchers.
 
 ### Matchers
 
 After creating a selector, you want to assert the widgets it found. 
-The `snapshot()` method creates a `MultiWidgetSnapshot` of the widget tree at that point in time and finds all widgets that match the selector
-
-You rarely have to use `snapshot()` directly, because the quantity matchers do it for you.
+The `snapshot()` method creates a `WidgetSnapshot` of the widget tree at that point in time and finds all widgets that match the selector.
 
 #### Quantity matchers
 
@@ -115,11 +113,11 @@ The easiest matchers are the quantity matchers. They allow checking how many wid
 
 ```dart
 
-final selector = spotSingle<ElevatedButton>();
+final selector = spot<ElevatedButton>();
 
 // calls snapshot() internally
-final snapshot = selector.existsOnce(); 
-final snapshot5 = selector.existsExactlyNTimes(5);
+final matchOne = selector.existsOnce(); 
+final matchMultiple = selector.existsExactlyNTimes(5);
 
 selector.doesNotExist(); // end, nothing to match on 
 ```
@@ -130,7 +128,7 @@ The property matchers allow asserting on the properties of the widgets.
 You don't have to use `execpt()`, instead you can use the `has*`/`is*` matchers directly.
 
 ```dart
-spotSingle<Tooltip>()
+spot<Tooltip>()
     .existsOnce() // takes snapshot and asserts quantity
     // start your chain of matchers
     .hasMessage('Favorite')
@@ -145,9 +143,7 @@ To match multiple widgets use `all()` or `any()`
 ```dart
 spot<AppBar>().spot<Tooltip>().existsAtLeastOnce()
     .all((tooltip) => tooltip
-      .hasShowDurationWhere(
-         (it) => it.isGreaterOrEqual(Duration(seconds: 1000)),
-      )
+      .hasShowDurationWhere((it) => it.isGreaterOrEqual(Duration(seconds: 1000)))
       .hasTriggerMode(TooltipTriggerMode.longPress)
     );
 ```
@@ -192,7 +188,7 @@ That's much more helpful!
 In the future, spot will only print the widget tree from the last node found node (`spot<AppBar>`).
 
 ```
-spot<AppBar>().spotSingleIcon(Icons.settings).existsOnce();
+spot<AppBar>().spotIcon(Icons.settings).existsOnce();
 
 Could not find 'icon "IconData(U+0E57F)"' as child of #2 type "IconButton"
 There are 1 possible parents for 'icon "IconData(U+0E57F)"' matching #2 type "IconButton". But non matched. The widget trees starting at #2 type "IconButton" are:
@@ -243,6 +239,10 @@ Could not find 'icon "IconData(U+0E57F)"' as child of [type "MaterialApp" > 'typ
 - ✅ Allow generating code for properties of 3rd party widgets
 - ✅ Interact with widgets (`act`)
 - ✅ Allow manually printing a screenshot at certain points
+- ✅ Negate child matchers
+- ✅ Simplify `WidgetSelector` API
+- ⬜️ Become the de facto Widget selector API for [patrol](https://pub.dev/packages/patrol) 
+- ⬜️ Combine multiple WidgetSelectors with `and`
 - ⬜️ More `act` features
 - ⬜️ Print only widget tree of the parent scope when test fails
 - ⬜️ Create screenshot when test fails

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -32,9 +32,13 @@ export 'package:spot/src/spot/matcher_generator.dart' show CreateMatchers;
 export 'package:spot/src/spot/props.dart';
 export 'package:spot/src/spot/selectors.dart'
     show
+        CreateWidgetMatcher,
+        // ignore: deprecated_member_use_from_same_package
+        DeprecatedSingleWidgetSnapshot,
         ElementFilter,
         // ignore: deprecated_member_use_from_same_package
         ExpectedQuantity,
+        // ignore: deprecated_member_use_from_same_package
         MatchProp,
         // ignore: deprecated_member_use_from_same_package
         MultiWidgetSelector,
@@ -46,18 +50,17 @@ export 'package:spot/src/spot/selectors.dart'
         QuantitySelectors,
         RelativeSelectors,
         SelectorQueries,
+        // ignore: deprecated_member_use_from_same_package
         SelectorToSnapshot,
         // ignore: deprecated_member_use_from_same_package
         SingleWidgetSelector,
         // ignore: deprecated_member_use_from_same_package
         SingleWidgetSnapshot,
-        DeprecatedSingleWidgetSnapshot,
         WidgetMatcher,
         WidgetMatcherExtensions,
         WidgetSelector,
         WidgetSnapshot;
-export 'package:spot/src/spot/snapshot.dart'
-    show MultiWidgetSelectorMatcher, SingleWidgetSelectorMatcher;
+export 'package:spot/src/spot/snapshot.dart' show MultiWidgetSelectorMatcher;
 export 'package:spot/src/spot/text/any_text.dart' show AnyText;
 export 'package:spot/src/spot/tree_snapshot.dart' show WidgetTreeNode;
 export 'package:spot/src/widgets/align.g.dart';

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -33,6 +33,7 @@ export 'package:spot/src/spot/props.dart';
 export 'package:spot/src/spot/selectors.dart'
     show
         ElementFilter,
+        // ignore: deprecated_member_use_from_same_package
         ExpectedQuantity,
         // ignore: deprecated_member_use_from_same_package
         MatchProp,

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -124,7 +124,7 @@ WidgetSelector<Widget> get allWidgets => WidgetSelector.all;
 /// If multiple Widgets of type [W] are expected, use [spot] instead.
 @useResult
 @Deprecated('Use spot<W>().atMost(1)')
-SingleWidgetSelector<W> spotSingle<W extends Widget>({
+WidgetSelector<W> spotSingle<W extends Widget>({
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
 }) {
@@ -173,7 +173,7 @@ WidgetSelector<W> spotWidget<W extends Widget>(
 /// identity
 @useResult
 @Deprecated('Use spotWidget<W>().atMost(1)')
-SingleWidgetSelector<W> spotSingleWidget<W extends Widget>(
+WidgetSelector<W> spotSingleWidget<W extends Widget>(
   W widget, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -279,7 +279,7 @@ WidgetSelector<AnyText> spotTextWhere(
   'spot<Text>().whereText((it) => it.equals("Hello")).first() instead',
 )
 @useResult
-SingleWidgetSelector<W> spotSingleText<W extends Widget>(
+WidgetSelector<W> spotSingleText<W extends Widget>(
   String text, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -322,7 +322,7 @@ WidgetSelector<W> spotTexts<W extends Widget>(
 /// [icon]
 @useResult
 @Deprecated('Use spotIcon<W>().atMost(1)')
-SingleWidgetSelector<Icon> spotSingleIcon(
+WidgetSelector<Icon> spotSingleIcon(
   IconData icon, {
   bool skipOffstage = true,
   List<WidgetSelector> parents = const [],
@@ -370,7 +370,7 @@ WidgetSelector<Icon> spotIcons(
 /// Creates a chainable [WidgetSelector] that finds a widget with the given [key].
 @useResult
 @Deprecated('Use spotKey().atMost(1)')
-SingleWidgetSelector<W> spotSingleKey<W extends Widget>(
+WidgetSelector<W> spotSingleKey<W extends Widget>(
   Key key, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -400,7 +400,7 @@ WidgetSelector<W> spotKey<W extends Widget>(
 /// [key].
 @useResult
 @Deprecated('Use spotKey()')
-MultiWidgetSelector<W> spotKeys<W extends Widget>(
+WidgetSelector<W> spotKeys<W extends Widget>(
   Key key, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -35,13 +35,16 @@ export 'package:spot/src/spot/selectors.dart'
         ElementFilter,
         ExpectedQuantity,
         MatchProp,
+        // ignore: deprecated_member_use_from_same_package
         MultiWidgetSelector,
         MultiWidgetSnapshot,
         MutliMatchers,
         QuantityMatchers,
+        QuantitySelectors,
         RelativeSelectors,
         SelectorQueries,
         SelectorToSnapshot,
+        // ignore: deprecated_member_use_from_same_package
         SingleWidgetSelector,
         SingleWidgetSnapshot,
         WidgetMatcher,
@@ -111,6 +114,7 @@ WidgetSelector<Widget> get allWidgets => WidgetSelector.all;
 ///
 /// If multiple Widgets of type [W] are expected, use [spot] instead.
 @useResult
+@Deprecated('Use spot<W>()')
 SingleWidgetSelector<W> spotSingle<W extends Widget>({
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -124,11 +128,7 @@ SingleWidgetSelector<W> spotSingle<W extends Widget>({
 /// Creates a chainable [WidgetSelector] that matches a all Widgets of
 /// type [W] in widget tree.
 ///
-/// `spot<SomeWidget>()` is the most common way to chain of selectors. For
-/// performance reasons and better error messages, it can be useful to use
-/// [spotSingle]. Use [spotSingle] in cases where only ever one Widget is
-/// expected. This allows the framework to stop when 100 instead of a
-/// 1 widget is found.
+/// `spot<SomeWidget>()` is the most common way to chain selectors.
 ///
 /// This selector compares the Widgets by runtimeType rather than by super
 /// type (see [WidgetTypeFilter]). This makes sure that e.g. `spot<Align>()`
@@ -144,9 +144,26 @@ WidgetSelector<W> spot<W extends Widget>({
   );
 }
 
+/// Creates a [WidgetSelector] that finds [widget] by identity and returns all
+/// occurrences of it in the widget tree
+///
+/// The comparison happens by identity (===)
+WidgetSelector<W> spotWidget<W extends Widget>(
+  W widget, {
+  List<WidgetSelector> parents = const [],
+  List<WidgetSelector> children = const [],
+}) {
+  return _global.spotWidget<W>(
+    widget,
+    parents: parents,
+    children: children,
+  );
+}
+
 /// Creates a chainable [WidgetSelector] that matches a single [Widget] by
 /// identity
 @useResult
+@Deprecated('Use spotWidget<W>()')
 SingleWidgetSelector<W> spotSingleWidget<W extends Widget>(
   W widget, {
   List<WidgetSelector> parents = const [],
@@ -161,6 +178,7 @@ SingleWidgetSelector<W> spotSingleWidget<W extends Widget>(
 
 /// Creates a chainable [WidgetSelector] that finds all [widget] by identity
 @useResult
+@Deprecated('Use spotWidget<W>()')
 WidgetSelector<W> spotWidgets<W extends Widget>(
   W widget, {
   List<WidgetSelector> parents = const [],
@@ -176,7 +194,7 @@ WidgetSelector<W> spotWidgets<W extends Widget>(
 /// Creates a chainable [WidgetSelector] that finds the widget that is currently
 /// associated to the given [element].
 @useResult
-SingleWidgetSelector<W> spotElement<W extends Widget>(
+WidgetSelector<W> spotElement<W extends Widget>(
   Element element, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -200,7 +218,7 @@ SingleWidgetSelector<W> spotElement<W extends Widget>(
 /// welcome.first().snapshot().hasMaxLines(1).hasTextAlign(TextAlign.center);
 /// ```
 @useResult
-SingleWidgetSelector<AnyText> spotText(
+WidgetSelector<AnyText> spotText(
   Pattern text, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -229,7 +247,7 @@ SingleWidgetSelector<AnyText> spotText(
 /// spotText('Wo');
 /// ```
 @useResult
-SingleWidgetSelector<AnyText> spotTextWhere(
+WidgetSelector<AnyText> spotTextWhere(
   void Function(Subject<String>) match, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -294,6 +312,7 @@ WidgetSelector<W> spotTexts<W extends Widget>(
 /// Creates a chainable [WidgetSelector] that finds a [Icon] based on [IconData]
 /// [icon]
 @useResult
+@Deprecated('Use spotIcon<W>()')
 SingleWidgetSelector<Icon> spotSingleIcon(
   IconData icon, {
   bool skipOffstage = true,
@@ -307,9 +326,25 @@ SingleWidgetSelector<Icon> spotSingleIcon(
   );
 }
 
+/// Creates a chainable [WidgetSelector] that finds a [Icon] based on [IconData]
+/// [icon]
+@useResult
+WidgetSelector<Icon> spotIcon(
+  IconData icon, {
+  List<WidgetSelector> parents = const [],
+  List<WidgetSelector> children = const [],
+}) {
+  return _global.spotIcon(
+    icon,
+    parents: parents,
+    children: children,
+  );
+}
+
 /// Creates a chainable [WidgetSelector] that finds all widgets of type [Icon]
 /// that have [icon] as [IconData]
 @useResult
+@Deprecated('Use spotIcon()')
 WidgetSelector<Icon> spotIcons(
   IconData icon, {
   bool skipOffstage = true,
@@ -325,6 +360,7 @@ WidgetSelector<Icon> spotIcons(
 
 /// Creates a chainable [WidgetSelector] that finds a widget with the given [key].
 @useResult
+@Deprecated('Use spotKey()')
 SingleWidgetSelector<W> spotSingleKey<W extends Widget>(
   Key key, {
   List<WidgetSelector> parents = const [],
@@ -337,9 +373,24 @@ SingleWidgetSelector<W> spotSingleKey<W extends Widget>(
   );
 }
 
+/// Creates a chainable [WidgetSelector] that finds a widget with the given [key].
+@useResult
+WidgetSelector<W> spotKey<W extends Widget>(
+  Key key, {
+  List<WidgetSelector> parents = const [],
+  List<WidgetSelector> children = const [],
+}) {
+  return _global.spotKey<W>(
+    key,
+    parents: parents,
+    children: children,
+  );
+}
+
 /// Creates a chainable [WidgetSelector] that finds all widgets with the given
 /// [key].
 @useResult
+@Deprecated('Use spotKey()')
 MultiWidgetSelector<W> spotKeys<W extends Widget>(
   Key key, {
   List<WidgetSelector> parents = const [],

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -33,12 +33,15 @@ export 'package:spot/src/spot/props.dart';
 export 'package:spot/src/spot/selectors.dart'
     show
         ElementFilter,
+        // ignore: deprecated_member_use_from_same_package
         ExpectedQuantity,
         MatchProp,
         // ignore: deprecated_member_use_from_same_package
         MultiWidgetSelector,
+        // ignore: deprecated_member_use_from_same_package
         MultiWidgetSnapshot,
         MutliMatchers,
+        QuantityConstraint,
         QuantityMatchers,
         QuantitySelectors,
         RelativeSelectors,
@@ -46,10 +49,13 @@ export 'package:spot/src/spot/selectors.dart'
         SelectorToSnapshot,
         // ignore: deprecated_member_use_from_same_package
         SingleWidgetSelector,
+        // ignore: deprecated_member_use_from_same_package
         SingleWidgetSnapshot,
+        DeprecatedSingleWidgetSnapshot,
         WidgetMatcher,
         WidgetMatcherExtensions,
-        WidgetSelector;
+        WidgetSelector,
+        WidgetSnapshot;
 export 'package:spot/src/spot/snapshot.dart'
     show MultiWidgetSelectorMatcher, SingleWidgetSelectorMatcher;
 export 'package:spot/src/spot/text/any_text.dart' show AnyText;

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -123,7 +123,7 @@ WidgetSelector<Widget> get allWidgets => WidgetSelector.all;
 ///
 /// If multiple Widgets of type [W] are expected, use [spot] instead.
 @useResult
-@Deprecated('Use spot<W>()')
+@Deprecated('Use spot<W>().atMost(1)')
 SingleWidgetSelector<W> spotSingle<W extends Widget>({
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
@@ -172,7 +172,7 @@ WidgetSelector<W> spotWidget<W extends Widget>(
 /// Creates a chainable [WidgetSelector] that matches a single [Widget] by
 /// identity
 @useResult
-@Deprecated('Use spotWidget<W>()')
+@Deprecated('Use spotWidget<W>().atMost(1)')
 SingleWidgetSelector<W> spotSingleWidget<W extends Widget>(
   W widget, {
   List<WidgetSelector> parents = const [],
@@ -321,7 +321,7 @@ WidgetSelector<W> spotTexts<W extends Widget>(
 /// Creates a chainable [WidgetSelector] that finds a [Icon] based on [IconData]
 /// [icon]
 @useResult
-@Deprecated('Use spotIcon<W>()')
+@Deprecated('Use spotIcon<W>().atMost(1)')
 SingleWidgetSelector<Icon> spotSingleIcon(
   IconData icon, {
   bool skipOffstage = true,
@@ -369,7 +369,7 @@ WidgetSelector<Icon> spotIcons(
 
 /// Creates a chainable [WidgetSelector] that finds a widget with the given [key].
 @useResult
-@Deprecated('Use spotKey()')
+@Deprecated('Use spotKey().atMost(1)')
 SingleWidgetSelector<W> spotSingleKey<W extends Widget>(
   Key key, {
   List<WidgetSelector> parents = const [],

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -32,11 +32,7 @@ export 'package:spot/src/spot/matcher_generator.dart' show CreateMatchers;
 export 'package:spot/src/spot/props.dart';
 export 'package:spot/src/spot/selectors.dart'
     show
-        CreateWidgetMatcher,
-        // ignore: deprecated_member_use_from_same_package
-        DeprecatedSingleWidgetSnapshot,
         ElementFilter,
-        // ignore: deprecated_member_use_from_same_package
         ExpectedQuantity,
         // ignore: deprecated_member_use_from_same_package
         MatchProp,
@@ -44,22 +40,25 @@ export 'package:spot/src/spot/selectors.dart'
         MultiWidgetSelector,
         // ignore: deprecated_member_use_from_same_package
         MultiWidgetSnapshot,
+        // ignore: deprecated_member_use_from_same_package
         MutliMatchers,
         QuantityConstraint,
         QuantityMatchers,
         QuantitySelectors,
         RelativeSelectors,
         SelectorQueries,
-        // ignore: deprecated_member_use_from_same_package
         SelectorToSnapshot,
         // ignore: deprecated_member_use_from_same_package
         SingleWidgetSelector,
         // ignore: deprecated_member_use_from_same_package
         SingleWidgetSnapshot,
+        ToWidgetMatcher,
+        // ignore: deprecated_member_use_from_same_package
         WidgetMatcher,
         WidgetMatcherExtensions,
         WidgetSelector,
-        WidgetSnapshot;
+        WidgetSnapshot,
+        WidgetSnapshotShorthands;
 export 'package:spot/src/spot/snapshot.dart' show MultiWidgetSelectorMatcher;
 export 'package:spot/src/spot/text/any_text.dart' show AnyText;
 export 'package:spot/src/spot/tree_snapshot.dart' show WidgetTreeNode;

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -26,7 +26,7 @@ class Act {
     return TestAsyncUtils.guard<void>(() async {
       return _alwaysPropagateDevicePointerEvents(() async {
         // Find the associated RenderObject to get the position of the element on the screen
-        final element = snapshot.element!;
+        final element = snapshot.discoveredElement!;
         final renderObject = element.renderObject;
         if (renderObject == null) {
           throw TestFailure(

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -26,7 +26,7 @@ class Act {
     return TestAsyncUtils.guard<void>(() async {
       return _alwaysPropagateDevicePointerEvents(() async {
         // Find the associated RenderObject to get the position of the element on the screen
-        final element = snapshot.discovered!.element;
+        final element = snapshot.element;
         final renderObject = element.renderObject;
         if (renderObject == null) {
           throw TestFailure(

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -21,12 +21,12 @@ class Act {
   /// Triggers a tap event on a given widget.
   Future<void> tap(WidgetSelector selector) async {
     // Check if widget is in the widget tree. Throws if not.
-    final snapshot = selector.existsOnce();
+    final snapshot = selector.snapshot()..existsOnce();
 
     return TestAsyncUtils.guard<void>(() async {
       return _alwaysPropagateDevicePointerEvents(() async {
         // Find the associated RenderObject to get the position of the element on the screen
-        final element = snapshot.element;
+        final element = snapshot.element!;
         final renderObject = element.renderObject;
         if (renderObject == null) {
           throw TestFailure(
@@ -94,7 +94,7 @@ class Act {
   void _pokeRenderObject({
     required Offset position,
     required RenderObject target,
-    required SingleWidgetSnapshot snapshot,
+    required WidgetSnapshot snapshot,
   }) {
     final binding = WidgetsBinding.instance;
 
@@ -133,7 +133,7 @@ class Act {
   /// the taps and doesn't forward them to the child
   void _detectAbsorbPointer(
     Element hitTarget,
-    SingleWidgetSnapshot<Widget> snapshot,
+    WidgetSnapshot<Widget> snapshot,
   ) {
     final childElement = hitTarget.children.firstOrNull;
     if (childElement?.widget is AbsorbPointer) {
@@ -153,7 +153,7 @@ class Act {
   /// Throws if the widget is wrapped in an IgnorePointer that is not forwarding events
   void _detectIgnorePointer(
     RenderObject target,
-    SingleWidgetSnapshot<Widget> snapshot,
+    WidgetSnapshot<Widget> snapshot,
   ) {
     final targetElement = (target.debugCreator as DebugCreator?)!.element;
     // sorted from root to target

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -58,7 +58,7 @@ Future<Screenshot> takeScreenshot({
       // taking a fresh snapshot guarantees an element that is currently in the
       // tree and can be screenshotted
       final snapshot = selector.snapshot().existsOnce();
-      return snapshot.element;
+      return snapshot.element!;
     }
 
     if (snapshot != null) {
@@ -160,7 +160,7 @@ extension SelectorScreenshotExtension<W extends Widget> on WidgetSelector<W> {
   }
 }
 
-/// Provides the ability to create screenshots of a [SingleWidgetSnapshot]
+/// Provides the ability to create screenshots of a [WidgetSnapshot]
 extension SnapshotScreenshotExtension<W extends Widget> on WidgetSnapshot<W> {
   /// Takes as screenshot of the widget that was captured in this snapshot.
   ///

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -58,7 +58,7 @@ Future<Screenshot> takeScreenshot({
       // taking a fresh snapshot guarantees an element that is currently in the
       // tree and can be screenshotted
       final snapshot = selector.snapshot().existsOnce();
-      return snapshot.element!;
+      return snapshot.element;
     }
 
     if (snapshot != null) {

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -46,7 +46,7 @@ class Screenshot {
 Future<Screenshot> takeScreenshot({
   Element? element,
   SingleWidgetSnapshot? snapshot,
-  SingleWidgetSelector? selector,
+  WidgetSelector? selector,
   String? name,
 }) async {
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.instance;
@@ -143,9 +143,8 @@ Future<Screenshot> takeScreenshot({
   return Screenshot(file: file, initiator: frame);
 }
 
-/// Provides the ability to create screenshots of a [SingleWidgetSelector]
-extension SelectorScreenshotExtension<W extends Widget>
-    on SingleWidgetSelector<W> {
+/// Provides the ability to create screenshots of a [WidgetSelector]
+extension SelectorScreenshotExtension<W extends Widget> on WidgetSelector<W> {
   /// Takes as screenshot of the widget that can be found by this selector.
   Future<Screenshot> takeScreenshot({String? name}) {
     return self.takeScreenshot(selector: this, name: name);

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -77,7 +77,7 @@ Future<Screenshot> takeScreenshot({
           'Only Elements that are currently mounted can be screenshotted.',
         );
       }
-      if (snapshot.discoveredWidgets.first != element.widget) {
+      if (snapshot.discoveredWidget != element.widget) {
         throw StateError(
           'Can not take a screenshot of snapshot $snapshot, because the Element has been updated since the snapshot was taken. '
           'This happens when the widget tree is rebuilt.',

--- a/lib/src/spot/finder_interop.dart
+++ b/lib/src/spot/finder_interop.dart
@@ -10,7 +10,9 @@ extension FinderToSpot on Finder {
   /// Like a [Finder], [WidgetSelector] can return 0, 1, or N widgets
   @useResult
   WidgetSelector<W> spot<W extends Widget>() {
-    return _FinderSelector<W>(this);
+    return WidgetSelector<W>(
+      elementFilters: [_FinderFilter(this)],
+    );
   }
 }
 
@@ -28,37 +30,10 @@ extension SpotToFinder<W extends Widget> on WidgetSelector<W> {
   /// Use [T] to specify the type of [Widget] to match.
   @useResult
   WidgetSelector<T> spotFinder<T extends Widget>(Finder finder) {
-    return _FinderSelector<T>(finder, parent: this);
-  }
-}
-
-class _FinderSelector<W extends Widget> extends WidgetSelector<W> {
-  final Finder finder;
-
-  _FinderSelector(
-    this.finder, {
-    WidgetSelector? parent,
-  }) : super(parents: parent != null ? [parent] : []);
-
-  @override
-  List<ElementFilter> createElementFilters() {
-    return [...super.createElementFilters(), _FinderFilter(finder)];
-  }
-
-  @override
-  String toString() {
-    final overridden = super.toString();
-    // ignore: deprecated_member_use
-    return 'widget with ${finder.description}'
-        '${overridden.isNotEmpty ? ' $overridden' : ''}';
-  }
-
-  @override
-  String toStringWithoutParents() {
-    final overridden = super.toStringWithoutParents();
-    // ignore: deprecated_member_use
-    return 'widget with ${finder.description}'
-        '${overridden.isNotEmpty ? ' $overridden' : ''}';
+    return WidgetSelector<T>(
+      parents: [this],
+      elementFilters: [_FinderFilter(finder)],
+    );
   }
 }
 
@@ -71,6 +46,12 @@ class _FinderFilter extends ElementFilter {
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     // ignore: deprecated_member_use
     return candidates.filter((it) => finder.apply([it.element]).isNotEmpty);
+  }
+
+  @override
+  String get description {
+    // ignore: deprecated_member_use
+    return finder.description;
   }
 }
 

--- a/lib/src/spot/finder_interop.dart
+++ b/lib/src/spot/finder_interop.dart
@@ -7,12 +7,9 @@ import 'package:spot/spot.dart';
 extension FinderToSpot on Finder {
   /// Converts the [Finder] to a [WidgetSelector]
   ///
-  /// By default, [Finder] matches List<[Element]>, thus the [WidgetSelector]s
-  /// concrete type is [MultiWidgetSelector]. Use [SelectorToSnapshot.single] to
-  /// convert the [Finder] to a [SingleWidgetSelector] when the intention is to
-  /// only match a single [Widget].
+  /// Like a [Finder], [WidgetSelector] can return 0, 1, or N widgets
   @useResult
-  MultiWidgetSelector<W> spot<W extends Widget>() {
+  WidgetSelector<W> spot<W extends Widget>() {
     return _FinderSelector<W>(this);
   }
 }
@@ -35,7 +32,7 @@ extension SpotToFinder<W extends Widget> on WidgetSelector<W> {
   }
 }
 
-class _FinderSelector<W extends Widget> extends MultiWidgetSelector<W> {
+class _FinderSelector<W extends Widget> extends WidgetSelector<W> {
   final Finder finder;
 
   _FinderSelector(

--- a/lib/src/spot/matcher_generator.dart
+++ b/lib/src/spot/matcher_generator.dart
@@ -53,8 +53,8 @@ extension CreateMatchers<W extends Widget> on WidgetSelector<W> {
     String? imports,
     bool Function(DiagnosticsNode node)? filter,
   }) {
-    final snapshot = existsAtLeastOnce();
-    final anyElement = snapshot.discoveredElements.first;
+    final s = snapshot()..existsAtLeastOnce();
+    final anyElement = s.discoveredElements.first;
 
     final elementProps = anyElement.toDiagnosticsNode().getProperties();
     final widgetProps =

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -432,7 +432,7 @@ mixin Selectors<T extends Widget> {
   @useResult
   WidgetSelector<T> first() {
     // TODO add names to the elementFilters, for a better WidgetSelector.toString()
-    return self!.copyWith(elementFilters: [FirstElement()]);
+    return self!.copyWith(elementFilters: [_FirstElement()]);
   }
 
   /// Selects the last of n widgets
@@ -442,16 +442,16 @@ mixin Selectors<T extends Widget> {
   /// tree
   @useResult
   WidgetSelector<T> last() {
-    return self!.copyWith(elementFilters: [LastElement()]);
+    return self!.copyWith(elementFilters: [_LastElement()]);
   }
 
   WidgetSelector<T> atIndex(int index) {
-    return self!.copyWith(elementFilters: [ElementAtIndex(index)]);
+    return self!.copyWith(elementFilters: [_ElementAtIndex(index)]);
   }
 }
 
-class FirstElement extends ElementFilter {
-  FirstElement();
+class _FirstElement extends ElementFilter {
+  _FirstElement();
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
@@ -466,8 +466,8 @@ class FirstElement extends ElementFilter {
   String get description => ':first';
 }
 
-class LastElement extends ElementFilter {
-  LastElement();
+class _LastElement extends ElementFilter {
+  _LastElement();
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
@@ -482,8 +482,8 @@ class LastElement extends ElementFilter {
   String get description => ':last';
 }
 
-class ElementAtIndex extends ElementFilter {
-  ElementAtIndex(this.index);
+class _ElementAtIndex extends ElementFilter {
+  _ElementAtIndex(this.index);
 
   final int index;
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -1510,6 +1510,7 @@ class MultiWidgetSnapshot<W extends Widget> {
       selector: selector,
       discovered: discovered.firstOrNull,
       debugCandidates: debugCandidates,
+      scope: scope,
     );
   }
 }
@@ -1520,6 +1521,7 @@ class SingleWidgetSnapshot<W extends Widget> implements WidgetMatcher<W> {
     required this.selector,
     required this.discovered,
     required this.debugCandidates,
+    required this.scope,
   }) : _widget = discovered?.element == null
             ? null
             : selector.mapElementToWidget(discovered!.element);
@@ -1531,6 +1533,8 @@ class SingleWidgetSnapshot<W extends Widget> implements WidgetMatcher<W> {
   /// the snapshot was taken. This allows to compare the widget with the current
   /// widget in the tree.
   final W? _widget;
+
+  final ScopedWidgetTreeSnapshot scope;
 
   @override
   final WidgetSelector<W> selector;
@@ -1566,6 +1570,16 @@ class SingleWidgetSnapshot<W extends Widget> implements WidgetMatcher<W> {
 
   @override
   W get widget => _widget!;
+
+  @useResult
+  MultiWidgetSnapshot<W> get multi {
+    return MultiWidgetSnapshot(
+      selector: selector,
+      discovered: [if (discovered != null) discovered!],
+      debugCandidates: debugCandidates,
+      scope: scope,
+    );
+  }
 }
 
 extension QuantitySelectors<W extends Widget> on WidgetSelector<W> {
@@ -1591,37 +1605,47 @@ extension QuantitySelectors<W extends Widget> on WidgetSelector<W> {
 extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   MultiWidgetSnapshot<W> existsAtLeastOnce() {
     TestAsyncUtils.guardSync();
-    return snapshot(this, validateQuantity: false).existsAtLeastOnce();
+    final atLeastOne =
+        copyWith(quantityConstraint: const QuantityConstraint.atLeast(1));
+    return snapshot(atLeastOne);
   }
 
   MultiWidgetSnapshot<W> existsAtMostOnce() {
     TestAsyncUtils.guardSync();
-    return snapshot(this, validateQuantity: false).existsAtMostOnce();
+    final atMostOne = copyWith(quantityConstraint: QuantityConstraint.single);
+    return snapshot(atMostOne);
   }
 
   void doesNotExist() {
     TestAsyncUtils.guardSync();
-    snapshot(this, validateQuantity: false).doesNotExist();
+    final none = copyWith(quantityConstraint: QuantityConstraint.none);
+    snapshot(none);
   }
 
   SingleWidgetSnapshot<W> existsOnce() {
     TestAsyncUtils.guardSync();
-    return snapshot(this, validateQuantity: false).existsOnce();
+    final one =
+        copyWith(quantityConstraint: const QuantityConstraint.exactly(1));
+    return snapshot(one).single;
   }
 
   MultiWidgetSnapshot<W> existsExactlyNTimes(int n) {
     TestAsyncUtils.guardSync();
-    return snapshot(this, validateQuantity: false).existsExactlyNTimes(n);
+    final exactlyNTimes =
+        copyWith(quantityConstraint: QuantityConstraint.exactly(n));
+    return snapshot(exactlyNTimes);
   }
 
   MultiWidgetSnapshot<W> existsAtLeastNTimes(int n) {
     TestAsyncUtils.guardSync();
-    return snapshot(this, validateQuantity: false).existsAtLeastNTimes(n);
+    final atLeast = copyWith(quantityConstraint: QuantityConstraint.atLeast(n));
+    return snapshot(atLeast);
   }
 
   MultiWidgetSnapshot<W> existsAtMostNTimes(int n) {
     TestAsyncUtils.guardSync();
-    return snapshot(this, validateQuantity: false).existsAtMostNTimes(n);
+    final atMostN = copyWith(quantityConstraint: QuantityConstraint.atMost(n));
+    return snapshot(atMostN);
   }
 }
 
@@ -1662,6 +1686,7 @@ extension AssertionMatcher<W extends Widget> on MultiWidgetSnapshot<W> {
       selector: selector,
       discovered: discovered.firstOrNull,
       debugCandidates: debugCandidates,
+      scope: scope,
     );
   }
 }

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -415,15 +415,6 @@ mixin Selectors<T extends Widget> {
     );
   }
 
-  @useResult
-  WidgetSelector<W> cast<W extends Widget>() {
-    return WidgetSelector<W>(
-      props: self!.props,
-      parents: self!.parents,
-      children: self!.children,
-    );
-  }
-
   /// Selects the first of n widgets
   ///
   /// "first" is neither the top-most or the bottom-most widget. Instead, it is

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -460,11 +460,8 @@ mixin Selectors<T extends Widget> {
   /// tree
   @useResult
   WidgetSelector<T> first() {
-    return FirstWidgetSelector<T>(
-      props: self!.props,
-      parents: self!.parents,
-      children: self!.children,
-    );
+    // TODO add names to the elementFilters, for a better WidgetSelector.toString()
+    return self!.copyWith(elementFilters: [FirstElement()]);
   }
 
   /// Selects the last of n widgets
@@ -474,34 +471,7 @@ mixin Selectors<T extends Widget> {
   /// tree
   @useResult
   WidgetSelector<T> last() {
-    return LastWidgetSelector<T>(
-      props: self!.props,
-      parents: self!.parents,
-      children: self!.children,
-    );
-  }
-}
-
-class FirstWidgetSelector<W extends Widget> extends WidgetSelector<W> {
-  FirstWidgetSelector({
-    required super.props,
-    required super.parents,
-    required super.children,
-  });
-
-  @override
-  List<ElementFilter> createElementFilters() {
-    return [...super.createElementFilters(), FirstElement()];
-  }
-
-  @override
-  String toString() {
-    return 'first Widget ${super.toString()}';
-  }
-
-  @override
-  String toStringWithoutParents() {
-    return ':first';
+    return self!.copyWith(elementFilters: [LastElement()]);
   }
 }
 
@@ -515,29 +485,6 @@ class FirstElement extends ElementFilter {
       return [];
     }
     return [first];
-  }
-}
-
-class LastWidgetSelector<W extends Widget> extends WidgetSelector<W> {
-  LastWidgetSelector({
-    required super.props,
-    required super.parents,
-    required super.children,
-  });
-
-  @override
-  List<ElementFilter> createElementFilters() {
-    return [...super.createElementFilters(), LastElement()];
-  }
-
-  @override
-  String toString() {
-    return 'last Widget ${super.toString()}';
-  }
-
-  @override
-  String toStringWithoutParents() {
-    return ':last';
   }
 }
 
@@ -1175,6 +1122,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
     List<PredicateWithDescription>? props,
     List<WidgetSelector>? parents,
     List<WidgetSelector>? children,
+    List<ElementFilter>? elementFilters,
     @Deprecated('Use quantityConstraint instead')
     ExpectedQuantity expectedQuantity = ExpectedQuantity.multi,
     QuantityConstraint? quantityConstraint,
@@ -1182,6 +1130,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
   })  : props = List.unmodifiable(props ?? []),
         parents = List.unmodifiable(parents?.toSet().toList() ?? []),
         children = List.unmodifiable(children ?? []),
+        elementFilters = List.unmodifiable(elementFilters ?? []),
         quantityConstraint = quantityConstraint ??
             (expectedQuantity == ExpectedQuantity.single
                 ? QuantityConstraint.single
@@ -1193,6 +1142,8 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
   final List<WidgetSelector> parents;
 
   final List<WidgetSelector> children;
+
+  final List<ElementFilter> elementFilters;
 
   /// Whether this selector expects to find a single or multiple widgets
   @Deprecated('Use quantityConstraint instead')
@@ -1220,6 +1171,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
     return [
       if (props.isNotEmpty) PropFilter(props),
       if (children.isNotEmpty) ChildFilter(children),
+      ...elementFilters,
     ];
   }
 
@@ -1281,6 +1233,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
     List<PredicateWithDescription>? props,
     List<WidgetSelector>? parents,
     List<WidgetSelector>? children,
+    List<ElementFilter>? elementFilters,
     ExpectedQuantity? expectedQuantity,
     QuantityConstraint? quantityConstraint,
     W Function(Element element)? mapElementToWidget,
@@ -1289,6 +1242,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
       props: props ?? this.props,
       parents: parents ?? this.parents,
       children: children ?? this.children,
+      elementFilters: elementFilters ?? this.elementFilters,
       // ignore: deprecated_member_use_from_same_package
       expectedQuantity: expectedQuantity ?? this.expectedQuantity,
       quantityConstraint: quantityConstraint ?? this.quantityConstraint,

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -1212,7 +1212,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
         : null;
 
     final constraints =
-        [props, filters, children, parents].where((e) => e != null);
+        [props, children, parents, filters].where((e) => e != null);
     if (constraints.isEmpty) {
       return '';
     }
@@ -1230,7 +1230,7 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
         ? elementFilters.map((e) => e.description).join(' ')
         : null;
 
-    final constraints = [props, filters, children].where((e) => e != null);
+    final constraints = [props, children, filters].where((e) => e != null);
     return constraints.join(' ');
   }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -1439,13 +1439,6 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
   }
 }
 
-// TODO move into WidgetSnapshot? Rename?
-extension CreateWidgetMatcher<W extends Widget> on WidgetSnapshot<W> {
-  W? get widget => discoveredWidgets.firstOrNull;
-
-  Element? get element => discoveredElements.firstOrNull;
-}
-
 /// The number of widgets that are expected to be found
 class QuantityConstraint {
   static const QuantityConstraint unconstrained = QuantityConstraint();
@@ -1538,13 +1531,6 @@ typedef MultiWidgetSnapshot<W extends Widget> = WidgetSnapshot<W>;
 @Deprecated('Use WidgetSnapshot')
 typedef SingleWidgetSnapshot<W extends Widget> = WidgetSnapshot<W>;
 
-extension DeprecatedSingleWidgetSnapshot<W extends Widget>
-    on WidgetSnapshot<W> {
-  Element? get discoveredElement => discoveredElements.firstOrNull;
-
-  W? get discoveredWidget => discoveredWidgets.firstOrNull;
-}
-
 /// A collection of [discovered] elements that match [selector]
 class WidgetSnapshot<W extends Widget> {
   WidgetSnapshot({
@@ -1579,6 +1565,37 @@ class WidgetSnapshot<W extends Widget> {
   /// All elements in [scope] that match [selector]
   final List<WidgetTreeNode> discovered;
 
+  @override
+  String toString() {
+    return 'SpotSnapshot of $selector (${discoveredElements.length} matches)}';
+  }
+}
+
+// TODO make WidgetSnapshot implement WidgetMatcher and MultiWidgetMatcher
+extension ToWidgetMatcher<W extends Widget> on WidgetSnapshot<W> {
+  @useResult
+  MultiWidgetMatcher<W> get multi {
+    return MultiWidgetMatcher.fromSnapshot(this);
+  }
+
+  @useResult
+  WidgetMatcher<W> get single {
+    assert(discovered.length <= 1);
+    return existsAtMostOnce();
+  }
+}
+
+extension WidgetSnapshotShorthands<W extends Widget> on WidgetSnapshot<W> {
+  W? get discoveredWidget => discoveredWidgets.firstOrNull;
+
+  @Deprecated('Use discoveredWidget')
+  W? get widget => discoveredWidget;
+
+  Element? get discoveredElement => discoveredElements.firstOrNull;
+
+  @Deprecated('Use discoveredElement')
+  Element? get element => discoveredElement;
+
   /// Shorthand to get the widgets of all discovered elements
   /// (see [discovered] or [discoveredElements])
   ///
@@ -1589,23 +1606,6 @@ class WidgetSnapshot<W extends Widget> {
 
   List<Element> get discoveredElements =>
       discovered.map((e) => e.element).toList();
-
-  @override
-  String toString() {
-    return 'SpotSnapshot of $selector (${discoveredElements.length} matches)}';
-  }
-
-  @useResult
-  MultiWidgetMatcher<W> get multi {
-    return MultiWidgetMatcher.fromSnapshot(this);
-  }
-
-  // TODO make WidgetSnapshot implement WidgetMatcher and MultiWidgetMatcher
-  @useResult
-  WidgetMatcher<W> get single {
-    assert(discovered.length <= 1);
-    return existsAtMostOnce();
-  }
 }
 
 extension QuantitySelectors<W extends Widget> on WidgetSelector<W> {
@@ -1701,17 +1701,6 @@ extension RelativeSelectors<W extends Widget> on WidgetSelector<W> {
   @useResult
   WidgetSelector<W> withChildren(List<WidgetSelector> children) {
     return copyWith(children: [...this.children, ...children]);
-  }
-}
-
-extension AssertionMatcher<W extends Widget> on WidgetSnapshot<W> {
-  WidgetSnapshot<W> single() {
-    return WidgetSnapshot(
-      selector: selector,
-      discovered: discovered,
-      debugCandidates: debugCandidates,
-      scope: scope,
-    );
   }
 }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -1603,10 +1603,8 @@ class WidgetSnapshot<W extends Widget> {
   // TODO make WidgetSnapshot implement WidgetMatcher and MultiWidgetMatcher
   @useResult
   WidgetMatcher<W> get single {
-    existsAtMostOnce();
-
     assert(discovered.length <= 1);
-    return WidgetMatcher.fromSnapshot(this);
+    return existsAtMostOnce();
   }
 }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -486,6 +486,9 @@ class FirstElement extends ElementFilter {
     }
     return [first];
   }
+
+  @override
+  String get description => ':first';
 }
 
 class LastElement extends ElementFilter {
@@ -499,6 +502,9 @@ class LastElement extends ElementFilter {
     }
     return [last];
   }
+
+  @override
+  String get description => ':last';
 }
 
 extension SelectorQueries<W extends Widget> on Selectors<W> {
@@ -970,7 +976,8 @@ abstract class ElementFilter {
   /// Filters all candidates, retuning only a subset that matches
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates);
 
-// TODO add description
+  /// A description to describe the filter
+  String get description;
 }
 
 abstract class CandidateGenerator<W extends Widget> {
@@ -993,6 +1000,9 @@ class WidgetTypeFilter<W extends Widget> implements ElementFilter {
   }
 
   @override
+  String get description => '$W';
+
+  @override
   String toString() {
     return 'WidgetTypeFilter of $W';
   }
@@ -1013,12 +1023,16 @@ class PropFilter implements ElementFilter {
   }
 
   @override
-  String toString() {
+  String get description {
     final props = this.props.isNotEmpty
         ? this.props.map((e) => e.description).join(' ')
         : null;
+    return props ?? 'any Widget';
+  }
 
-    return 'PropFilter of $props';
+  @override
+  String toString() {
+    return 'PropFilter of $description';
   }
 }
 
@@ -1083,13 +1097,16 @@ class ChildFilter implements ElementFilter {
     return matchingChildNodes;
   }
 
-  @override
-  String toString() {
+  String get description {
     final children = childSelectors.isNotEmpty
         ? 'with children: [${childSelectors.map((e) => e.toStringBreadcrumb()).join(', ')}]'
         : null;
+    return children ?? 'any Widget';
+  }
 
-    return 'PropFilter of $children';
+  @override
+  String toString() {
+    return 'PropFilter of $description';
   }
 }
 
@@ -1190,8 +1207,12 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
     final props = this.props.isNotEmpty
         ? this.props.map((e) => e.description).join(' ')
         : null;
+    final filters = elementFilters.isNotEmpty
+        ? elementFilters.map((e) => e.description).join(' ')
+        : null;
 
-    final constraints = [props, children, parents].where((e) => e != null);
+    final constraints =
+        [props, filters, children, parents].where((e) => e != null);
     if (constraints.isEmpty) {
       return '';
     }
@@ -1205,8 +1226,11 @@ class WidgetSelector<W extends Widget> with Selectors<W> {
     final props = this.props.isNotEmpty
         ? this.props.map((e) => e.description).join(' ')
         : null;
+    final filters = elementFilters.isNotEmpty
+        ? elementFilters.map((e) => e.description).join(' ')
+        : null;
 
-    final constraints = [props, children].where((e) => e != null);
+    final constraints = [props, filters, children].where((e) => e != null);
     return constraints.join(' ');
   }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -50,12 +50,12 @@ mixin Selectors<T extends Widget> {
   ///    .spotSingle<AppBar>()
   /// ```
   @useResult
-  @Deprecated('Use spot<W>()')
+  @Deprecated('Use spot<W>().atMost(1)')
   SingleWidgetSelector<W> spotSingle<W extends Widget>({
     List<WidgetSelector> parents = const [],
     List<WidgetSelector> children = const [],
   }) {
-    return spot<W>(parents: parents, children: children).single;
+    return spot<W>(parents: parents, children: children).atMost(1);
   }
 
   /// Creates a [WidgetSelector] that matches a all Widgets of
@@ -112,7 +112,7 @@ mixin Selectors<T extends Widget> {
   ///
   /// The comparison happens by identity (===)
   @useResult
-  @Deprecated('Use spotWidget()')
+  @Deprecated('Use spotWidget().atMost(1)')
   SingleWidgetSelector<W> spotSingleWidget<W extends Widget>(
     W widget, {
     List<WidgetSelector> parents = const [],
@@ -122,14 +122,14 @@ mixin Selectors<T extends Widget> {
       widget,
       parents: [if (self != null) self!, ...parents],
       children: children,
-    ).single;
+    ).atMost(1);
   }
 
   /// Creates a [WidgetSelector] that finds all [widget] by identity
   ///
   /// The comparison happens by identity (===)
   @useResult
-  @Deprecated('Use spotWidget()')
+  @Deprecated('Use spotWidget().atMost(1)')
   MultiWidgetSelector<W> spotWidgets<W extends Widget>(
     W widget, {
     List<WidgetSelector> parents = const [],
@@ -271,7 +271,7 @@ mixin Selectors<T extends Widget> {
       parents: [if (self != null) self!, ...parents],
       children: children,
       findRichText: findRichText,
-    ).single;
+    ).atMost(1);
   }
 
   /// Creates a [WidgetSelector] that finds all [Text], [EditableText] or
@@ -346,7 +346,7 @@ mixin Selectors<T extends Widget> {
 
   /// Creates a [WidgetSelector] that finds a single [Icon] based on the [icon]
   @useResult
-  @Deprecated('Use spotIcon()')
+  @Deprecated('Use spotIcon().atMost(1)')
   SingleWidgetSelector<Icon> spotSingleIcon(
     IconData icon, {
     bool skipOffstage = true,
@@ -357,7 +357,7 @@ mixin Selectors<T extends Widget> {
       icon,
       parents: [if (self != null) self!, ...parents],
       children: children,
-    ).single;
+    ).atMost(1);
   }
 
   /// Creates a [WidgetSelector] that finds all [Icon] widgets based on the [icon]
@@ -409,7 +409,7 @@ mixin Selectors<T extends Widget> {
 
   /// Creates a [WidgetSelector] that finds a single widget with the given [key]
   @useResult
-  @Deprecated('Use spotKey()')
+  @Deprecated('Use spotKey().atMost(1)')
   SingleWidgetSelector<W> spotSingleKey<W extends Widget>(
     Key key, {
     List<WidgetSelector> parents = const [],
@@ -419,7 +419,7 @@ mixin Selectors<T extends Widget> {
       key,
       parents: [if (self != null) self!, ...parents],
       children: children,
-    ).single;
+    ).atMost(1);
   }
 
   /// Creates a [WidgetSelector] that finds all widgets with the given [key]

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -1467,7 +1467,7 @@ class QuantityConstraint {
 extension SelectorToSnapshot<W extends Widget> on WidgetSelector<W> {
   MultiWidgetSnapshot<W> snapshot() {
     TestAsyncUtils.guardSync();
-    return snapshot_file.snapshot(this);
+    return snapshot_file.snapshot(this, validateQuantity: false);
   }
 
   @useResult
@@ -1637,37 +1637,37 @@ extension QuantitySelectors<W extends Widget> on WidgetSelector<W> {
 extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   MultiWidgetSnapshot<W> existsAtLeastOnce() {
     TestAsyncUtils.guardSync();
-    return snapshot(this).existsAtLeastOnce();
+    return snapshot(this, validateQuantity: false).existsAtLeastOnce();
   }
 
   MultiWidgetSnapshot<W> existsAtMostOnce() {
     TestAsyncUtils.guardSync();
-    return snapshot(this).existsAtMostOnce();
+    return snapshot(this, validateQuantity: false).existsAtMostOnce();
   }
 
   void doesNotExist() {
     TestAsyncUtils.guardSync();
-    snapshot(this).doesNotExist();
+    snapshot(this, validateQuantity: false).doesNotExist();
   }
 
   SingleWidgetSnapshot<W> existsOnce() {
     TestAsyncUtils.guardSync();
-    return snapshot(this).existsOnce();
+    return snapshot(this, validateQuantity: false).existsOnce();
   }
 
   MultiWidgetSnapshot<W> existsExactlyNTimes(int n) {
     TestAsyncUtils.guardSync();
-    return snapshot(this).existsExactlyNTimes(n);
+    return snapshot(this, validateQuantity: false).existsExactlyNTimes(n);
   }
 
   MultiWidgetSnapshot<W> existsAtLeastNTimes(int n) {
     TestAsyncUtils.guardSync();
-    return snapshot(this).existsAtLeastNTimes(n);
+    return snapshot(this, validateQuantity: false).existsAtLeastNTimes(n);
   }
 
   MultiWidgetSnapshot<W> existsAtMostNTimes(int n) {
     TestAsyncUtils.guardSync();
-    return snapshot(this).existsAtMostNTimes(n);
+    return snapshot(this, validateQuantity: false).existsAtMostNTimes(n);
   }
 }
 

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -235,17 +235,20 @@ extension _ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
 extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
   void doesNotExist() => _exists(max: 0);
 
-  WidgetSnapshot<W> existsOnce() => _exists(min: 1, max: 1);
+  WidgetMatcher<W> existsOnce() =>
+      WidgetMatcher.fromSnapshot(_exists(min: 1, max: 1));
 
-  WidgetSnapshot<W> existsAtLeastOnce() => _exists(min: 1);
+  MultiWidgetMatcher<W> existsAtLeastOnce() => _exists(min: 1).multi;
 
-  WidgetSnapshot<W> existsAtMostOnce() => _exists(max: 1);
+  WidgetMatcher<W> existsAtMostOnce() =>
+      WidgetMatcher.fromSnapshot(_exists(max: 1));
 
-  WidgetSnapshot<W> existsExactlyNTimes(int n) => _exists(min: n, max: n);
+  MultiWidgetMatcher<W> existsExactlyNTimes(int n) =>
+      _exists(min: n, max: n).multi;
 
-  WidgetSnapshot<W> existsAtLeastNTimes(int n) => _exists(min: n);
+  MultiWidgetMatcher<W> existsAtLeastNTimes(int n) => _exists(min: n).multi;
 
-  WidgetSnapshot<W> existsAtMostNTimes(int n) => _exists(max: n);
+  MultiWidgetMatcher<W> existsAtMostNTimes(int n) => _exists(max: n).multi;
 
   WidgetSnapshot<W> _exists({int? min, int? max}) {
     assert(min != null || max != null);

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -147,6 +147,9 @@ extension _ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
     final minimumConstraint = selector.quantityConstraint.min;
     final maximumConstraint = selector.quantityConstraint.max;
 
+    final unconstrainedSelector =
+        selector.overrideQuantityConstraint(QuantityConstraint.unconstrained);
+
     String significantWidgetTree() {
       final set = discoveredElements.toSet();
       return findCommonAncestor(set).toStringDeep();
@@ -156,10 +159,10 @@ extension _ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
       if (count == 0) {
         _tryMatchingLessSpecificCriteria(this);
         throw TestFailure(
-          'Could not find ${selector.toStringBreadcrumb()} in widget tree, '
+          'Could not find ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
           'expected at least $minimumConstraint\n'
           '${significantWidgetTree()}'
-          'Could not find ${selector.toStringBreadcrumb()} in widget tree, '
+          'Could not find ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
           'expected at least $minimumConstraint',
         );
       }
@@ -167,10 +170,10 @@ extension _ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
       if (minimumConstraint > count) {
         _tryMatchingLessSpecificCriteria(this);
         throw TestFailure(
-          'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+          'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
           'expected at least $minimumConstraint\n'
           '${significantWidgetTree()}'
-          'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+          'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
           'expected at least $minimumConstraint',
         );
       }
@@ -179,10 +182,10 @@ extension _ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
     if (maximumConstraint != null && minimumConstraint == null) {
       if (maximumConstraint < count) {
         throw TestFailure(
-          'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+          'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
           'expected at most $maximumConstraint\n'
           '${significantWidgetTree()}'
-          'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+          'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
           'expected at most $maximumConstraint',
         );
       }
@@ -198,19 +201,19 @@ extension _ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
           if (count == 0) {
             _tryMatchingLessSpecificCriteria(this);
             throw TestFailure(
-              'Could not find ${selector.toStringBreadcrumb()} in widget tree, '
+              'Could not find ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
               'expected exactly $exactCount\n'
               '${significantWidgetTree()}'
-              'Could not find ${selector.toStringBreadcrumb()} in widget tree, '
+              'Could not find ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
               'expected exactly $exactCount',
             );
           } else {
             _tryMatchingLessSpecificCriteria(this);
             throw TestFailure(
-              'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+              'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
               'expected exactly $exactCount\n'
               '${significantWidgetTree()}'
-              'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+              'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
               'expected exactly $exactCount',
             );
           }
@@ -218,10 +221,10 @@ extension _ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
       } else {
         // out of range
         throw TestFailure(
-          'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+          'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
           'expected between $minimumConstraint and $maximumConstraint\n'
           '${significantWidgetTree()}'
-          'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+          'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
           'expected between $minimumConstraint and $maximumConstraint',
         );
       }
@@ -317,18 +320,21 @@ void _tryMatchingLessSpecificCriteria(WidgetSnapshot snapshot) {
     final lessSpecificCount = lessSpecificSnapshot.discovered.length;
     final minimumConstraint = selector.quantityConstraint.min;
     final maximumConstraint = selector.quantityConstraint.max;
+    final unconstrainedSelector =
+        selector.overrideQuantityConstraint(QuantityConstraint.unconstrained);
+
     // error that selector could not be found, but instead spot detected lessSpecificSnapshot, which might be useful
     if (lessSpecificCount > count) {
       if (minimumConstraint != null && maximumConstraint == null) {
         if (count == 0) {
           errorBuilder.writeln(
-              'Could not find ${selector.toStringBreadcrumb()} in widget tree, '
+              'Could not find ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
               'expected at least $minimumConstraint');
         }
 
         if (minimumConstraint > count) {
           errorBuilder.writeln(
-              'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+              'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
               'expected at least $minimumConstraint');
         }
       }
@@ -336,7 +342,7 @@ void _tryMatchingLessSpecificCriteria(WidgetSnapshot snapshot) {
       if (maximumConstraint != null && minimumConstraint == null) {
         if (maximumConstraint < count) {
           errorBuilder.writeln(
-              'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+              'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
               'expected at most $maximumConstraint');
         }
       }
@@ -346,17 +352,17 @@ void _tryMatchingLessSpecificCriteria(WidgetSnapshot snapshot) {
           final exactCount = minimumConstraint;
           if (count == 0) {
             errorBuilder.writeln(
-                'Could not find ${selector.toStringBreadcrumb()} in widget tree, '
+                'Could not find ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
                 'expected exactly $exactCount');
           } else {
             errorBuilder.writeln(
-                'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+                'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
                 'expected exactly $exactCount');
           }
         } else {
           // out of range
           errorBuilder.writeln(
-              'Found $count elements matching ${selector.toStringBreadcrumb()} in widget tree, '
+              'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
               'expected between $minimumConstraint and $maximumConstraint');
         }
       }
@@ -365,7 +371,7 @@ void _tryMatchingLessSpecificCriteria(WidgetSnapshot snapshot) {
         "A less specific search ($lessSpecificSelector) discovered $lessSpecificCount matches!",
       );
       errorBuilder.writeln(
-        'Maybe you have to adjust your WidgetSelector ($selector) to cover those missing elements.\n',
+        'Maybe you have to adjust your WidgetSelector ($unconstrainedSelector) to cover those missing elements.\n',
       );
       int index = 0;
       for (final Element match in lessSpecificSnapshot.discoveredElements) {
@@ -454,7 +460,7 @@ extension _LessSpecificSelectors<W extends Widget> on WidgetSelector<W> {
       props: [],
       parents: [],
       children: [],
-      quantityConstraint: QuantityConstraint.none,
+      quantityConstraint: QuantityConstraint.unconstrained,
     );
     for (final criteria in criteria) {
       s = criteria(s);

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -184,24 +184,51 @@ extension _ValidateQuantity<W extends Widget> on MultiWidgetSnapshot<W> {
       return findCommonAncestor(set).toStringDeep();
     }
 
-    if (minimumConstraint != null && minimumConstraint > count) {
-      throw TestFailure(
-        'Found $count elements matching $selector in widget tree, '
-        'expected at least $minimumConstraint\n'
-        '${significantWidgetTree()}'
-        'Found $count elements matching $selector in widget tree, '
-        'expected at least $minimumConstraint',
-      );
+    if (minimumConstraint != null && maximumConstraint == null) {
+      if (minimumConstraint > count) {
+        throw TestFailure(
+          'Found $count elements matching $selector in widget tree, '
+          'expected at least $minimumConstraint\n'
+          '${significantWidgetTree()}'
+          'Found $count elements matching $selector in widget tree, '
+          'expected at least $minimumConstraint',
+        );
+      }
     }
 
-    if (maximumConstraint != null && maximumConstraint < count) {
-      throw TestFailure(
-        'Found $count elements matching $selector in widget tree, '
-        'expected at most $maximumConstraint\n'
-        '${significantWidgetTree()}'
-        'Found $count elements matching $selector in widget tree, '
-        'expected at most $maximumConstraint',
-      );
+    if (maximumConstraint != null && minimumConstraint == null) {
+      if (maximumConstraint < count) {
+        throw TestFailure(
+          'Found $count elements matching $selector in widget tree, '
+          'expected at most $maximumConstraint\n'
+          '${significantWidgetTree()}'
+          'Found $count elements matching $selector in widget tree, '
+          'expected at most $maximumConstraint',
+        );
+      }
+    }
+
+    if (minimumConstraint != null && maximumConstraint != null) {
+      if (minimumConstraint == maximumConstraint) {
+        final exactCount = minimumConstraint;
+        if (count != exactCount) {
+          throw TestFailure(
+            'Found $count elements matching $selector in widget tree, '
+            'expected exactly $exactCount\n'
+            '${significantWidgetTree()}'
+            'Found $count elements matching $selector in widget tree, '
+            'expected exactly $exactCount',
+          );
+        }
+      } else {
+        throw TestFailure(
+          'Found $count elements matching $selector in widget tree, '
+          'expected between $minimumConstraint and $maximumConstraint\n'
+          '${significantWidgetTree()}'
+          'Found $count elements matching $selector in widget tree, '
+          'expected between $minimumConstraint and $maximumConstraint',
+        );
+      }
     }
   }
 }
@@ -258,6 +285,9 @@ extension MultiWidgetSelectorMatcher<W extends Widget>
           errorBuilder.writeln("Possible match #$index:");
           errorBuilder.writeln(candidate.element.widget.toStringDeep());
         });
+
+        errorBuilder
+            .writeln(findCommonAncestor(discoveredElements).toStringDeep());
 
         errorBuilder.writeln(
           'Found ${discovered.length} elements matching $selector in widget tree, '

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -450,7 +450,8 @@ extension _LessSpecificSelectors<W extends Widget> on WidgetSelector<W> {
       // do not yield selectors which match any widgets
       if (selector.children.isNotEmpty ||
           selector.parents.isNotEmpty ||
-          selector.props.isNotEmpty) {
+          selector.props.isNotEmpty ||
+          selector.type != Widget) {
         yield selector;
       }
     }

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -44,6 +44,7 @@ class AnyText extends LeafRenderObjectWidget {
       selectionColor: widget.selectionColor,
     );
   }
+
   factory AnyText.fromRichText(RichText widget) {
     return AnyText._(
       widget: widget,

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -189,8 +189,8 @@ class AnyText extends LeafRenderObjectWidget {
 /// - [SelectableText]
 /// - [RichText]
 /// - [EditableText]
-class SingleAnyTextWidgetSelector extends SingleWidgetSelector<AnyText> {
-  SingleAnyTextWidgetSelector({
+class AnyTextWidgetSelector extends WidgetSelector<AnyText> {
+  AnyTextWidgetSelector({
     required super.props,
     super.children,
     super.parents,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spot
 description: Chainable finders and better assertions for powerful widget tests.
-version: 0.7.0
+version: 0.10.0
 repository: https://github.com/passsy/spot
 issue_tracker: https://github.com/passsy/spot/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: spot
 description: Chainable finders and better assertions for powerful widget tests.
-version: 0.10.0
+version: 0.10.0-beta.1
 repository: https://github.com/passsy/spot
 issue_tracker: https://github.com/passsy/spot/issues
 

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -69,7 +69,7 @@ void actTests() {
     await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
-        "Could not find 'ElevatedButton' in widget tree",
+        "Could not find ElevatedButton in widget tree",
       ]),
     );
   });
@@ -96,7 +96,7 @@ void actTests() {
     await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
-        "Found 2 elements matching 'ElevatedButton' in widget tree",
+        "Found 2 elements matching ElevatedButton in widget tree",
       ]),
     );
   });

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -28,7 +28,7 @@ void actTests() {
       ),
     );
 
-    final button = spotSingle<ElevatedButton>()..existsOnce();
+    final button = spot<ElevatedButton>()..existsOnce();
 
     expect(i, 0);
     await act.tap(button);
@@ -48,7 +48,7 @@ void actTests() {
         ),
       ),
     );
-    final future = act.tap(spotSingle<ElevatedButton>());
+    final future = act.tap(spot<ElevatedButton>());
 
     try {
       TestAsyncUtils.guardSync();
@@ -64,7 +64,7 @@ void actTests() {
 
   testWidgets('tap throws if widget not in widget tree', (tester) async {
     await tester.pumpWidget(const MaterialApp());
-    final button = spotSingle<ElevatedButton>()..doesNotExist();
+    final button = spot<ElevatedButton>()..doesNotExist();
 
     await expectLater(
       () => act.tap(button),
@@ -118,7 +118,7 @@ void actTests() {
       ),
     );
 
-    final button = spotSingle<ElevatedButton>()..existsOnce();
+    final button = spot<ElevatedButton>()..existsOnce();
 
     await expectLater(
       () => act.tap(button),
@@ -151,7 +151,7 @@ void actTests() {
       ),
     );
 
-    final button = spotSingle<ElevatedButton>()..existsOnce();
+    final button = spot<ElevatedButton>()..existsOnce();
     await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
@@ -176,7 +176,7 @@ void actTests() {
       ),
     );
 
-    final button = spotSingle<ElevatedButton>()..existsOnce();
+    final button = spot<ElevatedButton>()..existsOnce();
     await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
@@ -204,7 +204,7 @@ void actTests() {
       ),
     );
 
-    final button = spotSingle<ElevatedButton>()..existsOnce();
+    final button = spot<ElevatedButton>()..existsOnce();
     await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
@@ -217,7 +217,7 @@ void actTests() {
 
   testWidgets('tapping throws for non cartesian widgets', (tester) async {
     await tester.pumpWidget(_NonCartesianWidget());
-    final button = spotSingle<_NonCartesianWidget>()..existsOnce();
+    final button = spot<_NonCartesianWidget>()..existsOnce();
     await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([
@@ -231,7 +231,7 @@ void actTests() {
   testWidgets('tapping throws for widgets without a RenderObject',
       (tester) async {
     await tester.pumpWidget(_NoRenderObjectWidget());
-    final button = spotSingle<_NoRenderObjectWidget>()..existsOnce();
+    final button = spot<_NoRenderObjectWidget>()..existsOnce();
     await expectLater(
       () => act.tap(button),
       throwsSpotErrorContaining([

--- a/test/checks/checks_test.dart
+++ b/test/checks/checks_test.dart
@@ -1,4 +1,5 @@
 import 'package:spot/src/checks/checks_nullability.dart';
+
 // import 'package:checks/checks.dart';
 import 'package:checks/context.dart' show softCheck;
 import 'package:checks/checks.dart' show it;

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -44,21 +44,21 @@ void main() {
     spot<Text>().first().existsOnce().hasText('Pepe');
 
     final WidgetSelector<Scaffold> scaffold =
-        spotSingle<MaterialApp>().spotSingle<Scaffold>();
-    final appBar = scaffold.spotSingle<AppBar>();
+        spot<MaterialApp>().spot<Scaffold>();
+    final appBar = scaffold.spot<AppBar>();
 
-    final container = scaffold.spotSingle<Container>()..existsOnce();
+    final container = scaffold.spot<Container>()..existsOnce();
 
-    appBar.spotSingleIcon(
+    appBar.spotIcon(
       Icons.home,
       parents: [spot<IconButton>(), container],
     ).existsOnce();
 
-    appBar.spotSingle<IconButton>(
-      children: [spotSingleIcon(Icons.settings)],
+    appBar.spot<IconButton>(
+      children: [spotIcon(Icons.settings)],
     ).doesNotExist();
 
-    appBar.spotSingleIcon(
+    appBar.spotIcon(
       Icons.settings,
       parents: [spot<IconButton>()],
     ).doesNotExist();

--- a/test/selectors/custom_matcher_test.dart
+++ b/test/selectors/custom_matcher_test.dart
@@ -37,7 +37,7 @@ void main() {
         ),
       ),
     );
-    final checkbox = spotSingle<Checkbox>();
+    final checkbox = spot<Checkbox>();
 
     testWidgets('hasProp selector', (widgetTester) async {
       await widgetTester.pumpWidget(checkedCheckbox);

--- a/test/selectors/filter_test.dart
+++ b/test/selectors/filter_test.dart
@@ -39,6 +39,24 @@ void main() {
       final topMostCenter = spot<Center>().first();
       topMostCenter.spot<Row>().existsOnce();
     });
+
+    testWidgets('first().copyWith() returns a single item', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Row(
+            children: [
+              Text('a'),
+              Text('b'),
+              Text('c'),
+            ],
+          ),
+        ),
+      );
+      final first = spot<Text>().first();
+      first.existsOnce().hasText('a');
+      final copy = first.copyWith();
+      copy.existsOnce().hasText('a');
+    });
   });
 
   group('last', () {

--- a/test/selectors/interop_test.dart
+++ b/test/selectors/interop_test.dart
@@ -80,8 +80,7 @@ void main() {
         ),
       );
 
-      final text = spot<MaterialApp>().spotSingle<Text>()
-        ..existsOnce().hasText('a');
+      final text = spot<MaterialApp>().spot<Text>()..existsOnce().hasText('a');
       expect(text.finder, findsOneWidget);
     });
   });

--- a/test/selectors/interop_test.dart
+++ b/test/selectors/interop_test.dart
@@ -52,23 +52,13 @@ void main() {
             (e) => e.message,
             'message',
             anyOf(
-              // Flutter 3.10
+              // Flutter 3.10, Flutter 3.13,
               contains(
                 'Could not find text "nope" which is an ancestor of type "Directionality" in widget tree, expected exactly 1',
               ),
-              // Flutter 3.13
+              // Flutter 3.15, Flutter 3.16
               contains(
-                'Could not find widget with text "nope" which is an ancestor of type "Directionality" in widget tree',
-              ),
-
-              // Flutter 3.15
-              contains(
-                'Could not find widget with widgets with text "nope" that are ancestors of widgets with type "Directionality" in widget tree',
-              ),
-
-              // Flutter 3.16
-              contains(
-                'Could not find widgets with text "nope" that are ancestors of widgets with type "Directionality" in widget tree',
+                'Could not find widgets with text "nope" that are ancestors of widgets with type "Directionality" in widget tree, expected exactly 1',
               ),
             ),
           ),

--- a/test/selectors/interop_test.dart
+++ b/test/selectors/interop_test.dart
@@ -30,7 +30,8 @@ void main() {
           .hasDiagnosticProp<String>('data', (it) => it.equals('a'));
     });
 
-    testWidgets('readable error messages', (tester) async {
+    testWidgets('readable error messages when ancestor could not be found',
+        (tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,
@@ -51,6 +52,10 @@ void main() {
             (e) => e.message,
             'message',
             anyOf(
+              // Flutter 3.10
+              contains(
+                'Could not find text "nope" which is an ancestor of type "Directionality" in widget tree, expected exactly 1',
+              ),
               // Flutter 3.13
               contains(
                 'Could not find widget with text "nope" which is an ancestor of type "Directionality" in widget tree',
@@ -109,7 +114,7 @@ void main() {
           .hasText('a');
     });
 
-    testWidgets('readable error messages', (tester) async {
+    testWidgets('spotFinder has readable error messages', (tester) async {
       await tester.pumpWidget(
         Directionality(
           textDirection: TextDirection.ltr,

--- a/test/selectors/interop_test.dart
+++ b/test/selectors/interop_test.dart
@@ -60,6 +60,11 @@ void main() {
               contains(
                 'Could not find widget with widgets with text "nope" that are ancestors of widgets with type "Directionality" in widget tree',
               ),
+
+              // Flutter 3.16
+              contains(
+                'Could not find widgets with text "nope" that are ancestors of widgets with type "Directionality" in widget tree',
+              ),
             ),
           ),
         ),
@@ -120,8 +125,7 @@ void main() {
             (e) => e.message,
             'message',
             contains(
-              'Could not find widget with text "nope" '
-              "'with parents: ['Directionality']' in widget tree",
+              'Could not find Directionality > text "nope" in widget tree',
             ),
           ),
         ),

--- a/test/selectors/multi_matchers_test.dart
+++ b/test/selectors/multi_matchers_test.dart
@@ -30,7 +30,7 @@ void main() {
 
     final scaffold = spot<MaterialApp>().spot<Scaffold>();
     final appBar = scaffold.spot<AppBar>();
-    spot<AppBar>().spotSingleIcon(Icons.settings).existsOnce();
+    spot<AppBar>().spotIcon(Icons.settings).existsOnce();
 
     spot<Icon>(parents: [appBar, spot<IconButton>()])
         .existsExactlyNTimes(2)
@@ -63,7 +63,7 @@ void main() {
 
     final scaffold = spot<MaterialApp>().spot<Scaffold>();
     final appBar = scaffold.spot<AppBar>();
-    spot<AppBar>().spotSingleIcon(Icons.settings).existsOnce();
+    spot<AppBar>().spotIcon(Icons.settings).existsOnce();
 
     spot<Icon>(parents: [appBar, spot<IconButton>()])
         .existsExactlyNTimes(2)
@@ -93,7 +93,7 @@ void main() {
 
     final scaffold = spot<MaterialApp>().spot<Scaffold>();
     final appBar = scaffold.spot<AppBar>();
-    spot<AppBar>().spotSingleIcon(Icons.settings).existsOnce();
+    spot<AppBar>().spotIcon(Icons.settings).existsOnce();
 
     expect(
       () => spot<Icon>(parents: [appBar, spot<IconButton>()])
@@ -130,7 +130,7 @@ void main() {
 
     final scaffold = spot<MaterialApp>().spot<Scaffold>();
     final appBar = scaffold.spot<AppBar>();
-    spot<AppBar>().spotSingleIcon(Icons.settings).existsOnce();
+    spot<AppBar>().spotIcon(Icons.settings).existsOnce();
 
     expect(
       () => spot<Icon>(parents: [appBar, spot<IconButton>()])

--- a/test/selectors/prop_filter_test.dart
+++ b/test/selectors/prop_filter_test.dart
@@ -6,7 +6,7 @@ import 'package:spot/spot.dart';
 
 void main() {
   testWidgets('filter', (widgetTester) async {
-    final verticalWrapSpot = spotSingle<Wrap>().withDirection(Axis.vertical);
+    final verticalWrapSpot = spot<Wrap>().withDirection(Axis.vertical);
 
     expect(
       verticalWrapSpot.toString(),
@@ -17,7 +17,7 @@ void main() {
     );
 
     final horizontalWrapSpot =
-        spotSingle<Wrap>().whereDirection((it) => it.equals(Axis.horizontal));
+        spot<Wrap>().whereDirection((it) => it.equals(Axis.horizontal));
 
     expect(
       horizontalWrapSpot.toString(),

--- a/test/selectors/selector_test.dart
+++ b/test/selectors/selector_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
@@ -36,7 +38,7 @@ void main() {
     expect(singleSelector.expectedQuantity, ExpectedQuantity.single);
 
     await tester.pumpWidget(const Center());
-    final centerElement = spotSingle<Center>().snapshot().element;
+    final centerElement = spotSingle<Center>().snapshot().single.element;
 
     final multiMap = multiSelector.mapElementToWidget(centerElement);
     final singleMap = singleSelector.mapElementToWidget(centerElement);

--- a/test/selectors/selector_test.dart
+++ b/test/selectors/selector_test.dart
@@ -54,6 +54,8 @@ void main() {
     expect(parents, isNotNull);
     final List<WidgetSelector<Widget>> children = selector.children;
     expect(children, isNotNull);
+    final List<ElementFilter> filters = selector.elementFilters;
+    expect(filters, isNotNull);
     final Type type = selector.type;
     expect(type, isNotNull);
     final ExpectedQuantity expectedQuantity = selector.expectedQuantity;
@@ -86,11 +88,11 @@ void main() {
   });
 
   testWidgets("don't lose mapElementToWidget", (tester) async {
-    final singleSelector = spotText("home");
+    final singleSelector = spotText("home").single;
     final multiSelector = singleSelector.multi;
 
     await tester.pumpWidget(const MaterialApp(home: Text('home')));
-    final centerElement = spotText('home').snapshot().single.element;
+    final centerElement = spotText('home').existsOnce().element;
 
     final AnyText multiMap = multiSelector.mapElementToWidget(centerElement);
     final AnyText singleMap = singleSelector.mapElementToWidget(centerElement);

--- a/test/selectors/selector_test.dart
+++ b/test/selectors/selector_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
+import 'package:spot/src/spot/selectors.dart';
 
 void main() {
   testWidgets('.single keeps all information', (tester) async {
@@ -42,12 +43,52 @@ void main() {
     expect(multiMap.runtimeType, singleMap.runtimeType);
   });
 
-  testWidgets('dont lose mapElementToWidget', (tester) async {
-    final singleSelector = spotText('home');
+  testWidgets('WidgetSelector API', (tester) async {
+    await tester.pumpWidget(const Center());
+    final WidgetSelector<Center> selector = spot<Center>();
+    final List<PredicateWithDescription> props = selector.props;
+    expect(props, isNotNull);
+    final List<WidgetSelector<Widget>> parents = selector.parents;
+    expect(parents, isNotNull);
+    final List<WidgetSelector<Widget>> children = selector.children;
+    expect(children, isNotNull);
+    final Type type = selector.type;
+    expect(type, isNotNull);
+    final ExpectedQuantity expectedQuantity = selector.expectedQuantity;
+    expect(expectedQuantity, isNotNull);
+    final MultiWidgetSnapshot<Center> snapshot = selector.snapshot();
+    expect(snapshot, isNotNull);
+    final Center Function(Element element) mapElementToWidget =
+        selector.mapElementToWidget;
+    expect(mapElementToWidget, isNotNull);
+    final List<ElementFilter> createElementFilters =
+        selector.createElementFilters();
+    expect(createElementFilters, isNotNull);
+    final CandidateGenerator<Center> createCandidateGenerator =
+        selector.createCandidateGenerator();
+    expect(createCandidateGenerator, isNotNull);
+    final String stringWithoutParents = selector.toStringWithoutParents();
+    expect(stringWithoutParents, isNotNull);
+    final String stringBreadcrumb = selector.toStringBreadcrumb();
+    expect(stringBreadcrumb, isNotNull);
+    final WidgetSelector<Center> self = selector.self;
+    expect(self, isNotNull);
+    final WidgetSelector<Center> copyWith = selector.copyWith();
+    expect(copyWith, isNotNull);
+    final WidgetSelector<Center> withProp =
+        selector.withProp(match: (it) => it, widgetSelector: (it) => it);
+    expect(withProp, isNotNull);
+    final WidgetSelector<Center> withDiagnosticProp =
+        selector.withDiagnosticProp('a', (it) => it);
+    expect(withDiagnosticProp, isNotNull);
+  });
+
+  testWidgets("don't lose mapElementToWidget", (tester) async {
+    final singleSelector = spotText("home");
     final multiSelector = singleSelector.multi;
 
     await tester.pumpWidget(const MaterialApp(home: Text('home')));
-    final centerElement = spotText('home').snapshot().element;
+    final centerElement = spotText('home').snapshot().single.element;
 
     final AnyText multiMap = multiSelector.mapElementToWidget(centerElement);
     final AnyText singleMap = singleSelector.mapElementToWidget(centerElement);

--- a/test/selectors/selector_test.dart
+++ b/test/selectors/selector_test.dart
@@ -38,7 +38,7 @@ void main() {
     expect(singleSelector.expectedQuantity, ExpectedQuantity.single);
 
     await tester.pumpWidget(const Center());
-    final centerElement = spotSingle<Center>().snapshot().single.element;
+    final centerElement = spotSingle<Center>().snapshot().element!;
 
     final multiMap = multiSelector.mapElementToWidget(centerElement);
     final singleMap = singleSelector.mapElementToWidget(centerElement);

--- a/test/selectors/spot_key_test.dart
+++ b/test/selectors/spot_key_test.dart
@@ -16,13 +16,13 @@ void main() {
           ),
         ),
       );
-      spotSingleKey(const ValueKey('key')).existsOnce();
+      spotKey(const ValueKey('key')).existsOnce();
     });
 
     testWidgets('spotKey errors', (tester) async {
       await tester.pumpWidget(Center());
       expect(
-        () => spotSingleKey(const ValueKey('key')).existsOnce(),
+        () => spotKey(const ValueKey('key')).existsOnce(),
         throwsSpotErrorContaining([
           "Could not find Widget with key: \"[<'key'>]\" in widget tree",
         ]),
@@ -39,13 +39,13 @@ void main() {
           ),
         ),
       );
-      spot<Center>().spotSingleKey(const ValueKey('key')).existsOnce();
+      spot<Center>().spotKey(const ValueKey('key')).existsOnce();
     });
 
     testWidgets('spotKey errors', (tester) async {
       await tester.pumpWidget(Center(child: SizedBox()));
       expect(
-        () => spot<Center>().spotSingleKey(const ValueKey('key')).existsOnce(),
+        () => spot<Center>().spotKey(const ValueKey('key')).existsOnce(),
         throwsSpotErrorContaining([
           "Could not find Center > Widget with key: \"[<'key'>]\" in widget tree",
         ]),
@@ -107,8 +107,8 @@ void main() {
           ),
         ),
       );
-      spotKeys(key1).existsExactlyNTimes(2);
-      spotKeys(key2).existsExactlyNTimes(2);
+      spotKey(key1).existsExactlyNTimes(2);
+      spotKey(key2).existsExactlyNTimes(2);
     });
 
     testWidgets(
@@ -138,7 +138,7 @@ void main() {
           ),
         );
         expect(
-          () => spotSingleKey(key1).existsOnce(),
+          () => spotKey(key1).existsOnce(),
           throwsSpotErrorContaining([
             'Found 2 elements matching Widget with key: "[<1>]"',
             'Text-[<1>]("a"',

--- a/test/selectors/spot_key_test.dart
+++ b/test/selectors/spot_key_test.dart
@@ -24,7 +24,7 @@ void main() {
       expect(
         () => spotSingleKey(const ValueKey('key')).existsOnce(),
         throwsSpotErrorContaining([
-          "Could not find 'Widget with key: \"[<'key'>]\"' in widget tree",
+          "Could not find Widget with key: \"[<'key'>]\" in widget tree",
         ]),
       );
     });
@@ -140,7 +140,7 @@ void main() {
         expect(
           () => spotSingleKey(key1).existsOnce(),
           throwsSpotErrorContaining([
-            "Found 2 elements matching 'Widget with key: \"[<1>]\"'",
+            'Found 2 elements matching Widget with key: "[<1>]"',
             'Text-[<1>]("a"',
             'Text-[<1>]("x"',
           ]),

--- a/test/spot/existence_comparison_test.dart
+++ b/test/spot/existence_comparison_test.dart
@@ -13,52 +13,53 @@ void main() {
     testWidgets('no match', (tester) async {
       await tester.pumpWidget(Placeholder());
 
-      final spotter = spot<SizedBox>();
+      final sizedBox = spot<SizedBox>();
 
-      expect(() => spotter.doesNotExist(), returnsNormally);
-      expect(() => spotter.existsOnce(), throwsTestFailure);
-      expect(() => spotter.existsAtLeastOnce(), throwsTestFailure);
-      expect(() => spotter.existsAtMostOnce(), returnsNormally);
-      expect(() => spotter.existsExactlyNTimes(1), throwsTestFailure);
-      expect(() => spotter.existsExactlyNTimes(2), throwsTestFailure);
-      expect(() => spotter.existsAtLeastNTimes(1), throwsTestFailure);
-      expect(() => spotter.existsAtLeastNTimes(2), throwsTestFailure);
-      expect(() => spotter.existsAtMostNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtMostNTimes(2), returnsNormally);
+      expect(() => sizedBox.doesNotExist(), returnsNormally);
+      expect(() => sizedBox.existsOnce(), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastOnce(), throwsTestFailure);
+      sizedBox.existsAtMostOnce();
+      expect(() => sizedBox.existsAtMostOnce(), returnsNormally);
+      expect(() => sizedBox.existsExactlyNTimes(1), throwsTestFailure);
+      expect(() => sizedBox.existsExactlyNTimes(2), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastNTimes(1), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastNTimes(2), throwsTestFailure);
+      expect(() => sizedBox.existsAtMostNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsAtMostNTimes(2), returnsNormally);
     });
 
     testWidgets('1 match', (tester) async {
       await tester.pumpWidget(SizedBox());
 
-      final spotter = spot<SizedBox>();
+      final sizedBox = spot<SizedBox>();
 
-      expect(() => spotter.doesNotExist(), throwsTestFailure);
-      expect(() => spotter.existsOnce(), returnsNormally);
-      expect(() => spotter.existsAtLeastOnce(), returnsNormally);
-      expect(() => spotter.existsAtMostOnce(), returnsNormally);
-      expect(() => spotter.existsExactlyNTimes(1), returnsNormally);
-      expect(() => spotter.existsExactlyNTimes(2), throwsTestFailure);
-      expect(() => spotter.existsAtLeastNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtLeastNTimes(2), throwsTestFailure);
-      expect(() => spotter.existsAtMostNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtMostNTimes(2), returnsNormally);
+      expect(() => sizedBox.doesNotExist(), throwsTestFailure);
+      expect(() => sizedBox.existsOnce(), returnsNormally);
+      expect(() => sizedBox.existsAtLeastOnce(), returnsNormally);
+      expect(() => sizedBox.existsAtMostOnce(), returnsNormally);
+      expect(() => sizedBox.existsExactlyNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsExactlyNTimes(2), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsAtLeastNTimes(2), throwsTestFailure);
+      expect(() => sizedBox.existsAtMostNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsAtMostNTimes(2), returnsNormally);
     });
 
     testWidgets('2 matches ', (tester) async {
       await tester.pumpWidget(Column(children: [SizedBox(), SizedBox()]));
 
-      final spotter = spot<SizedBox>();
+      final sizedBox = spot<SizedBox>();
 
-      expect(() => spotter.doesNotExist(), throwsTestFailure);
-      expect(() => spotter.existsOnce(), throwsTestFailure);
-      expect(() => spotter.existsAtLeastOnce(), returnsNormally);
-      expect(() => spotter.existsAtMostOnce(), throwsTestFailure);
-      expect(() => spotter.existsExactlyNTimes(1), throwsTestFailure);
-      expect(() => spotter.existsExactlyNTimes(2), returnsNormally);
-      expect(() => spotter.existsAtLeastNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtLeastNTimes(2), returnsNormally);
-      expect(() => spotter.existsAtMostNTimes(1), throwsTestFailure);
-      expect(() => spotter.existsAtMostNTimes(2), returnsNormally);
+      expect(() => sizedBox.doesNotExist(), throwsTestFailure);
+      expect(() => sizedBox.existsOnce(), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastOnce(), returnsNormally);
+      expect(() => sizedBox.existsAtMostOnce(), throwsTestFailure);
+      expect(() => sizedBox.existsExactlyNTimes(1), throwsTestFailure);
+      expect(() => sizedBox.existsExactlyNTimes(2), returnsNormally);
+      expect(() => sizedBox.existsAtLeastNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsAtLeastNTimes(2), returnsNormally);
+      expect(() => sizedBox.existsAtMostNTimes(1), throwsTestFailure);
+      expect(() => sizedBox.existsAtMostNTimes(2), returnsNormally);
     });
   });
 
@@ -73,20 +74,20 @@ void main() {
         ),
       );
 
-      final spotter = spot<SizedBox>(parents: [spot<Center>()]);
+      final sizedBox = spot<SizedBox>(parents: [spot<Center>()]);
 
-      expect(spotter.snapshot().discovered, isNotNull);
+      expect(sizedBox.snapshot().discovered, isNotNull);
 
-      expect(() => spotter.doesNotExist(), throwsTestFailure);
-      expect(() => spotter.existsOnce(), returnsNormally);
-      expect(() => spotter.existsAtLeastOnce(), returnsNormally);
-      expect(() => spotter.existsAtMostOnce(), returnsNormally);
-      expect(() => spotter.existsExactlyNTimes(1), returnsNormally);
-      expect(() => spotter.existsExactlyNTimes(2), throwsTestFailure);
-      expect(() => spotter.existsAtLeastNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtLeastNTimes(2), throwsTestFailure);
-      expect(() => spotter.existsAtMostNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtMostNTimes(2), returnsNormally);
+      expect(() => sizedBox.doesNotExist(), throwsTestFailure);
+      expect(() => sizedBox.existsOnce(), returnsNormally);
+      expect(() => sizedBox.existsAtLeastOnce(), returnsNormally);
+      expect(() => sizedBox.existsAtMostOnce(), returnsNormally);
+      expect(() => sizedBox.existsExactlyNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsExactlyNTimes(2), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsAtLeastNTimes(2), throwsTestFailure);
+      expect(() => sizedBox.existsAtMostNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsAtMostNTimes(2), returnsNormally);
     });
 
     testWidgets('parent does not exist, item exists', (tester) async {
@@ -99,20 +100,20 @@ void main() {
         ),
       );
 
-      final spotter = spot<SizedBox>(parents: [spot<Material>()]);
+      final sizedBox = spot<SizedBox>(parents: [spot<Material>()]);
 
-      expect(spotter.snapshot().discovered, isEmpty);
+      expect(sizedBox.snapshot().discovered, isEmpty);
 
-      expect(() => spotter.doesNotExist(), returnsNormally);
-      expect(() => spotter.existsOnce(), throwsTestFailure);
-      expect(() => spotter.existsAtLeastOnce(), throwsTestFailure);
-      expect(() => spotter.existsAtMostOnce(), returnsNormally);
-      expect(() => spotter.existsExactlyNTimes(1), throwsTestFailure);
-      expect(() => spotter.existsExactlyNTimes(2), throwsTestFailure);
-      expect(() => spotter.existsAtLeastNTimes(1), throwsTestFailure);
-      expect(() => spotter.existsAtLeastNTimes(2), throwsTestFailure);
-      expect(() => spotter.existsAtMostNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtMostNTimes(2), returnsNormally);
+      expect(() => sizedBox.doesNotExist(), returnsNormally);
+      expect(() => sizedBox.existsOnce(), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastOnce(), throwsTestFailure);
+      expect(() => sizedBox.existsAtMostOnce(), returnsNormally);
+      expect(() => sizedBox.existsExactlyNTimes(1), throwsTestFailure);
+      expect(() => sizedBox.existsExactlyNTimes(2), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastNTimes(1), throwsTestFailure);
+      expect(() => sizedBox.existsAtLeastNTimes(2), throwsTestFailure);
+      expect(() => sizedBox.existsAtMostNTimes(1), returnsNormally);
+      expect(() => sizedBox.existsAtMostNTimes(2), returnsNormally);
     });
 
     testWidgets('parent exists, item does not exist', (tester) async {
@@ -125,24 +126,24 @@ void main() {
         ),
       );
 
-      final spotter = spot<Material>(parents: [spot<SizedBox>()]);
+      final material = spot<Material>(parents: [spot<SizedBox>()]);
 
       final throwsFailureWithMessage = throwsSpotErrorContaining(
         ["Could not find SizedBox > Material in widget tree"],
       );
 
-      expect(spotter.snapshot().discovered, isEmpty);
+      expect(material.snapshot().discovered, isEmpty);
 
-      expect(() => spotter.doesNotExist(), returnsNormally);
-      expect(() => spotter.existsOnce(), throwsFailureWithMessage);
-      expect(() => spotter.existsAtLeastOnce(), throwsFailureWithMessage);
-      expect(() => spotter.existsAtMostOnce(), returnsNormally);
-      expect(() => spotter.existsExactlyNTimes(1), throwsFailureWithMessage);
-      expect(() => spotter.existsExactlyNTimes(2), throwsFailureWithMessage);
-      expect(() => spotter.existsAtLeastNTimes(1), throwsFailureWithMessage);
-      expect(() => spotter.existsAtLeastNTimes(2), throwsFailureWithMessage);
-      expect(() => spotter.existsAtMostNTimes(1), returnsNormally);
-      expect(() => spotter.existsAtMostNTimes(2), returnsNormally);
+      expect(() => material.doesNotExist(), returnsNormally);
+      expect(() => material.existsOnce(), throwsFailureWithMessage);
+      expect(() => material.existsAtLeastOnce(), throwsFailureWithMessage);
+      expect(() => material.existsAtMostOnce(), returnsNormally);
+      expect(() => material.existsExactlyNTimes(1), throwsFailureWithMessage);
+      expect(() => material.existsExactlyNTimes(2), throwsFailureWithMessage);
+      expect(() => material.existsAtLeastNTimes(1), throwsFailureWithMessage);
+      expect(() => material.existsAtLeastNTimes(2), throwsFailureWithMessage);
+      expect(() => material.existsAtMostNTimes(1), returnsNormally);
+      expect(() => material.existsAtMostNTimes(2), returnsNormally);
     });
 
     testWidgets('error shows alternative item', (tester) async {

--- a/test/spot/existence_comparison_test.dart
+++ b/test/spot/existence_comparison_test.dart
@@ -13,7 +13,7 @@ void main() {
     testWidgets('no match', (tester) async {
       await tester.pumpWidget(Placeholder());
 
-      final spotter = spotSingle<SizedBox>();
+      final spotter = spot<SizedBox>();
 
       expect(() => spotter.doesNotExist(), returnsNormally);
       expect(() => spotter.existsOnce(), throwsTestFailure);
@@ -30,7 +30,7 @@ void main() {
     testWidgets('1 match', (tester) async {
       await tester.pumpWidget(SizedBox());
 
-      final spotter = spotSingle<SizedBox>();
+      final spotter = spot<SizedBox>();
 
       expect(() => spotter.doesNotExist(), throwsTestFailure);
       expect(() => spotter.existsOnce(), returnsNormally);
@@ -73,7 +73,7 @@ void main() {
         ),
       );
 
-      final spotter = spotSingle<SizedBox>(parents: [spotSingle<Center>()]);
+      final spotter = spot<SizedBox>(parents: [spot<Center>()]);
 
       expect(spotter.snapshot().discovered, isNotNull);
 
@@ -99,7 +99,7 @@ void main() {
         ),
       );
 
-      final spotter = spotSingle<SizedBox>(parents: [spotSingle<Material>()]);
+      final spotter = spot<SizedBox>(parents: [spot<Material>()]);
 
       expect(spotter.snapshot().discovered, isNull);
 
@@ -125,7 +125,7 @@ void main() {
         ),
       );
 
-      final spotter = spotSingle<Material>(parents: [spot<SizedBox>()]);
+      final spotter = spot<Material>(parents: [spot<SizedBox>()]);
 
       final throwsFailureWithMessage = throwsSpotErrorContaining(
         ["Could not find SizedBox > Material in widget tree"],
@@ -155,9 +155,9 @@ void main() {
         ),
       );
 
-      final selector = spotSingle<Center>(
-        children: [spotSingle<SizedBox>()],
-        parents: [spotSingle<Material>()], // <-- does not exist
+      final selector = spot<Center>(
+        children: [spot<SizedBox>()],
+        parents: [spot<Material>()], // <-- does not exist
       );
 
       expect(selector.snapshot().discovered, isNull);
@@ -166,7 +166,8 @@ void main() {
         "Could not find Material > Center with children: ['SizedBox'] in widget tree, expected",
         RegExp(r"(?:exactly|at most|at least) \d+"),
         RegExp(
-            r"A less specific search 'Center with children: \['SizedBox'\]' discovered \d+ matches"),
+          r"A less specific search 'Center with children: \['SizedBox'\]' discovered \d+ matches",
+        ),
         "Possible match #1:\nCenter(alignment: Alignment.center",
       ]);
 
@@ -194,7 +195,7 @@ void main() {
         ),
       );
 
-      final spotter = spotSingle<SizedBox>(children: [spotSingle<Center>()]);
+      final spotter = spot<SizedBox>(children: [spot<Center>()]);
 
       expect(spotter.snapshot().discovered, isNotNull);
 
@@ -220,7 +221,7 @@ void main() {
         ),
       );
 
-      final spotter = spotSingle<SizedBox>(children: [spotSingle<Material>()]);
+      final spotter = spot<SizedBox>(children: [spot<Material>()]);
 
       expect(spotter.snapshot().discovered, isNull);
 
@@ -254,7 +255,7 @@ void main() {
         ),
       );
       expect(
-        () => spot<Text>(parents: [spotSingle<Row>()]).existsAtLeastNTimes(2),
+        () => spot<Text>(parents: [spot<Row>()]).existsAtLeastNTimes(2),
         throwsSpotErrorContaining(
           [
             "Found 1 elements matching Row > Text in widget tree, expected at least 2",

--- a/test/spot/existence_comparison_test.dart
+++ b/test/spot/existence_comparison_test.dart
@@ -128,7 +128,7 @@ void main() {
       final spotter = spotSingle<Material>(parents: [spot<SizedBox>()]);
 
       final throwsFailureWithMessage = throwsSpotErrorContaining(
-        ["Could not find 'Material with parents: ['SizedBox']' in widget tree"],
+        ["Could not find SizedBox > Material in widget tree"],
       );
 
       expect(spotter.snapshot().discovered, isNull);
@@ -163,7 +163,10 @@ void main() {
       expect(selector.snapshot().discovered, isNull);
 
       final throwsFailureWithMessage = throwsSpotErrorContaining([
-        "but found 1 matches when searching for 'Center",
+        "Could not find Material > Center with children: ['SizedBox'] in widget tree, expected",
+        RegExp(r"(?:exactly|at most|at least) \d+"),
+        RegExp(
+            r"A less specific search 'Center with children: \['SizedBox'\]' discovered \d+ matches"),
         "Possible match #1:\nCenter(alignment: Alignment.center",
       ]);
 
@@ -254,8 +257,9 @@ void main() {
         () => spot<Text>(parents: [spotSingle<Row>()]).existsAtLeastNTimes(2),
         throwsSpotErrorContaining(
           [
-            "Could not find at least 2 matches for Row > Text in widget tree, but found 3 matches when searching for 'Text'",
-            "Please check the 3 matches for Text and adjust the constraints of the selector 'Text with parents: ['Row']' accordingly",
+            "Found 1 elements matching Row > Text in widget tree, expected at least 2",
+            "A less specific search 'Text' discovered 3 matches!",
+            "Maybe you have to adjust your WidgetSelector ('Text with parents: ['Row']') to cover those missing elements.",
             'Possible match #1:\nText("a"',
             'Possible match #2:\nText("b"',
             'Possible match #3:\nText("c"',
@@ -281,17 +285,16 @@ void main() {
           ),
         ),
       );
-
       expect(
         () => spot<Text>()
             .whereText((text) => text.startsWith('a'))
             .existsExactlyNTimes(3),
         throwsSpotErrorContaining([
-          "Found 4 elements matching 'Text with prop \"data\" starts with 'a'' in widget tree, expected at most 3",
-          'Text("aa")',
-          'Text("ab")',
-          'Text("ac")',
-          'Text("ad")',
+          'Found 4 elements matching Text with prop "data" starts with \'a\' in widget tree, expected exactly 3',
+          'Text("aa"',
+          'Text("ab"',
+          'Text("ac"',
+          'Text("ad"',
         ]),
       );
     });

--- a/test/spot/existence_comparison_test.dart
+++ b/test/spot/existence_comparison_test.dart
@@ -101,7 +101,7 @@ void main() {
 
       final spotter = spot<SizedBox>(parents: [spot<Material>()]);
 
-      expect(spotter.snapshot().discovered, isNull);
+      expect(spotter.snapshot().discovered, isEmpty);
 
       expect(() => spotter.doesNotExist(), returnsNormally);
       expect(() => spotter.existsOnce(), throwsTestFailure);
@@ -131,7 +131,7 @@ void main() {
         ["Could not find SizedBox > Material in widget tree"],
       );
 
-      expect(spotter.snapshot().discovered, isNull);
+      expect(spotter.snapshot().discovered, isEmpty);
 
       expect(() => spotter.doesNotExist(), returnsNormally);
       expect(() => spotter.existsOnce(), throwsFailureWithMessage);
@@ -160,13 +160,13 @@ void main() {
         parents: [spot<Material>()], // <-- does not exist
       );
 
-      expect(selector.snapshot().discovered, isNull);
+      expect(selector.snapshot().discovered, isEmpty);
 
       final throwsFailureWithMessage = throwsSpotErrorContaining([
-        "Could not find Material > Center with children: ['SizedBox'] in widget tree, expected",
+        "Could not find Material > Center with children: [SizedBox] in widget tree, expected",
         RegExp(r"(?:exactly|at most|at least) \d+"),
         RegExp(
-          r"A less specific search 'Center with children: \['SizedBox'\]' discovered \d+ matches",
+          r"A less specific search \(Center with children: \[SizedBox\]\) discovered \d+ matches",
         ),
         "Possible match #1:\nCenter(alignment: Alignment.center",
       ]);
@@ -223,7 +223,7 @@ void main() {
 
       final spotter = spot<SizedBox>(children: [spot<Material>()]);
 
-      expect(spotter.snapshot().discovered, isNull);
+      expect(spotter.snapshot().discovered, isEmpty);
 
       expect(() => spotter.doesNotExist(), returnsNormally);
       expect(() => spotter.existsOnce(), throwsTestFailure);
@@ -259,8 +259,8 @@ void main() {
         throwsSpotErrorContaining(
           [
             "Found 1 elements matching Row > Text in widget tree, expected at least 2",
-            "A less specific search 'Text' discovered 3 matches!",
-            "Maybe you have to adjust your WidgetSelector ('Text with parents: ['Row']') to cover those missing elements.",
+            "A less specific search (Text) discovered 3 matches!",
+            "Maybe you have to adjust your WidgetSelector (Text with parents: [Row]) to cover those missing elements.",
             'Possible match #1:\nText("a"',
             'Possible match #2:\nText("b"',
             'Possible match #3:\nText("c"',

--- a/test/spot/exists_once_test.dart
+++ b/test/spot/exists_once_test.dart
@@ -172,8 +172,8 @@ void main() {
         .existsOnce()
         .hasText('Hello');
 
-    final textSpot = spot<Wrap>()
-        .spot<Text>(parents: [spot<GestureDetector>()]);
+    final textSpot =
+        spot<Wrap>().spot<Text>(parents: [spot<GestureDetector>()]);
     textSpot.existsOnce().hasText('Hello');
 
     spot<Text>(parents: [spot<Wrap>()])
@@ -182,11 +182,7 @@ void main() {
         .hasText('Hello');
     selector.existsOnce().hasText('Hello');
 
-    spot<Wrap>()
-        .spot<Text>()
-        .withMaxLines(1)
-        .existsOnce()
-        .hasText('World');
+    spot<Wrap>().spot<Text>().withMaxLines(1).existsOnce().hasText('World');
   });
 
   testWidgets('narrow down scope', (tester) async {

--- a/test/spot/exists_once_test.dart
+++ b/test/spot/exists_once_test.dart
@@ -82,7 +82,7 @@ void main() {
       throwsSpotErrorContaining(
         [
           'Found 2 elements',
-          'expected only one\nWrap(',
+          'expected at most 1\nWrap(',
           'Text("World"',
           'Text("Hello"',
         ],
@@ -95,7 +95,7 @@ void main() {
         [
           "parents: ['Wrap']",
           'Found 2 elements',
-          'expected only one\nWrap(',
+          'expected at most 1\nWrap(',
           'Text("World"',
           'Text("Hello"',
         ],

--- a/test/spot/exists_once_test.dart
+++ b/test/spot/exists_once_test.dart
@@ -82,7 +82,8 @@ void main() {
       throwsSpotErrorContaining(
         [
           'Found 2 elements',
-          'expected at most 1\nWrap(',
+          'expected at most 1',
+          '\nWrap(', // at the beginning of the line, common ancestor
           'Text("World"',
           'Text("Hello"',
         ],
@@ -95,7 +96,8 @@ void main() {
         [
           "parents: ['Wrap']",
           'Found 2 elements',
-          'expected at most 1\nWrap(',
+          'expected at most 1',
+          '\nWrap(', // at the beginning of the line, common ancestor
           'Text("World"',
           'Text("Hello"',
         ],

--- a/test/spot/exists_once_test.dart
+++ b/test/spot/exists_once_test.dart
@@ -82,7 +82,7 @@ void main() {
       throwsSpotErrorContaining(
         [
           'Found 2 elements',
-          'expected at most 1',
+          'expected exactly 1',
           '\nWrap(', // at the beginning of the line, common ancestor
           'Text("World"',
           'Text("Hello"',
@@ -91,12 +91,25 @@ void main() {
       ),
     );
     expect(
-      () => spotSingle<Text>(parents: [spotSingle<Wrap>()]).existsOnce(),
+      () => spot<Text>().amount(1).existsOnce(),
       throwsSpotErrorContaining(
         [
-          "parents: ['Wrap']",
           'Found 2 elements',
-          'expected at most 1',
+          'expected exactly 1',
+          '\nWrap(', // at the beginning of the line, common ancestor
+          'Text("World"',
+          'Text("Hello"',
+        ],
+        not: ['root'],
+      ),
+    );
+    expect(
+      () => spot<Text>(parents: [spot<Wrap>()]).amount(1).existsOnce(),
+      throwsSpotErrorContaining(
+        [
+          'Found 2 elements',
+          "Wrap > Text",
+          'expected exactly 1',
           '\nWrap(', // at the beginning of the line, common ancestor
           'Text("World"',
           'Text("Hello"',

--- a/test/spot/exists_once_test.dart
+++ b/test/spot/exists_once_test.dart
@@ -45,16 +45,16 @@ void main() {
       findsOneWidget,
     );
 
-    spotSingle<MaterialApp>().spotSingle<Center>().existsOnce();
-    spotSingle<Center>(
-      parents: [spotSingle<MaterialApp>()],
-      children: [spotSingle<Padding>()],
+    spot<MaterialApp>().spot<Center>().existsOnce();
+    spot<Center>(
+      parents: [spot<MaterialApp>()],
+      children: [spot<Padding>()],
     ).existsOnce();
-    spotSingle<Padding>().existsOnce();
-    spotSingle<Wrap>().existsOnce();
-    spotSingle<Wrap>().spot<Text>().existsAtLeastOnce();
-    spotSingle<Wrap>().spot<Text>().existsAtLeastOnce();
-    spotSingle<GestureDetector>().existsOnce();
+    spot<Padding>().existsOnce();
+    spot<Wrap>().existsOnce();
+    spot<Wrap>().spot<Text>().existsAtLeastOnce();
+    spot<Wrap>().spot<Text>().existsAtLeastOnce();
+    spot<GestureDetector>().existsOnce();
   });
 
   testWidgets('existsOnce() fails when multiple widgets exist', (tester) async {
@@ -78,7 +78,7 @@ void main() {
       ),
     );
     expect(
-      () => spotSingle<Text>().existsOnce(),
+      () => spot<Text>().existsOnce(),
       throwsSpotErrorContaining(
         [
           'Found 2 elements',
@@ -144,46 +144,46 @@ void main() {
         ),
       ),
     );
-    final appBar = spotSingle<AppBar>();
-    appBar.spotSingle<Text>().existsOnce().hasText('App Title').hasMaxLines(2);
+    final appBar = spot<AppBar>();
+    appBar.spot<Text>().existsOnce().hasText('App Title').hasMaxLines(2);
 
     // Error message only show that it could not be found
-    spotSingle<Wrap>().withDirection(Axis.horizontal).withDiagnosticProp<Axis>(
+    spot<Wrap>().withDirection(Axis.horizontal).withDiagnosticProp<Axis>(
       'direction',
       (Subject<Axis> it) {
         it.equals(Axis.horizontal);
       },
     ).existsAtLeastOnce();
 
-    spotSingle<Wrap>().withDirection(Axis.horizontal).existsAtLeastOnce();
+    spot<Wrap>().withDirection(Axis.horizontal).existsAtLeastOnce();
 
     // Error message can show the actual value of the direction
     spot<Wrap>()
         .existsAtLeastOnce()
         .any((wrap) => wrap.hasDirection(Axis.horizontal));
-    spotSingle<Wrap>().existsOnce().hasDirection(Axis.horizontal);
+    spot<Wrap>().existsOnce().hasDirection(Axis.horizontal);
 
     final WidgetSelector<Text> selector =
-        spotSingle<Wrap>().spotSingle<Text>().withMaxLines(2);
+        spot<Wrap>().spot<Text>().withMaxLines(2);
     selector.existsOnce().hasText('Hello');
 
-    spotSingle<Wrap>()
-        .spotSingle<Text>(parents: [spotSingle<GestureDetector>()])
+    spot<Wrap>()
+        .spot<Text>(parents: [spot<GestureDetector>()])
         .existsOnce()
         .hasText('Hello');
 
-    final textSpot = spotSingle<Wrap>()
-        .spotSingle<Text>(parents: [spotSingle<GestureDetector>()]);
+    final textSpot = spot<Wrap>()
+        .spot<Text>(parents: [spot<GestureDetector>()]);
     textSpot.existsOnce().hasText('Hello');
 
-    spotSingle<Text>(parents: [spotSingle<Wrap>()])
+    spot<Text>(parents: [spot<Wrap>()])
         .withMaxLines(2)
         .existsOnce()
         .hasText('Hello');
     selector.existsOnce().hasText('Hello');
 
-    spotSingle<Wrap>()
-        .spotSingle<Text>()
+    spot<Wrap>()
+        .spot<Text>()
         .withMaxLines(1)
         .existsOnce()
         .hasText('World');
@@ -215,9 +215,9 @@ void main() {
     final textSnapshot = spot<Text>().snapshot();
     expect(textSnapshot.discoveredElements.length, 2);
 
-    final wrap = spotSingle<Wrap>()..snapshot().existsOnce();
+    final wrap = spot<Wrap>()..snapshot().existsOnce();
     // only find the single sizedBox below Wrap
-    wrap.spotSingle<SizedBox>().existsOnce();
+    wrap.spot<SizedBox>().existsOnce();
 
     final multipleSpotter = spot<Text>();
     expect(snapshot(multipleSpotter).discovered.length, 2);
@@ -227,7 +227,7 @@ void main() {
     multipleSpotter.copyWith(
       parents: [
         // only finds the single SizedBox in Wrap, not the SizedBox below Center
-        wrap.spotSingle<SizedBox>(),
+        wrap.spot<SizedBox>(),
       ],
     ).existsOnce();
   });

--- a/test/spot/negate_test.dart
+++ b/test/spot/negate_test.dart
@@ -1,0 +1,56 @@
+// ignore_for_file: unnecessary_const, prefer_const_constructors, prefer_const_literals_to_create_immutables
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+
+import '../util/assert_error.dart';
+
+void main() {
+  testWidgets('doesNotExist() checks for non-existence', (tester) async {
+    await tester.pumpWidget(MaterialApp());
+    spot<Placeholder>().doesNotExist();
+  });
+
+  testWidgets('negate child', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ListView(),
+        ),
+      ),
+    );
+    spot<Scaffold>().existsOnce();
+    spot<Scaffold>().withChild(spot<ListView>()).existsOnce();
+
+    // check that Scaffold does not have a child of type ListView
+    spot<Scaffold>().withChild(spot<ListView>().atMost(0)).doesNotExist();
+
+    // check that Scaffold does not have a child of type Placeholder
+    spot<Scaffold>().withChild(spot<Placeholder>().atMost(0)).existsOnce();
+  });
+
+  testWidgets('fail due to negate', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ListView(),
+        ),
+      ),
+    );
+
+    expect(
+      () => spot<Scaffold>().withChild(spot<ListView>().atMost(0)).existsOnce(),
+      throwsSpotErrorContaining(
+        [
+          'Could not find Scaffold with children: [ListView (amount: 0)] in widget tree, expected exactly 1',
+        ],
+      ),
+    );
+    expect(
+      () =>
+          spot<Scaffold>().withChild(spot<ListView>().atMost(0)).doesNotExist(),
+      returnsNormally,
+    );
+  });
+}

--- a/test/spot/parents_and_children_test.dart
+++ b/test/spot/parents_and_children_test.dart
@@ -152,6 +152,9 @@ void main() {
     containers.withChild(spot<Wrap>()).existsOnce();
     // Enforcing a single Wrap fails because the subtree of Container has two Wraps
     containers.withChild(spotSingle<Wrap>()).doesNotExist();
+    containers.withChild(spot<Wrap>().amount(1)).doesNotExist();
+    containers.withChild(spot<Wrap>().atLeast(1)).existsOnce();
+    containers.withChild(spot<Wrap>().atMost(1)).doesNotExist();
     // It does not throw though! The child constraints are filter and do not enforce that every Container must have a single Wrap
   });
 

--- a/test/spot/parents_and_children_test.dart
+++ b/test/spot/parents_and_children_test.dart
@@ -151,8 +151,9 @@ void main() {
 
     // child query expects one or more Wraps, which can be found
     containers.withChild(spot<Wrap>()).existsOnce();
+    // exactly two child Wraps can be found
+    containers.withChild(spot<Wrap>().amount(2)).existsOnce();
     // Enforcing a single Wrap fails because the subtree of Container has two Wraps
-    containers.withChild(spot<Wrap>()).doesNotExist();
     containers.withChild(spot<Wrap>().amount(1)).doesNotExist();
     containers.withChild(spot<Wrap>().atLeast(1)).existsOnce();
     containers.withChild(spot<Wrap>().atMost(1)).doesNotExist();
@@ -195,8 +196,7 @@ void main() {
     // TODO create a method that actually does validate the amount. evaluate()?
 
     // Check for no matches when amount does not match
-    spot<Wrap>().amount(2).existsExactlyNTimes(
-        3); // TODO does this make sense that amount(2) is ignored?
+    spot<Wrap>().amount(2).existsExactlyNTimes(3);
     spot<Wrap>().amount(3).existsExactlyNTimes(3);
     spot<Wrap>().amount(4).existsExactlyNTimes(3);
   });

--- a/test/spot/parents_and_children_test.dart
+++ b/test/spot/parents_and_children_test.dart
@@ -173,6 +173,30 @@ void main() {
     containers.withChildren([spot<Wrap>()]).existsOnce();
   });
 
+  testWidgets('withChild(a).withChild(b) == withChildren(a,b)', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Row(
+          children: [
+            Container(),
+            Container(),
+            Container(child: Wrap(children: const [Center()])),
+          ],
+        ),
+      ),
+    );
+    final withChildTwice = spot<Container>()
+        .withChild(spot<Center>())
+        .withChild(spot<Wrap>())
+      ..existsOnce();
+    final withChildren = spot<Container>()
+        .withChildren([spot<Center>(), spot<Wrap>()])
+      ..existsOnce();
+
+    expect(withChildTwice.children.length, 2);
+    expect(withChildren.children.length, 2);
+  });
+
   testWidgets('withParent', (tester) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -189,5 +213,37 @@ void main() {
     containers.existsExactlyNTimes(3);
     containers.withParent(spot<Wrap>()).existsOnce();
     containers.withParents([spot<Wrap>()]).existsOnce();
+  });
+
+  testWidgets('withParent(a).withParent(b) == withParents(a,b)',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            title: Text('Test'),
+            actions: [
+              Wrap(
+                children: [
+                  Center(
+                    child: Container(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    final withParentTwice = spot<Container>()
+        .withParent(spot<Center>())
+        .withParent(spot<Wrap>())
+      ..existsOnce();
+    final withParents = spot<Container>()
+        .withParents([spot<Center>(), spot<Wrap>()])
+      ..existsOnce();
+
+    expect(withParentTwice.parents.length, 2);
+    expect(withParents.parents.length, 2);
   });
 }

--- a/test/spot/parents_and_children_test.dart
+++ b/test/spot/parents_and_children_test.dart
@@ -5,8 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
 
-import '../util/assert_error.dart';
-
 void main() {
   testWidgets('parents can have parents too', (tester) async {
     await tester.pumpWidget(
@@ -46,9 +44,9 @@ void main() {
       ),
     );
 
-    final materialApp = spotSingle<MaterialApp>();
-    final scaffold = materialApp.spotSingle<Scaffold>();
-    final wrap = scaffold.spotSingle<Wrap>();
+    final materialApp = spot<MaterialApp>();
+    final scaffold = materialApp.spot<Scaffold>();
+    final wrap = scaffold.spot<Wrap>();
 
     // IconButton has parents with a different scope
     // and search is not limited to scope of IconButton
@@ -92,11 +90,11 @@ void main() {
       ),
     );
 
-    final materialApp = spotSingle<MaterialApp>();
-    final scaffold = materialApp.spotSingle<Scaffold>();
-    final wrap = scaffold.spotSingle<Wrap>();
+    final materialApp = spot<MaterialApp>();
+    final scaffold = materialApp.spot<Scaffold>();
+    final wrap = scaffold.spot<Wrap>();
 
-    final iconButton = wrap.spotSingle<IconButton>();
+    final iconButton = wrap.spot<IconButton>();
 
     scaffold.spot<Container>(children: [iconButton]).existsOnce();
   });
@@ -119,13 +117,13 @@ void main() {
     final wraps = spot<Wrap>();
     wraps.existsExactlyNTimes(2);
 
-    // spotSingle can be used matching only a single Wrap despite multiple Wraps being in the widget tree.
+    // spot can be used matching only a single Wrap despite multiple Wraps being in the widget tree.
     // There is only a single Wrap in the subtree of the last Container, so this test passes.
-    containers.withChild(spotSingle<Wrap>()).existsOnce();
+    containers.withChild(spot<Wrap>()).existsOnce();
 
     // The child matcher can reach outside of the subtree. MaterialApp (parent) is defined outside.
     // Still both Wraps match, but only the one in the subtree is counted
-    containers.withChild(spot<MaterialApp>().spotSingle<Wrap>()).existsOnce();
+    containers.withChild(spot<MaterialApp>().spot<Wrap>()).existsOnce();
   });
 
   testWidgets('children scope does not throw when quantity does not match',
@@ -154,7 +152,7 @@ void main() {
     // child query expects one or more Wraps, which can be found
     containers.withChild(spot<Wrap>()).existsOnce();
     // Enforcing a single Wrap fails because the subtree of Container has two Wraps
-    containers.withChild(spotSingle<Wrap>()).doesNotExist();
+    containers.withChild(spot<Wrap>()).doesNotExist();
     containers.withChild(spot<Wrap>().amount(1)).doesNotExist();
     containers.withChild(spot<Wrap>().atLeast(1)).existsOnce();
     containers.withChild(spot<Wrap>().atMost(1)).doesNotExist();
@@ -180,7 +178,7 @@ void main() {
       ),
     );
 
-    spotSingle<CupertinoApp>().doesNotExist();
+    spot<CupertinoApp>().doesNotExist();
     spot<CupertinoApp>().atMost(1).doesNotExist();
     spot<CupertinoApp>().atLeast(1).doesNotExist();
     spot<CupertinoApp>().amount(1).doesNotExist();

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -87,7 +87,7 @@ void main() {
 
     // Remove element that is captured in the snapshot
     await tester.pumpWidget(Container());
-    expect(containerSnapshot.element!.mounted, isFalse);
+    expect(containerSnapshot.discoveredElement!.mounted, isFalse);
 
     await expectLater(
       takeScreenshot(snapshot: containerSnapshot),
@@ -110,7 +110,7 @@ void main() {
         ),
       ),
     );
-    final containerElement = spot<Container>().snapshot().element;
+    final containerElement = spot<Container>().snapshot().discoveredElement;
 
     final container = await takeScreenshot(element: containerElement);
     expect(container.file.existsSync(), isTrue);
@@ -132,7 +132,7 @@ void main() {
         ),
       ),
     );
-    final containerElement = spot<Container>().snapshot().element;
+    final containerElement = spot<Container>().snapshot().discoveredElement;
 
     // Remove containerElement
     await tester.pumpWidget(Container());
@@ -166,7 +166,7 @@ void main() {
     expect(screenshot2.file.existsSync(), isTrue);
 
     final screenshot3 =
-        await spot<Container>().snapshot().element!.takeScreenshot();
+        await spot<Container>().snapshot().discoveredElement!.takeScreenshot();
     expect(screenshot3.file.existsSync(), isTrue);
   });
 

--- a/test/spot/screenshot_test.dart
+++ b/test/spot/screenshot_test.dart
@@ -41,7 +41,7 @@ void main() {
       ),
     );
 
-    final container = await takeScreenshot(selector: spotSingle<Container>());
+    final container = await takeScreenshot(selector: spot<Container>());
     expect(container.file.existsSync(), isTrue);
 
     final redPixelCoverage =
@@ -60,7 +60,7 @@ void main() {
         ),
       ),
     );
-    final containerSnapshot = spotSingle<Container>().snapshot();
+    final containerSnapshot = spot<Container>().snapshot();
 
     final container = await takeScreenshot(snapshot: containerSnapshot);
     expect(container.file.existsSync(), isTrue);
@@ -83,11 +83,11 @@ void main() {
         ),
       ),
     );
-    final containerSnapshot = spotSingle<Container>().snapshot();
+    final containerSnapshot = spot<Container>().snapshot();
 
     // Remove element that is captured in the snapshot
     await tester.pumpWidget(Container());
-    expect(containerSnapshot.element.mounted, isFalse);
+    expect(containerSnapshot.element!.mounted, isFalse);
 
     await expectLater(
       takeScreenshot(snapshot: containerSnapshot),
@@ -110,7 +110,7 @@ void main() {
         ),
       ),
     );
-    final containerElement = spotSingle<Container>().snapshot().element;
+    final containerElement = spot<Container>().snapshot().element;
 
     final container = await takeScreenshot(element: containerElement);
     expect(container.file.existsSync(), isTrue);
@@ -132,11 +132,11 @@ void main() {
         ),
       ),
     );
-    final containerElement = spotSingle<Container>().snapshot().element;
+    final containerElement = spot<Container>().snapshot().element;
 
     // Remove containerElement
     await tester.pumpWidget(Container());
-    expect(containerElement.mounted, isFalse);
+    expect(containerElement!.mounted, isFalse);
 
     await expectLater(
       takeScreenshot(element: containerElement),
@@ -159,15 +159,14 @@ void main() {
         ),
       ),
     );
-    final screenshot1 = await spotSingle<Container>().takeScreenshot();
+    final screenshot1 = await spot<Container>().takeScreenshot();
     expect(screenshot1.file.existsSync(), isTrue);
 
-    final screenshot2 =
-        await spotSingle<Container>().snapshot().takeScreenshot();
+    final screenshot2 = await spot<Container>().snapshot().takeScreenshot();
     expect(screenshot2.file.existsSync(), isTrue);
 
     final screenshot3 =
-        await spotSingle<Container>().snapshot().element.takeScreenshot();
+        await spot<Container>().snapshot().element!.takeScreenshot();
     expect(screenshot3.file.existsSync(), isTrue);
   });
 

--- a/test/spot/snapshot_test.dart
+++ b/test/spot/snapshot_test.dart
@@ -9,22 +9,19 @@ void main() {
   testWidgets('MultiWidgetSnapshot keeps reference to old Widget',
       (tester) async {
     await tester.pumpWidget(Center(child: SizedBox(height: 200)));
-    final MultiWidgetSnapshot<SizedBox> oldTree = snapshot(spot<SizedBox>());
+    final WidgetSnapshot<SizedBox> oldTree = snapshot(spot<SizedBox>());
     await tester.pumpWidget(Center(child: SizedBox(height: 100)));
-    final MultiWidgetSnapshot<SizedBox> newTree = snapshot(spot<SizedBox>());
+    final WidgetSnapshot<SizedBox> newTree = snapshot(spot<SizedBox>());
     expect(oldTree.discoveredWidgets.first.height, 200);
     expect(newTree.discoveredWidgets.first.height, 100);
   });
 
-  testWidgets('SingleWidgetSnapshot keeps reference to old Widget',
-      (tester) async {
+  testWidgets('WidgetSnapshot keeps reference to old Widget', (tester) async {
     await tester.pumpWidget(Center(child: SizedBox(height: 200)));
-    final SingleWidgetSnapshot<SizedBox> oldTree =
-        snapshot(spot<SizedBox>()).single;
+    final WidgetSnapshot<SizedBox> oldTree = snapshot(spot<SizedBox>());
     await tester.pumpWidget(Center(child: SizedBox(height: 100)));
-    final SingleWidgetSnapshot<SizedBox> newTree =
-        snapshot(spot<SizedBox>()).single;
-    expect(oldTree.widget.height, 200);
-    expect(newTree.widget.height, 100);
+    final WidgetSnapshot<SizedBox> newTree = snapshot(spot<SizedBox>());
+    expect(oldTree.widget!.height, 200);
+    expect(newTree.widget!.height, 100);
   });
 }

--- a/test/spot/snapshot_test.dart
+++ b/test/spot/snapshot_test.dart
@@ -21,7 +21,7 @@ void main() {
     final WidgetSnapshot<SizedBox> oldTree = snapshot(spot<SizedBox>());
     await tester.pumpWidget(Center(child: SizedBox(height: 100)));
     final WidgetSnapshot<SizedBox> newTree = snapshot(spot<SizedBox>());
-    expect(oldTree.widget!.height, 200);
-    expect(newTree.widget!.height, 100);
+    expect(oldTree.discoveredWidget!.height, 200);
+    expect(newTree.discoveredWidget!.height, 100);
   });
 }

--- a/test/spot/spot_single_test.dart
+++ b/test/spot/spot_single_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: avoid_unnecessary_containers, prefer_const_constructors, prefer_const_literals_to_create_immutables
+// ignore_for_file: avoid_unnecessary_containers, prefer_const_constructors, prefer_const_literals_to_create_immutables, deprecated_member_use_from_same_package
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/spot/spot_single_test.dart
+++ b/test/spot/spot_single_test.dart
@@ -38,7 +38,7 @@ void main() {
       expect(
         () => spotSingle<Text>(parents: [spotSingle<Container>()]).existsOnce(),
         throwsSpotErrorContaining([
-          "Found 3 elements matching 'Container' in widget tree, expected only one",
+          "Found 3 elements matching 'Container' in widget tree, expected at most 1",
         ]),
       );
     });
@@ -67,7 +67,7 @@ void main() {
       expect(
         () => appBar.spotSingle<Text>().existsOnce(),
         throwsSpotErrorContaining([
-          "Found 2 elements matching 'AppBar' in widget tree, expected only one",
+          "Found 2 elements matching 'AppBar' in widget tree, expected at most 1",
         ]),
       );
     });

--- a/test/spot/spot_single_test.dart
+++ b/test/spot/spot_single_test.dart
@@ -38,7 +38,7 @@ void main() {
       expect(
         () => spotSingle<Text>(parents: [spotSingle<Container>()]).existsOnce(),
         throwsSpotErrorContaining([
-          "Found 3 elements matching 'Container' in widget tree, expected at most 1",
+          "Found 3 elements matching Container in widget tree, expected at most 1",
         ]),
       );
     });
@@ -63,11 +63,10 @@ void main() {
       );
 
       final appBar = spotSingle<AppBar>();
-
       expect(
         () => appBar.spotSingle<Text>().existsOnce(),
         throwsSpotErrorContaining([
-          "Found 2 elements matching 'AppBar' in widget tree, expected at most 1",
+          "Found 2 elements matching AppBar in widget tree, expected at most 1",
         ]),
       );
     });

--- a/test/spot/spotters_test.dart
+++ b/test/spot/spotters_test.dart
@@ -7,17 +7,25 @@ import 'package:spot/spot.dart';
 void main() {
   test('top level spotters match chained spotters', () {
     spot<Center>().spot<Center>();
-    spotSingle<Center>().spotSingle<Center>();
-    spot<Center>().spot<Center>();
-    spotSingleText('hello').spotSingleText('hello');
-    spotTexts('hello').spotTexts('hello');
+    spotSingle<Center>().spotSingle<Center>(); // deprecated
+
     spotText('hello').spotText('hello');
-    spotSingleIcon(Icons.add).spotSingleIcon(Icons.add);
-    spotIcons(Icons.add).spotIcons(Icons.add);
-    spotSingleWidget(_anyWidget).spotSingleWidget(_anyWidget);
-    spotWidgets(_anyWidget).spotWidgets(_anyWidget);
+    spotTexts('hello').spotTexts('hello'); // deprecated
+    spotSingleText('hello').spotSingleText('hello'); // deprecated
+
+    spotIcon(Icons.add).spotIcon(Icons.add);
+    spotIcons(Icons.add).spotIcons(Icons.add); // deprecated
+    spotSingleIcon(Icons.add).spotSingleIcon(Icons.add); // deprecated
+
+    spotWidget(_anyWidget).spotWidget(_anyWidget);
+    spotWidgets(_anyWidget).spotWidgets(_anyWidget); // deprecated
+    spotSingleWidget(_anyWidget).spotSingleWidget(_anyWidget); // deprecated
+
     spotElement(_anyElement).spotElement(_anyElement);
-    spotSingleKey(_key).spotSingleKey(_key);
+
+    spotKey(_key).spotKey(_key);
+    spotKeys(_key).spotKeys(_key); // deprecated
+    spotSingleKey(_key).spotSingleKey(_key); // deprecated
   });
 }
 

--- a/test/util/assert_error.dart
+++ b/test/util/assert_error.dart
@@ -1,15 +1,15 @@
 import 'package:flutter_test/flutter_test.dart';
 
 Matcher throwsSpotErrorContaining(
-  List<String> errorMessageParts, {
-  List<String> not = const [],
+  List<Pattern> errorMessageParts, {
+  List<Pattern> not = const [],
 }) {
   return throwsErrorContaining<TestFailure>(errorMessageParts);
 }
 
 Matcher throwsErrorContaining<E>(
-  List<String> errorMessageParts, {
-  List<String> not = const [],
+  List<Pattern> errorMessageParts, {
+  List<Pattern> not = const [],
 }) {
   final List<TypeMatcher<E>> failures = [];
   for (final part in errorMessageParts) {

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -113,7 +113,7 @@ void main() {
           await tester.pumpWidget(tree.value);
           final foundSnapshot = spotText('foo').snapshot();
           check(foundSnapshot.discovered).length.equals(1);
-          check(foundSnapshot.single.discovered).isA<WidgetTreeNode>();
+          check(foundSnapshot.single.discovered).isA<List<WidgetTreeNode>>();
           check(foundSnapshot.single.discoveredElement).isA<Element>();
           check(foundSnapshot.single.discoveredWidget).isA<AnyText>();
           check(foundSnapshot.single.element).isA<Element>();

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -19,8 +19,8 @@ void main() {
         controller: TextEditingController(text: 'foo'),
         focusNode: FocusNode(),
         maxLines: null,
-        style: testTextStyle,
         // not inherited from DefaultTextStyle
+        style: testTextStyle,
         cursorColor: Colors.black,
         backgroundCursorColor: Colors.black,
       ),
@@ -32,7 +32,8 @@ void main() {
       RichText(
         text: TextSpan(
           text: 'foo',
-          style: testTextStyle, // not inherited from DefaultTextStyle
+          // not inherited from DefaultTextStyle
+          style: testTextStyle,
         ),
       ),
     ],

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -204,6 +204,20 @@ void main() {
     });
   });
 
+  testWidgets('spotText finds multiple text', (tester) async {
+    await tester.pumpWidget(
+      _stage(
+        children: [
+          Text('a'),
+          Text('b'),
+          Text('a'),
+        ],
+      ),
+    );
+
+    spotText('a').existsExactlyNTimes(2);
+  });
+
   group('spotTextWhere', () {
     for (final tree in trees.entries) {
       final widgetType = tree.key;

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -47,80 +47,84 @@ void main() {
     for (final tree in trees.entries) {
       final widgetType = tree.key;
 
-      testWidgets('$widgetType finds', (tester) async {
-        await tester.pumpWidget(tree.value);
+      group(widgetType, () {
+        testWidgets('$widgetType finds', (tester) async {
+          await tester.pumpWidget(tree.value);
 
-        spotText('foo').existsOnce();
-        spotText('foo').existsOnce().hasMaxLines(null);
-      });
+          spotText('foo').existsOnce();
+          spotText('foo').existsOnce().hasMaxLines(null);
+        });
 
-      testWidgets('$widgetType contains', (tester) async {
-        await tester.pumpWidget(tree.value);
+        testWidgets('$widgetType contains', (tester) async {
+          await tester.pumpWidget(tree.value);
 
-        spotText('oo').existsOnce();
-        spotText('oo').existsOnce().hasMaxLines(null);
-      });
+          spotText('oo').existsOnce();
+          spotText('oo').existsOnce().hasMaxLines(null);
+        });
 
-      testWidgets('$widgetType whereWidget', (tester) async {
-        await tester.pumpWidget(tree.value);
-        final checked = [];
-        spotText('foo').whereWidget(
-          (AnyText widget) {
-            checked.add(widget);
-            return widget.maxLines == 3;
-          },
-          description: 'maxlines 3',
-        ).doesNotExist();
-        // found one item, but nothing matched maxlines 3
-        expect(checked, hasLength(1));
-      });
+        testWidgets('$widgetType whereWidget', (tester) async {
+          await tester.pumpWidget(tree.value);
+          final checked = [];
+          spotText('foo').whereWidget(
+            (AnyText widget) {
+              checked.add(widget);
+              return widget.maxLines == 3;
+            },
+            description: 'maxlines 3',
+          ).doesNotExist();
+          // found one item, but nothing matched maxlines 3
+          expect(checked, hasLength(1));
+        });
 
-      testWidgets('$widgetType with filter', (tester) async {
-        await tester.pumpWidget(tree.value);
-        spotText('foo')
-            .whereMaxLines((it) => it.isNull())
-            .whereText((it) => it.equals('foo'))
-            .whereFontColor((it) => it.isNotNull())
-            .existsOnce();
-      });
+        testWidgets('$widgetType with filter', (tester) async {
+          await tester.pumpWidget(tree.value);
+          spotText('foo')
+              .whereMaxLines((it) => it.isNull())
+              .whereText((it) => it.equals('foo'))
+              .whereFontColor((it) => it.isNotNull())
+              .existsOnce();
+        });
 
-      testWidgets('$widgetType matches', (tester) async {
-        await tester.pumpWidget(tree.value);
-        spotText('foo')
-            .existsOnce()
-            .hasTextWhere((it) => it.equals('foo'))
-            .hasMaxLinesWhere((it) => it.isNull())
-            .hasFontColor(Colors.red)
-            .hasFontSize(14)
-            .hasFontStyleWhere((it) => it.isNull());
-      });
+        testWidgets('$widgetType matches', (tester) async {
+          await tester.pumpWidget(tree.value);
+          spotText('foo')
+              .existsOnce()
+              .hasTextWhere((it) => it.equals('foo'))
+              .hasMaxLinesWhere((it) => it.isNull())
+              .hasFontColor(Colors.red)
+              .hasFontSize(14)
+              .hasFontStyleWhere((it) => it.isNull());
+        });
 
-      testWidgets('$widgetType exact', (tester) async {
-        await tester.pumpWidget(tree.value);
-        spotText('foo', exact: true).existsOnce();
-        spotText('oo', exact: true).doesNotExist();
-      });
+        testWidgets('$widgetType exact', (tester) async {
+          await tester.pumpWidget(tree.value);
+          spotText('foo', exact: true).existsOnce();
+          spotText('oo', exact: true).doesNotExist();
+        });
 
-      testWidgets('$widgetType RegEx', (tester) async {
-        await tester.pumpWidget(tree.value);
+        testWidgets('$widgetType RegEx', (tester) async {
+          await tester.pumpWidget(tree.value);
 
-        spotText(RegExp('f.*o')).existsOnce();
-        spotText(RegExp('f.*o')).existsOnce().hasMaxLines(null);
-      });
+          spotText(RegExp('f.*o')).existsOnce();
+          spotText(RegExp('f.*o')).existsOnce().hasMaxLines(null);
+        });
 
-      testWidgets('snapshot', (tester) async {
-        await tester.pumpWidget(tree.value);
-        final foundSnapshot = spotText('foo').snapshot();
-        check(foundSnapshot.discovered).isA<WidgetTreeNode>();
-        check(foundSnapshot.discoveredElement).isA<Element>();
-        check(foundSnapshot.discoveredWidget).isA<AnyText>();
-        check(foundSnapshot.element).isA<Element>();
+        testWidgets('snapshot', (tester) async {
+          await tester.pumpWidget(tree.value);
+          final foundSnapshot = spotText('foo').snapshot();
+          check(foundSnapshot.discovered).length.equals(1);
+          check(foundSnapshot.single.discovered).isA<WidgetTreeNode>();
+          check(foundSnapshot.single.discoveredElement).isA<Element>();
+          check(foundSnapshot.single.discoveredWidget).isA<AnyText>();
+          check(foundSnapshot.single.element).isA<Element>();
 
-        final notFound = spotText('bar').snapshot();
-        check(notFound.discovered).isNull();
-        check(notFound.discoveredWidget).isNull();
-        check(() => notFound.element).throws<StateError>();
-        check(() => notFound.discoveredElement).throws<StateError>();
+          final notFound = spotText('bar').snapshot();
+          check(notFound.discovered).length.equals(0);
+          check(notFound.single.discovered).isNull();
+          check(notFound.single.discoveredWidget).isNull();
+          check(() => notFound.single.element).throws<StateError>();
+          check(() => notFound.single.discoveredElement).throws<StateError>();
+        });
       });
     }
 

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -112,18 +112,18 @@ void main() {
         testWidgets('snapshot', (tester) async {
           await tester.pumpWidget(tree.value);
           final foundSnapshot = spotText('foo').snapshot();
+          check(foundSnapshot.discovered).isA<List<WidgetTreeNode>>();
           check(foundSnapshot.discovered).length.equals(1);
-          check(foundSnapshot.single.discovered).isA<List<WidgetTreeNode>>();
-          check(foundSnapshot.single.discoveredElement).isA<Element>();
-          check(foundSnapshot.single.discoveredWidget).isA<AnyText>();
-          check(foundSnapshot.single.element).isA<Element>();
+          check(foundSnapshot.element).isA<Element>();
+          check(foundSnapshot.widget).isA<AnyText>();
+          check(foundSnapshot.discoveredElement).isA<Element>();
 
           final notFound = spotText('bar').snapshot();
           check(notFound.discovered).length.equals(0);
-          check(notFound.single.discovered).isNull();
-          check(notFound.single.discoveredWidget).isNull();
-          check(() => notFound.single.element).throws<StateError>();
-          check(() => notFound.single.discoveredElement).throws<StateError>();
+          check(notFound.discovered).isEmpty();
+          check(notFound.widget).isNull();
+          check(notFound.element).isNull();
+          check(notFound.discoveredElement).isNull();
         });
       });
     }

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -19,7 +19,8 @@ void main() {
         controller: TextEditingController(text: 'foo'),
         focusNode: FocusNode(),
         maxLines: null,
-        style: testTextStyle, // not inherited from DefaultTextStyle
+        style: testTextStyle,
+        // not inherited from DefaultTextStyle
         cursorColor: Colors.black,
         backgroundCursorColor: Colors.black,
       ),

--- a/test/widgets/wrap_test.dart
+++ b/test/widgets/wrap_test.dart
@@ -11,11 +11,10 @@ void main() {
     testWidgets('filter', (widgetTester) async {
       await widgetTester.pumpWidget(MaterialApp(home: Wrap()));
 
-      final verticalWrapSpot = spotSingle<Wrap>().withDirection(Axis.vertical);
+      final verticalWrapSpot = spot<Wrap>().withDirection(Axis.vertical);
       verticalWrapSpot.doesNotExist();
 
-      final horizontalWrapSpot =
-          spotSingle<Wrap>().withDirection(Axis.horizontal);
+      final horizontalWrapSpot = spot<Wrap>().withDirection(Axis.horizontal);
       horizontalWrapSpot.existsOnce();
     });
 
@@ -23,11 +22,11 @@ void main() {
       await widgetTester.pumpWidget(MaterialApp(home: Wrap()));
 
       final verticalWrapSpot =
-          spotSingle<Wrap>().whereDirection((it) => it.equals(Axis.vertical));
+          spot<Wrap>().whereDirection((it) => it.equals(Axis.vertical));
       verticalWrapSpot.doesNotExist();
 
       final horizontalWrapSpot =
-          spotSingle<Wrap>().whereDirection((it) => it.equals(Axis.horizontal));
+          spot<Wrap>().whereDirection((it) => it.equals(Axis.horizontal));
       horizontalWrapSpot.existsOnce();
     });
 


### PR DESCRIPTION
- `spotSingle<W>()` is now deprecated. Use `spot<W>()` instead, or `spot<W>().atMost(1)` to indicate that only a single widget is expected.
- `WidgetSelector` replaces `SingleWidgetSelector` and `MultiWidgetSelector`
- `WidgetSelector` now has a `quantityConstraint` property (deprecates `expectedQuantity`) that allows setting the `min` and `max` number of expected widgets.
- New: `.atIndex(n)` allows to get the widget at a specific index (when multiple are found)
- Fix: `.first()` and `.last()` now work after calling `.copyWith()`
- **Breaking** Quantity assertions like `.doesNotExist()` or `.existsOnce()` now return `WidgetMatcher`/`MultiWidgetMatcher` instead of `WidgetSnapshot`. To get the `WidgetSnapshot` use `snapshot()` instead.
- `spotText('a')` can now return multiple widgets