### PR TITLE
Add effective text style selectors

### DIFF
--- a/lib/src/spot/effective/effective_text.dart
+++ b/lib/src/spot/effective/effective_text.dart
@@ -82,7 +82,11 @@ extension TextStyleSubject on Subject<TextStyle> {
   }
 }
 
+/// Selectors for the [Text] widget like
+/// - [Text.maxLines]
+/// - [Text.textStyle]
 extension EffectiveTextSelector on WidgetSelector<Text> {
+  /// Selects the [Text] widget where given maxLine properties match.
   WidgetSelector<Text> withEffectiveMaxLinesMatching(MatchProp<int?> match) {
     return withProp(
       elementSelector: (subject) => subject.context.nest<int?>(
@@ -93,8 +97,33 @@ extension EffectiveTextSelector on WidgetSelector<Text> {
     );
   }
 
+  /// Selects a [Text] widget with given `maxLines`.
   WidgetSelector<Text> withEffectiveMaxLines(int? value) {
     return withEffectiveMaxLinesMatching((it) => it.equals(value));
+  }
+
+  /// Selects the [Text] widget where given [TextStyle] properties match.
+  WidgetSelector<Text> withEffectiveTextStyleMatching(
+    MatchProp<TextStyle> match,
+  ) {
+    return withProp(
+      elementSelector: (subject) => subject.context.nest<TextStyle>(
+        () => ['with "textStyle"'],
+        (Element element) => Extracted.value(_extractTextStyle(element)),
+      ),
+      match: match,
+    );
+  }
+
+  /// Selects a [Text] widget with a given [TextStyle].
+  WidgetSelector<Text> withEffectiveTextStyle(TextStyle? value) {
+    return withEffectiveTextStyleMatching((it) {
+      if (value == null) {
+        it.isNull();
+      } else {
+        it.equals(value);
+      }
+    });
   }
 }
 

--- a/lib/src/spot/effective/effective_text.dart
+++ b/lib/src/spot/effective/effective_text.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/widgets.dart';
 import 'package:spot/spot.dart';
+import 'package:spot/src/checks/checks_nullability.dart';
 import 'package:spot/src/spot/element_extensions.dart';
 import 'package:spot/src/spot/selectors.dart';
 
+/// Matchers for the [Text] widget to make assertions about:
+/// - [Text.maxLines]
+/// - [Text.textStyle]
 extension EffectiveTextMatcher on WidgetMatcher<Text> {
   /// Matches the [Text] widget when it has the given [maxLines].
   ///
@@ -20,6 +24,7 @@ extension EffectiveTextMatcher on WidgetMatcher<Text> {
     );
   }
 
+  /// Matches the [Text] widget for given maxLines.
   WidgetMatcher<Text> hasEffectiveMaxLines(int? value) {
     return hasEffectiveMaxLinesWhere((it) {
       if (value == null) {
@@ -30,6 +35,7 @@ extension EffectiveTextMatcher on WidgetMatcher<Text> {
     });
   }
 
+  /// Matches the [Text] widget when it has the given [TextStyle].
   WidgetMatcher<Text> hasEffectiveTextStyleWhere(MatchProp<TextStyle> match) {
     return hasProp(
       elementSelector: (subject) => subject.context.nest<TextStyle?>(
@@ -86,7 +92,7 @@ extension TextStyleSubject on Subject<TextStyle> {
 /// - [Text.maxLines]
 /// - [Text.textStyle]
 extension EffectiveTextSelector on WidgetSelector<Text> {
-  /// Selects the [Text] widget where given maxLine properties match.
+  /// Selects the [Text] widget where given `maxLines` properties match.
   WidgetSelector<Text> withEffectiveMaxLinesMatching(MatchProp<int?> match) {
     return withProp(
       elementSelector: (subject) => subject.context.nest<int?>(

--- a/lib/src/spot/effective/effective_text.dart
+++ b/lib/src/spot/effective/effective_text.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 import 'package:spot/spot.dart';
-import 'package:spot/src/checks/checks_nullability.dart';
 import 'package:spot/src/spot/element_extensions.dart';
 import 'package:spot/src/spot/selectors.dart';
 

--- a/test/widgets/effective_text_test.dart
+++ b/test/widgets/effective_text_test.dart
@@ -254,11 +254,10 @@ void main() {
         // Select with single props
         spot<Text>().withText('Great Text').withEffectiveTextStyleMatching(
           (style) {
-            final subject = style.isNotNull();
-            subject.fontSize.equals(20);
-            subject.fontStyle.equals(FontStyle.italic);
-            subject.fontWeight.equals(FontWeight.bold);
-            subject.letterSpacing.equals(2);
+            style.fontSize.equals(20);
+            style.fontStyle.equals(FontStyle.italic);
+            style.fontWeight.equals(FontWeight.bold);
+            style.letterSpacing.equals(2);
           },
         ).existsOnce();
 

--- a/test/widgets/effective_text_test.dart
+++ b/test/widgets/effective_text_test.dart
@@ -223,5 +223,95 @@ void main() {
         ]),
       );
     });
+
+    testWidgets(
+      'Select with TextStyle',
+      (widgetTester) async {
+        final style = TextStyle(
+          fontSize: 20,
+          fontStyle: FontStyle.italic,
+          fontWeight: FontWeight.bold,
+          letterSpacing: 2,
+        );
+
+        await widgetTester.pumpWidget(
+          MaterialApp(
+            home: Column(
+              children: [
+                Text(
+                  'Great Text',
+                  style: TextStyle(fontSize: 20),
+                ),
+                DefaultTextStyle(
+                  style: style,
+                  child: Text('Great Text'),
+                ),
+              ],
+            ),
+          ),
+        );
+
+        // Select with single props
+        spot<Text>().withText('Great Text').withEffectiveTextStyleMatching(
+          (style) {
+            final subject = style.isNotNull();
+            subject.fontSize.equals(20);
+            subject.fontStyle.equals(FontStyle.italic);
+            subject.fontWeight.equals(FontWeight.bold);
+            subject.letterSpacing.equals(2);
+          },
+        ).existsOnce();
+
+        // Select with complete TextStyle
+        spot<Text>()
+            .withText('Great Text')
+            .withEffectiveTextStyle(style)
+            .existsOnce();
+      },
+    );
+
+    testWidgets('Failed selection with TextStyle shows missing values',
+        (widgetTester) async {
+      final style = TextStyle(
+        fontSize: 20,
+        fontStyle: FontStyle.italic,
+        fontWeight: FontWeight.bold,
+        letterSpacing: 2,
+      );
+
+      await widgetTester.pumpWidget(
+        MaterialApp(
+          home: DefaultTextStyle(
+            style: style,
+            child: Text('Great Text'),
+          ),
+        ),
+      );
+
+      expect(
+        () =>
+            spot<Text>().withText('Great Text').withEffectiveTextStyleMatching(
+          (style) {
+            style.fontSize.equals(20);
+            style.fontStyle.equals(FontStyle.normal);
+            style.fontWeight.equals(FontWeight.bold);
+            style.letterSpacing.equals(2);
+          },
+        ).existsOnce(),
+        throwsSpotErrorContaining([
+          'with "textStyle" that: has fontSize that: equals <20.0> has fontStyle that: equals <FontStyle.normal> has fontWeight that: equals <FontWeight.w700> has letterSpacing that: equals <2.0>',
+        ]),
+      );
+
+      expect(
+        () => spot<Text>()
+            .withText('Great Text')
+            .withEffectiveTextStyle(style.copyWith(fontStyle: FontStyle.normal))
+            .existsOnce(),
+        throwsSpotErrorContaining([
+          'with "textStyle" that: equals <TextStyle(inherit: true, size: 20.0, weight: 700, style: normal, letterSpacing: 2.0)>',
+        ]),
+      );
+    });
   });
 }


### PR DESCRIPTION
This PR adds the following text selectors:

- `WidgetSelector<Text> withEffectiveTextStyleMatching(MatchProp<TextStyle> match)`
- `WidgetSelector<Text> withEffectiveTextStyle(TextStyle? value)`