### PR TITLE
Fix example usage in hasEffectiveMaxLinesWhere documentation

### DIFF
--- a/lib/src/spot/effective/effective_text.dart
+++ b/lib/src/spot/effective/effective_text.dart
@@ -8,7 +8,7 @@ extension EffectiveTextMatcher on WidgetMatcher<Text> {
   ///
   /// ```dart
   /// spot<Text>().withText('foo').existsOnce()
-  /// .hasEffectiveMaxLinesWhere((it) => it.equals(1));
+  ///   .hasEffectiveMaxLinesWhere((it) => it.equals(1));
   /// ```
   WidgetMatcher<Text> hasEffectiveMaxLinesWhere(MatchProp<int> match) {
     return hasProp(

--- a/lib/src/spot/effective/effective_text.dart
+++ b/lib/src/spot/effective/effective_text.dart
@@ -4,10 +4,11 @@ import 'package:spot/src/spot/element_extensions.dart';
 import 'package:spot/src/spot/selectors.dart';
 
 extension EffectiveTextMatcher on WidgetMatcher<Text> {
-  /// Matches the [Text] widget when it has the given [maxLines]
+  /// Matches the [Text] widget when it has the given [maxLines].
   ///
   /// ```dart
-  /// spotTexts('foo').hasEffectiveMaxLinesWhere((it)=> it.equals(1));
+  /// spot<Text>().withText('foo').existsOnce()
+  /// .hasEffectiveMaxLinesWhere((it) => it.equals(1));
   /// ```
   WidgetMatcher<Text> hasEffectiveMaxLinesWhere(MatchProp<int> match) {
     return hasProp(


### PR DESCRIPTION
This pull request fixes an example usage in the ```hasEffectiveMaxLinesWhere``` method documentation.

The previous example applied it to a `WidgetSelector<Text>`in stead of a `WidgetMatcher<Text>`.