### PR TITLE
Add getDiagnosticProp()

### DIFF
--- a/lib/src/spot/diagnostic_props.dart
+++ b/lib/src/spot/diagnostic_props.dart
@@ -95,6 +95,21 @@ extension DiagnosticPropWidgetSelector<W extends Widget> on WidgetSelector<W> {
 
 /// All [DiagnosticsProperty] related matchers
 extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
+  /// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// final checked = spot<Checkbox>().existsOnce().getDiagnosticProp<bool>('value');
+  /// ```
+  T getDiagnosticProp<T>(String propName) {
+    final diagnosticsNode =
+        selector.mapElementToWidget(element).toDiagnosticsNode();
+    final DiagnosticsNode? prop = diagnosticsNode
+        .getProperties()
+        .firstOrNullWhere((e) => e.name == propName);
+    final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
+    return actual as T;
+  }
 
   /// Asserts that a widget has a specific diagnostic property.
   ///

--- a/lib/src/spot/matcher_generator.dart
+++ b/lib/src/spot/matcher_generator.dart
@@ -85,6 +85,14 @@ extension ${widgetType}Selector on WidgetSelector<$widgetType> {
 ''',
     );
 
+    final getterSb = StringBuffer();
+    getterSb.writeln(
+      '''
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension ${widgetType}Getter on WidgetMatcher<$widgetType> {
+''',
+    );
+
     final distinctProps =
         [...widgetProps, ...elementProps].distinctBy((it) => it.name).toList();
     for (final DiagnosticsNode prop in distinctProps) {
@@ -161,6 +169,13 @@ extension ${widgetType}Selector on WidgetSelector<$widgetType> {
       final String valueExample = _getExampleValue(node: prop);
       final String matcherExample = _getExampleValue(node: prop, matcher: true);
 
+      getterSb.writeln('''
+  /// Returns the $humanPropName of the matched [$widgetType] via [Widget.toDiagnosticsNode]
+  $propType get${humanPropName.capitalize()}() {
+    return getDiagnosticProp<$propType>('$diagnosticPropName');
+  }
+''');
+
       matcherSb.writeln('''
   /// Expects that $humanPropName of [$widgetType] matches the condition in [match].
   ///
@@ -212,6 +227,7 @@ extension ${widgetType}Selector on WidgetSelector<$widgetType> {
 
     matcherSb.writeln('}');
     selectorSb.writeln('}');
+    getterSb.writeln('}');
 
     if (addedMethods == false) {
       // nothing added, don't generate the file at all
@@ -245,7 +261,10 @@ ${imports ?? "import 'package:flutter/widgets.dart';"}
 import 'package:spot/spot.dart';
 
 $selectorSb
+
 $matcherSb
+
+$getterSb
     ''';
   }
 }

--- a/lib/src/widgets/align.g.dart
+++ b/lib/src/widgets/align.g.dart
@@ -197,3 +197,26 @@ extension AlignMatcher on WidgetMatcher<Align> {
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension AlignGetter on WidgetMatcher<Align> {
+  /// Returns the alignment of the matched [Align] via [Widget.toDiagnosticsNode]
+  AlignmentGeometry getAlignment() {
+    return getDiagnosticProp<AlignmentGeometry>('alignment');
+  }
+
+  /// Returns the widthFactor of the matched [Align] via [Widget.toDiagnosticsNode]
+  double getWidthFactor() {
+    return getDiagnosticProp<double>('widthFactor');
+  }
+
+  /// Returns the heightFactor of the matched [Align] via [Widget.toDiagnosticsNode]
+  double getHeightFactor() {
+    return getDiagnosticProp<double>('heightFactor');
+  }
+
+  /// Returns the renderObject of the matched [Align] via [Widget.toDiagnosticsNode]
+  RenderPositionedBox getRenderObject() {
+    return getDiagnosticProp<RenderPositionedBox>('renderObject');
+  }
+}

--- a/lib/src/widgets/anytext.g.dart
+++ b/lib/src/widgets/anytext.g.dart
@@ -1170,3 +1170,137 @@ extension AnyTextMatcher on WidgetMatcher<AnyText> {
         'font_size', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension AnyTextGetter on WidgetMatcher<AnyText> {
+  /// Returns the text of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  String getText() {
+    return getDiagnosticProp<String>('text');
+  }
+
+  /// Returns the textDirection of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the textAlign of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  TextAlign getTextAlign() {
+    return getDiagnosticProp<TextAlign>('textAlign');
+  }
+
+  /// Returns the selectionColor of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  Color getSelectionColor() {
+    return getDiagnosticProp<Color>('selectionColor');
+  }
+
+  /// Returns the softWrap of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  bool getSoftWrap() {
+    return getDiagnosticProp<bool>('softWrap');
+  }
+
+  /// Returns the overflow of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  TextOverflow getOverflow() {
+    return getDiagnosticProp<TextOverflow>('overflow');
+  }
+
+  /// Returns the maxLines of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  int getMaxLines() {
+    return getDiagnosticProp<int>('maxLines');
+  }
+
+  /// Returns the locale of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  Locale getLocale() {
+    return getDiagnosticProp<Locale>('locale');
+  }
+
+  /// Returns the minLines of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  int getMinLines() {
+    return getDiagnosticProp<int>('minLines');
+  }
+
+  /// Returns the fontInherit of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  bool getFontInherit() {
+    return getDiagnosticProp<bool>('font_inherit');
+  }
+
+  /// Returns the fontColor of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  Color getFontColor() {
+    return getDiagnosticProp<Color>('font_color');
+  }
+
+  /// Returns the fontBackgroundColor of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  Color getFontBackgroundColor() {
+    return getDiagnosticProp<Color>('font_backgroundColor');
+  }
+
+  /// Returns the fontFamily of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  String getFontFamily() {
+    return getDiagnosticProp<String>('font_family');
+  }
+
+  /// Returns the fontFamilyFallback of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  String getFontFamilyFallback() {
+    return getDiagnosticProp<String>('font_familyFallback');
+  }
+
+  /// Returns the fontWeight of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  FontWeight getFontWeight() {
+    return getDiagnosticProp<FontWeight>('font_weight');
+  }
+
+  /// Returns the fontStyle of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  FontStyle getFontStyle() {
+    return getDiagnosticProp<FontStyle>('font_style');
+  }
+
+  /// Returns the fontLetterSpacing of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  double getFontLetterSpacing() {
+    return getDiagnosticProp<double>('font_letterSpacing');
+  }
+
+  /// Returns the fontWordSpacing of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  double getFontWordSpacing() {
+    return getDiagnosticProp<double>('font_wordSpacing');
+  }
+
+  /// Returns the fontBaseline of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  TextBaseline getFontBaseline() {
+    return getDiagnosticProp<TextBaseline>('font_baseline');
+  }
+
+  /// Returns the fontHeight of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  double getFontHeight() {
+    return getDiagnosticProp<double>('font_height');
+  }
+
+  /// Returns the fontLeadingDistribution of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  TextLeadingDistribution getFontLeadingDistribution() {
+    return getDiagnosticProp<TextLeadingDistribution>(
+        'font_leadingDistribution');
+  }
+
+  /// Returns the fontLocale of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  Locale getFontLocale() {
+    return getDiagnosticProp<Locale>('font_locale');
+  }
+
+  /// Returns the fontForeground of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  Paint getFontForeground() {
+    return getDiagnosticProp<Paint>('font_foreground');
+  }
+
+  /// Returns the fontBackground of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  Paint getFontBackground() {
+    return getDiagnosticProp<Paint>('font_background');
+  }
+
+  /// Returns the inherit of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  bool getInherit() {
+    return getDiagnosticProp<bool>('inherit');
+  }
+
+  /// Returns the fontSize of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  double getFontSize() {
+    return getDiagnosticProp<double>('font_size');
+  }
+}

--- a/lib/src/widgets/circularprogressindicator.g.dart
+++ b/lib/src/widgets/circularprogressindicator.g.dart
@@ -66,3 +66,12 @@ extension CircularProgressIndicatorMatcher
         'value', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension CircularProgressIndicatorGetter
+    on WidgetMatcher<CircularProgressIndicator> {
+  /// Returns the value of the matched [CircularProgressIndicator] via [Widget.toDiagnosticsNode]
+  double getValue() {
+    return getDiagnosticProp<double>('value');
+  }
+}

--- a/lib/src/widgets/column.g.dart
+++ b/lib/src/widgets/column.g.dart
@@ -377,3 +377,46 @@ extension ColumnMatcher on WidgetMatcher<Column> {
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension ColumnGetter on WidgetMatcher<Column> {
+  /// Returns the direction of the matched [Column] via [Widget.toDiagnosticsNode]
+  Axis getDirection() {
+    return getDiagnosticProp<Axis>('direction');
+  }
+
+  /// Returns the mainAxisAlignment of the matched [Column] via [Widget.toDiagnosticsNode]
+  MainAxisAlignment getMainAxisAlignment() {
+    return getDiagnosticProp<MainAxisAlignment>('mainAxisAlignment');
+  }
+
+  /// Returns the mainAxisSize of the matched [Column] via [Widget.toDiagnosticsNode]
+  MainAxisSize getMainAxisSize() {
+    return getDiagnosticProp<MainAxisSize>('mainAxisSize');
+  }
+
+  /// Returns the crossAxisAlignment of the matched [Column] via [Widget.toDiagnosticsNode]
+  CrossAxisAlignment getCrossAxisAlignment() {
+    return getDiagnosticProp<CrossAxisAlignment>('crossAxisAlignment');
+  }
+
+  /// Returns the textDirection of the matched [Column] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the verticalDirection of the matched [Column] via [Widget.toDiagnosticsNode]
+  VerticalDirection getVerticalDirection() {
+    return getDiagnosticProp<VerticalDirection>('verticalDirection');
+  }
+
+  /// Returns the textBaseline of the matched [Column] via [Widget.toDiagnosticsNode]
+  TextBaseline getTextBaseline() {
+    return getDiagnosticProp<TextBaseline>('textBaseline');
+  }
+
+  /// Returns the renderObject of the matched [Column] via [Widget.toDiagnosticsNode]
+  RenderFlex getRenderObject() {
+    return getDiagnosticProp<RenderFlex>('renderObject');
+  }
+}

--- a/lib/src/widgets/constrainedbox.g.dart
+++ b/lib/src/widgets/constrainedbox.g.dart
@@ -111,3 +111,16 @@ extension ConstrainedBoxMatcher on WidgetMatcher<ConstrainedBox> {
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension ConstrainedBoxGetter on WidgetMatcher<ConstrainedBox> {
+  /// Returns the constraints of the matched [ConstrainedBox] via [Widget.toDiagnosticsNode]
+  BoxConstraints getConstraints() {
+    return getDiagnosticProp<BoxConstraints>('constraints');
+  }
+
+  /// Returns the renderObject of the matched [ConstrainedBox] via [Widget.toDiagnosticsNode]
+  RenderConstrainedBox getRenderObject() {
+    return getDiagnosticProp<RenderConstrainedBox>('renderObject');
+  }
+}

--- a/lib/src/widgets/container.g.dart
+++ b/lib/src/widgets/container.g.dart
@@ -373,3 +373,46 @@ extension ContainerMatcher on WidgetMatcher<Container> {
         'transform', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension ContainerGetter on WidgetMatcher<Container> {
+  /// Returns the alignment of the matched [Container] via [Widget.toDiagnosticsNode]
+  AlignmentGeometry getAlignment() {
+    return getDiagnosticProp<AlignmentGeometry>('alignment');
+  }
+
+  /// Returns the padding of the matched [Container] via [Widget.toDiagnosticsNode]
+  EdgeInsetsGeometry getPadding() {
+    return getDiagnosticProp<EdgeInsetsGeometry>('padding');
+  }
+
+  /// Returns the clipBehavior of the matched [Container] via [Widget.toDiagnosticsNode]
+  Clip getClipBehavior() {
+    return getDiagnosticProp<Clip>('clipBehavior');
+  }
+
+  /// Returns the background of the matched [Container] via [Widget.toDiagnosticsNode]
+  Decoration getBackground() {
+    return getDiagnosticProp<Decoration>('bg');
+  }
+
+  /// Returns the foreground of the matched [Container] via [Widget.toDiagnosticsNode]
+  Decoration getForeground() {
+    return getDiagnosticProp<Decoration>('fg');
+  }
+
+  /// Returns the constraints of the matched [Container] via [Widget.toDiagnosticsNode]
+  BoxConstraints getConstraints() {
+    return getDiagnosticProp<BoxConstraints>('constraints');
+  }
+
+  /// Returns the margin of the matched [Container] via [Widget.toDiagnosticsNode]
+  EdgeInsetsGeometry getMargin() {
+    return getDiagnosticProp<EdgeInsetsGeometry>('margin');
+  }
+
+  /// Returns the transform of the matched [Container] via [Widget.toDiagnosticsNode]
+  Matrix4 getTransform() {
+    return getDiagnosticProp<Matrix4>('transform');
+  }
+}

--- a/lib/src/widgets/editabletext.g.dart
+++ b/lib/src/widgets/editabletext.g.dart
@@ -1907,3 +1907,217 @@ extension EditableTextMatcher on WidgetMatcher<EditableText> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension EditableTextGetter on WidgetMatcher<EditableText> {
+  /// Returns the controller of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  TextEditingController getController() {
+    return getDiagnosticProp<TextEditingController>('controller');
+  }
+
+  /// Returns the focusNode of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+
+  /// Returns the obscureText of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getObscureText() {
+    return getDiagnosticProp<bool>('obscureText');
+  }
+
+  /// Returns the readOnly of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getReadOnly() {
+    return getDiagnosticProp<bool>('readOnly');
+  }
+
+  /// Returns the autocorrect of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getAutocorrect() {
+    return getDiagnosticProp<bool>('autocorrect');
+  }
+
+  /// Returns the smartDashesType of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  SmartDashesType getSmartDashesType() {
+    return getDiagnosticProp<SmartDashesType>('smartDashesType');
+  }
+
+  /// Returns the smartQuotesType of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  SmartQuotesType getSmartQuotesType() {
+    return getDiagnosticProp<SmartQuotesType>('smartQuotesType');
+  }
+
+  /// Returns the enableSuggestions of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getEnableSuggestions() {
+    return getDiagnosticProp<bool>('enableSuggestions');
+  }
+
+  /// Returns the inherit of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getInherit() {
+    return getDiagnosticProp<bool>('inherit');
+  }
+
+  /// Returns the color of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  Color getColor() {
+    return getDiagnosticProp<Color>('color');
+  }
+
+  /// Returns the backgroundColor of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  Color getBackgroundColor() {
+    return getDiagnosticProp<Color>('backgroundColor');
+  }
+
+  /// Returns the family of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  String getFamily() {
+    return getDiagnosticProp<String>('family');
+  }
+
+  /// Returns the familyFallback of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  String getFamilyFallback() {
+    return getDiagnosticProp<String>('familyFallback');
+  }
+
+  /// Returns the size of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  double getSize() {
+    return getDiagnosticProp<double>('size');
+  }
+
+  /// Returns the weight of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  FontWeight getWeight() {
+    return getDiagnosticProp<FontWeight>('weight');
+  }
+
+  /// Returns the style of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  FontStyle getStyle() {
+    return getDiagnosticProp<FontStyle>('style');
+  }
+
+  /// Returns the letterSpacing of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  double getLetterSpacing() {
+    return getDiagnosticProp<double>('letterSpacing');
+  }
+
+  /// Returns the wordSpacing of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  double getWordSpacing() {
+    return getDiagnosticProp<double>('wordSpacing');
+  }
+
+  /// Returns the baseline of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  TextBaseline getBaseline() {
+    return getDiagnosticProp<TextBaseline>('baseline');
+  }
+
+  /// Returns the height of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  double getHeight() {
+    return getDiagnosticProp<double>('height');
+  }
+
+  /// Returns the leadingDistribution of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  TextLeadingDistribution getLeadingDistribution() {
+    return getDiagnosticProp<TextLeadingDistribution>('leadingDistribution');
+  }
+
+  /// Returns the locale of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  Locale getLocale() {
+    return getDiagnosticProp<Locale>('locale');
+  }
+
+  /// Returns the foreground of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  Paint getForeground() {
+    return getDiagnosticProp<Paint>('foreground');
+  }
+
+  /// Returns the background of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  Paint getBackground() {
+    return getDiagnosticProp<Paint>('background');
+  }
+
+  /// Returns the textAlign of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  TextAlign getTextAlign() {
+    return getDiagnosticProp<TextAlign>('textAlign');
+  }
+
+  /// Returns the textDirection of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the textScaler of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  TextScaler getTextScaler() {
+    return getDiagnosticProp<TextScaler>('textScaler');
+  }
+
+  /// Returns the maxLines of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  int getMaxLines() {
+    return getDiagnosticProp<int>('maxLines');
+  }
+
+  /// Returns the minLines of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  int getMinLines() {
+    return getDiagnosticProp<int>('minLines');
+  }
+
+  /// Returns the expands of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getExpands() {
+    return getDiagnosticProp<bool>('expands');
+  }
+
+  /// Returns the autofocus of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getAutofocus() {
+    return getDiagnosticProp<bool>('autofocus');
+  }
+
+  /// Returns the keyboardType of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  TextInputType getKeyboardType() {
+    return getDiagnosticProp<TextInputType>('keyboardType');
+  }
+
+  /// Returns the scrollController of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  ScrollController getScrollController() {
+    return getDiagnosticProp<ScrollController>('scrollController');
+  }
+
+  /// Returns the scrollPhysics of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  ScrollPhysics getScrollPhysics() {
+    return getDiagnosticProp<ScrollPhysics>('scrollPhysics');
+  }
+
+  /// Returns the autofillHints of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  Iterable<String> getAutofillHints() {
+    return getDiagnosticProp<Iterable<String>>('autofillHints');
+  }
+
+  /// Returns the textHeightBehavior of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  TextHeightBehavior getTextHeightBehavior() {
+    return getDiagnosticProp<TextHeightBehavior>('textHeightBehavior');
+  }
+
+  /// Returns the scribbleEnabled of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getScribbleEnabled() {
+    return getDiagnosticProp<bool>('scribbleEnabled');
+  }
+
+  /// Returns the enableIMEPersonalizedLearning of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getEnableIMEPersonalizedLearning() {
+    return getDiagnosticProp<bool>('enableIMEPersonalizedLearning');
+  }
+
+  /// Returns the enableInteractiveSelection of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  bool getEnableInteractiveSelection() {
+    return getDiagnosticProp<bool>('enableInteractiveSelection');
+  }
+
+  /// Returns the undoController of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  UndoHistoryController getUndoController() {
+    return getDiagnosticProp<UndoHistoryController>('undoController');
+  }
+
+  /// Returns the spellCheckConfiguration of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  SpellCheckConfiguration getSpellCheckConfiguration() {
+    return getDiagnosticProp<SpellCheckConfiguration>(
+        'spellCheckConfiguration');
+  }
+
+  /// Returns the contentCommitMimeTypes of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  List<String> getContentCommitMimeTypes() {
+    return getDiagnosticProp<List<String>>('contentCommitMimeTypes');
+  }
+}

--- a/lib/src/widgets/editabletext.g.dart
+++ b/lib/src/widgets/editabletext.g.dart
@@ -620,27 +620,27 @@ extension EditableTextSelector on WidgetSelector<EditableText> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Creates a [WidgetSelector] that finds all [EditableText] where textScaler matches the condition.
+  /// Creates a [WidgetSelector] that finds all [EditableText] where textScaleFactor matches the condition.
   ///
   /// #### Example usage:
   /// ```dart
-  /// spot<EditableText>().whereTextScaler((it) => it.equals(your TextScaler value to match)).existsOnce();
+  /// spot<EditableText>().whereTextScaleFactor((it) => it.isGreaterThan(10.5)).existsOnce();
   /// ```
   @useResult
-  WidgetSelector<EditableText> whereTextScaler(MatchProp<TextScaler> match) {
-    return withDiagnosticProp<TextScaler>('textScaler', match);
+  WidgetSelector<EditableText> whereTextScaleFactor(MatchProp<double> match) {
+    return withDiagnosticProp<double>('textScaleFactor', match);
   }
 
-  /// Creates a [WidgetSelector] that finds all [EditableText] where textScaler equals (==) [value].
+  /// Creates a [WidgetSelector] that finds all [EditableText] where textScaleFactor equals (==) [value].
   ///
   /// #### Example usage:
   /// ```dart
-  /// spot<EditableText>().withTextScaler(your TextScaler value to match).existsOnce();
+  /// spot<EditableText>().withTextScaleFactor(10.5).existsOnce();
   /// ```
   @useResult
-  WidgetSelector<EditableText> withTextScaler(TextScaler? value) {
-    return withDiagnosticProp<TextScaler>(
-        'textScaler', (it) => value == null ? it.isNull() : it.equals(value));
+  WidgetSelector<EditableText> withTextScaleFactor(double? value) {
+    return withDiagnosticProp<double>('textScaleFactor',
+        (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Creates a [WidgetSelector] that finds all [EditableText] where maxLines matches the condition.
@@ -1559,25 +1559,25 @@ extension EditableTextMatcher on WidgetMatcher<EditableText> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Expects that textScaler of [EditableText] matches the condition in [match].
+  /// Expects that textScaleFactor of [EditableText] matches the condition in [match].
   ///
   /// #### Example usage:
   /// ```dart
-  /// spot<EditableText>().existsOnce().hasTextScalerWhere((it) => it.equals(your TextScaler value to match));
+  /// spot<EditableText>().existsOnce().hasTextScaleFactorWhere((it) => it.isGreaterThan(10.5));
   /// ```
-  WidgetMatcher<EditableText> hasTextScalerWhere(MatchProp<TextScaler> match) {
-    return hasDiagnosticProp<TextScaler>('textScaler', match);
+  WidgetMatcher<EditableText> hasTextScaleFactorWhere(MatchProp<double> match) {
+    return hasDiagnosticProp<double>('textScaleFactor', match);
   }
 
-  /// Expects that textScaler of [EditableText] equals (==) [value].
+  /// Expects that textScaleFactor of [EditableText] equals (==) [value].
   ///
   /// #### Example usage:
   /// ```dart
-  /// spot<EditableText>().existsOnce().hasTextScaler(your TextScaler value to match);
+  /// spot<EditableText>().existsOnce().hasTextScaleFactor(10.5);
   /// ```
-  WidgetMatcher<EditableText> hasTextScaler(TextScaler? value) {
-    return hasDiagnosticProp<TextScaler>(
-        'textScaler', (it) => value == null ? it.isNull() : it.equals(value));
+  WidgetMatcher<EditableText> hasTextScaleFactor(double? value) {
+    return hasDiagnosticProp<double>('textScaleFactor',
+        (it) => value == null ? it.isNull() : it.equals(value));
   }
 
   /// Expects that maxLines of [EditableText] matches the condition in [match].
@@ -2040,9 +2040,9 @@ extension EditableTextGetter on WidgetMatcher<EditableText> {
     return getDiagnosticProp<TextDirection>('textDirection');
   }
 
-  /// Returns the textScaler of the matched [EditableText] via [Widget.toDiagnosticsNode]
-  TextScaler getTextScaler() {
-    return getDiagnosticProp<TextScaler>('textScaler');
+  /// Returns the textScaleFactor of the matched [EditableText] via [Widget.toDiagnosticsNode]
+  double getTextScaleFactor() {
+    return getDiagnosticProp<double>('textScaleFactor');
   }
 
   /// Returns the maxLines of the matched [EditableText] via [Widget.toDiagnosticsNode]

--- a/lib/src/widgets/elevatedbutton.g.dart
+++ b/lib/src/widgets/elevatedbutton.g.dart
@@ -150,3 +150,21 @@ extension ElevatedButtonMatcher on WidgetMatcher<ElevatedButton> {
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension ElevatedButtonGetter on WidgetMatcher<ElevatedButton> {
+  /// Returns the enabled of the matched [ElevatedButton] via [Widget.toDiagnosticsNode]
+  bool getEnabled() {
+    return getDiagnosticProp<bool>('enabled');
+  }
+
+  /// Returns the style of the matched [ElevatedButton] via [Widget.toDiagnosticsNode]
+  ButtonStyle getStyle() {
+    return getDiagnosticProp<ButtonStyle>('style');
+  }
+
+  /// Returns the focusNode of the matched [ElevatedButton] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+}

--- a/lib/src/widgets/floatingactionbutton.g.dart
+++ b/lib/src/widgets/floatingactionbutton.g.dart
@@ -750,3 +750,86 @@ extension FloatingActionButtonMatcher on WidgetMatcher<FloatingActionButton> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension FloatingActionButtonGetter on WidgetMatcher<FloatingActionButton> {
+  /// Returns the tooltip of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  String getTooltip() {
+    return getDiagnosticProp<String>('tooltip');
+  }
+
+  /// Returns the foregroundColor of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  Color getForegroundColor() {
+    return getDiagnosticProp<Color>('foregroundColor');
+  }
+
+  /// Returns the backgroundColor of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  Color getBackgroundColor() {
+    return getDiagnosticProp<Color>('backgroundColor');
+  }
+
+  /// Returns the focusColor of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  Color getFocusColor() {
+    return getDiagnosticProp<Color>('focusColor');
+  }
+
+  /// Returns the hoverColor of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  Color getHoverColor() {
+    return getDiagnosticProp<Color>('hoverColor');
+  }
+
+  /// Returns the splashColor of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  Color getSplashColor() {
+    return getDiagnosticProp<Color>('splashColor');
+  }
+
+  /// Returns the heroTag of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  Object getHeroTag() {
+    return getDiagnosticProp<Object>('heroTag');
+  }
+
+  /// Returns the elevation of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  double getElevation() {
+    return getDiagnosticProp<double>('elevation');
+  }
+
+  /// Returns the focusElevation of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  double getFocusElevation() {
+    return getDiagnosticProp<double>('focusElevation');
+  }
+
+  /// Returns the hoverElevation of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  double getHoverElevation() {
+    return getDiagnosticProp<double>('hoverElevation');
+  }
+
+  /// Returns the highlightElevation of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  double getHighlightElevation() {
+    return getDiagnosticProp<double>('highlightElevation');
+  }
+
+  /// Returns the disabledElevation of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  double getDisabledElevation() {
+    return getDiagnosticProp<double>('disabledElevation');
+  }
+
+  /// Returns the shape of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  ShapeBorder getShape() {
+    return getDiagnosticProp<ShapeBorder>('shape');
+  }
+
+  /// Returns the focusNode of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+
+  /// Returns the isExtended of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  bool getIsExtended() {
+    return getDiagnosticProp<bool>('isExtended');
+  }
+
+  /// Returns the materialTapTargetSize of the matched [FloatingActionButton] via [Widget.toDiagnosticsNode]
+  MaterialTapTargetSize getMaterialTapTargetSize() {
+    return getDiagnosticProp<MaterialTapTargetSize>('materialTapTargetSize');
+  }
+}

--- a/lib/src/widgets/gridview.g.dart
+++ b/lib/src/widgets/gridview.g.dart
@@ -327,3 +327,41 @@ extension GridViewMatcher on WidgetMatcher<GridView> {
         'padding', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension GridViewGetter on WidgetMatcher<GridView> {
+  /// Returns the scrollDirection of the matched [GridView] via [Widget.toDiagnosticsNode]
+  Axis getScrollDirection() {
+    return getDiagnosticProp<Axis>('scrollDirection');
+  }
+
+  /// Returns the reverse of the matched [GridView] via [Widget.toDiagnosticsNode]
+  bool getReverse() {
+    return getDiagnosticProp<bool>('reverse');
+  }
+
+  /// Returns the controller of the matched [GridView] via [Widget.toDiagnosticsNode]
+  ScrollController getController() {
+    return getDiagnosticProp<ScrollController>('controller');
+  }
+
+  /// Returns the primary of the matched [GridView] via [Widget.toDiagnosticsNode]
+  bool getPrimary() {
+    return getDiagnosticProp<bool>('primary');
+  }
+
+  /// Returns the physics of the matched [GridView] via [Widget.toDiagnosticsNode]
+  ScrollPhysics getPhysics() {
+    return getDiagnosticProp<ScrollPhysics>('physics');
+  }
+
+  /// Returns the shrinkWrap of the matched [GridView] via [Widget.toDiagnosticsNode]
+  bool getShrinkWrap() {
+    return getDiagnosticProp<bool>('shrinkWrap');
+  }
+
+  /// Returns the padding of the matched [GridView] via [Widget.toDiagnosticsNode]
+  EdgeInsetsGeometry getPadding() {
+    return getDiagnosticProp<EdgeInsetsGeometry>('padding');
+  }
+}

--- a/lib/src/widgets/icon.g.dart
+++ b/lib/src/widgets/icon.g.dart
@@ -458,3 +458,56 @@ extension IconMatcher on WidgetMatcher<Icon> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension IconGetter on WidgetMatcher<Icon> {
+  /// Returns the icon of the matched [Icon] via [Widget.toDiagnosticsNode]
+  IconData getIcon() {
+    return getDiagnosticProp<IconData>('icon');
+  }
+
+  /// Returns the size of the matched [Icon] via [Widget.toDiagnosticsNode]
+  double getSize() {
+    return getDiagnosticProp<double>('size');
+  }
+
+  /// Returns the fill of the matched [Icon] via [Widget.toDiagnosticsNode]
+  double getFill() {
+    return getDiagnosticProp<double>('fill');
+  }
+
+  /// Returns the weight of the matched [Icon] via [Widget.toDiagnosticsNode]
+  double getWeight() {
+    return getDiagnosticProp<double>('weight');
+  }
+
+  /// Returns the grade of the matched [Icon] via [Widget.toDiagnosticsNode]
+  double getGrade() {
+    return getDiagnosticProp<double>('grade');
+  }
+
+  /// Returns the opticalSize of the matched [Icon] via [Widget.toDiagnosticsNode]
+  double getOpticalSize() {
+    return getDiagnosticProp<double>('opticalSize');
+  }
+
+  /// Returns the color of the matched [Icon] via [Widget.toDiagnosticsNode]
+  Color getColor() {
+    return getDiagnosticProp<Color>('color');
+  }
+
+  /// Returns the shadows of the matched [Icon] via [Widget.toDiagnosticsNode]
+  Shadow getShadows() {
+    return getDiagnosticProp<Shadow>('shadows');
+  }
+
+  /// Returns the semanticLabel of the matched [Icon] via [Widget.toDiagnosticsNode]
+  String getSemanticLabel() {
+    return getDiagnosticProp<String>('semanticLabel');
+  }
+
+  /// Returns the textDirection of the matched [Icon] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+}

--- a/lib/src/widgets/iconbutton.g.dart
+++ b/lib/src/widgets/iconbutton.g.dart
@@ -459,3 +459,56 @@ extension IconButtonMatcher on WidgetMatcher<IconButton> {
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension IconButtonGetter on WidgetMatcher<IconButton> {
+  /// Returns the icon of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  Widget getIcon() {
+    return getDiagnosticProp<Widget>('icon');
+  }
+
+  /// Returns the tooltip of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  String getTooltip() {
+    return getDiagnosticProp<String>('tooltip');
+  }
+
+  /// Returns the color of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  Color getColor() {
+    return getDiagnosticProp<Color>('color');
+  }
+
+  /// Returns the disabledColor of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  Color getDisabledColor() {
+    return getDiagnosticProp<Color>('disabledColor');
+  }
+
+  /// Returns the focusColor of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  Color getFocusColor() {
+    return getDiagnosticProp<Color>('focusColor');
+  }
+
+  /// Returns the hoverColor of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  Color getHoverColor() {
+    return getDiagnosticProp<Color>('hoverColor');
+  }
+
+  /// Returns the highlightColor of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  Color getHighlightColor() {
+    return getDiagnosticProp<Color>('highlightColor');
+  }
+
+  /// Returns the splashColor of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  Color getSplashColor() {
+    return getDiagnosticProp<Color>('splashColor');
+  }
+
+  /// Returns the padding of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  EdgeInsetsGeometry getPadding() {
+    return getDiagnosticProp<EdgeInsetsGeometry>('padding');
+  }
+
+  /// Returns the focusNode of the matched [IconButton] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+}

--- a/lib/src/widgets/image.g.dart
+++ b/lib/src/widgets/image.g.dart
@@ -722,3 +722,86 @@ extension ImageMatcher on WidgetMatcher<Image> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension ImageGetter on WidgetMatcher<Image> {
+  /// Returns the image of the matched [Image] via [Widget.toDiagnosticsNode]
+  ImageProvider<Object> getImage() {
+    return getDiagnosticProp<ImageProvider<Object>>('image');
+  }
+
+  /// Returns the frameBuilder of the matched [Image] via [Widget.toDiagnosticsNode]
+  Function getFrameBuilder() {
+    return getDiagnosticProp<Function>('frameBuilder');
+  }
+
+  /// Returns the loadingBuilder of the matched [Image] via [Widget.toDiagnosticsNode]
+  Function getLoadingBuilder() {
+    return getDiagnosticProp<Function>('loadingBuilder');
+  }
+
+  /// Returns the width of the matched [Image] via [Widget.toDiagnosticsNode]
+  double getWidth() {
+    return getDiagnosticProp<double>('width');
+  }
+
+  /// Returns the height of the matched [Image] via [Widget.toDiagnosticsNode]
+  double getHeight() {
+    return getDiagnosticProp<double>('height');
+  }
+
+  /// Returns the color of the matched [Image] via [Widget.toDiagnosticsNode]
+  Color getColor() {
+    return getDiagnosticProp<Color>('color');
+  }
+
+  /// Returns the opacity of the matched [Image] via [Widget.toDiagnosticsNode]
+  Animation<double>? getOpacity() {
+    return getDiagnosticProp<Animation<double>?>('opacity');
+  }
+
+  /// Returns the colorBlendMode of the matched [Image] via [Widget.toDiagnosticsNode]
+  BlendMode getColorBlendMode() {
+    return getDiagnosticProp<BlendMode>('colorBlendMode');
+  }
+
+  /// Returns the fit of the matched [Image] via [Widget.toDiagnosticsNode]
+  BoxFit getFit() {
+    return getDiagnosticProp<BoxFit>('fit');
+  }
+
+  /// Returns the alignment of the matched [Image] via [Widget.toDiagnosticsNode]
+  AlignmentGeometry getAlignment() {
+    return getDiagnosticProp<AlignmentGeometry>('alignment');
+  }
+
+  /// Returns the repeat of the matched [Image] via [Widget.toDiagnosticsNode]
+  ImageRepeat getRepeat() {
+    return getDiagnosticProp<ImageRepeat>('repeat');
+  }
+
+  /// Returns the centerSlice of the matched [Image] via [Widget.toDiagnosticsNode]
+  Rect getCenterSlice() {
+    return getDiagnosticProp<Rect>('centerSlice');
+  }
+
+  /// Returns the matchTextDirection of the matched [Image] via [Widget.toDiagnosticsNode]
+  bool getMatchTextDirection() {
+    return getDiagnosticProp<bool>('matchTextDirection');
+  }
+
+  /// Returns the semanticLabel of the matched [Image] via [Widget.toDiagnosticsNode]
+  String getSemanticLabel() {
+    return getDiagnosticProp<String>('semanticLabel');
+  }
+
+  /// Returns the excludeFromSemantics of the matched [Image] via [Widget.toDiagnosticsNode]
+  bool getExcludeFromSemantics() {
+    return getDiagnosticProp<bool>('this.excludeFromSemantics');
+  }
+
+  /// Returns the filterQuality of the matched [Image] via [Widget.toDiagnosticsNode]
+  FilterQuality getFilterQuality() {
+    return getDiagnosticProp<FilterQuality>('filterQuality');
+  }
+}

--- a/lib/src/widgets/linearprogressindicator.g.dart
+++ b/lib/src/widgets/linearprogressindicator.g.dart
@@ -65,3 +65,12 @@ extension LinearProgressIndicatorMatcher
         'value', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension LinearProgressIndicatorGetter
+    on WidgetMatcher<LinearProgressIndicator> {
+  /// Returns the value of the matched [LinearProgressIndicator] via [Widget.toDiagnosticsNode]
+  double getValue() {
+    return getDiagnosticProp<double>('value');
+  }
+}

--- a/lib/src/widgets/listtile.g.dart
+++ b/lib/src/widgets/listtile.g.dart
@@ -1434,3 +1434,166 @@ extension ListTileMatcher on WidgetMatcher<ListTile> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension ListTileGetter on WidgetMatcher<ListTile> {
+  /// Returns the leading of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Widget getLeading() {
+    return getDiagnosticProp<Widget>('leading');
+  }
+
+  /// Returns the title of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Widget getTitle() {
+    return getDiagnosticProp<Widget>('title');
+  }
+
+  /// Returns the subtitle of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Widget getSubtitle() {
+    return getDiagnosticProp<Widget>('subtitle');
+  }
+
+  /// Returns the trailing of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Widget getTrailing() {
+    return getDiagnosticProp<Widget>('trailing');
+  }
+
+  /// Returns the isThreeLine of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  bool getIsThreeLine() {
+    return getDiagnosticProp<bool>('isThreeLine');
+  }
+
+  /// Returns the dense of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  bool getDense() {
+    return getDiagnosticProp<bool>('dense');
+  }
+
+  /// Returns the visualDensity of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  VisualDensity getVisualDensity() {
+    return getDiagnosticProp<VisualDensity>('visualDensity');
+  }
+
+  /// Returns the shape of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  ShapeBorder getShape() {
+    return getDiagnosticProp<ShapeBorder>('shape');
+  }
+
+  /// Returns the style of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  ListTileStyle getStyle() {
+    return getDiagnosticProp<ListTileStyle>('style');
+  }
+
+  /// Returns the selectedColor of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Color getSelectedColor() {
+    return getDiagnosticProp<Color>('selectedColor');
+  }
+
+  /// Returns the iconColor of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Color getIconColor() {
+    return getDiagnosticProp<Color>('iconColor');
+  }
+
+  /// Returns the textColor of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Color getTextColor() {
+    return getDiagnosticProp<Color>('textColor');
+  }
+
+  /// Returns the titleTextStyle of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  TextStyle getTitleTextStyle() {
+    return getDiagnosticProp<TextStyle>('titleTextStyle');
+  }
+
+  /// Returns the subtitleTextStyle of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  TextStyle getSubtitleTextStyle() {
+    return getDiagnosticProp<TextStyle>('subtitleTextStyle');
+  }
+
+  /// Returns the leadingAndTrailingTextStyle of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  TextStyle getLeadingAndTrailingTextStyle() {
+    return getDiagnosticProp<TextStyle>('leadingAndTrailingTextStyle');
+  }
+
+  /// Returns the contentPadding of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  EdgeInsetsGeometry getContentPadding() {
+    return getDiagnosticProp<EdgeInsetsGeometry>('contentPadding');
+  }
+
+  /// Returns the enabled of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  bool getEnabled() {
+    return getDiagnosticProp<bool>('enabled');
+  }
+
+  /// Returns the onTap of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Function getOnTap() {
+    return getDiagnosticProp<Function>('onTap');
+  }
+
+  /// Returns the onLongPress of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Function getOnLongPress() {
+    return getDiagnosticProp<Function>('onLongPress');
+  }
+
+  /// Returns the mouseCursor of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  MouseCursor getMouseCursor() {
+    return getDiagnosticProp<MouseCursor>('mouseCursor');
+  }
+
+  /// Returns the selected of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  bool getSelected() {
+    return getDiagnosticProp<bool>('selected');
+  }
+
+  /// Returns the focusColor of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Color getFocusColor() {
+    return getDiagnosticProp<Color>('focusColor');
+  }
+
+  /// Returns the hoverColor of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Color getHoverColor() {
+    return getDiagnosticProp<Color>('hoverColor');
+  }
+
+  /// Returns the focusNode of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+
+  /// Returns the autofocus of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  bool getAutofocus() {
+    return getDiagnosticProp<bool>('autofocus');
+  }
+
+  /// Returns the tileColor of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Color getTileColor() {
+    return getDiagnosticProp<Color>('tileColor');
+  }
+
+  /// Returns the selectedTileColor of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  Color getSelectedTileColor() {
+    return getDiagnosticProp<Color>('selectedTileColor');
+  }
+
+  /// Returns the enableFeedback of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  bool getEnableFeedback() {
+    return getDiagnosticProp<bool>('enableFeedback');
+  }
+
+  /// Returns the horizontalTitleGap of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  double getHorizontalTitleGap() {
+    return getDiagnosticProp<double>('horizontalTitleGap');
+  }
+
+  /// Returns the minVerticalPadding of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  double getMinVerticalPadding() {
+    return getDiagnosticProp<double>('minVerticalPadding');
+  }
+
+  /// Returns the minLeadingWidth of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  double getMinLeadingWidth() {
+    return getDiagnosticProp<double>('minLeadingWidth');
+  }
+
+  /// Returns the titleAlignment of the matched [ListTile] via [Widget.toDiagnosticsNode]
+  ListTileTitleAlignment getTitleAlignment() {
+    return getDiagnosticProp<ListTileTitleAlignment>('titleAlignment');
+  }
+}

--- a/lib/src/widgets/opacity.g.dart
+++ b/lib/src/widgets/opacity.g.dart
@@ -151,3 +151,21 @@ extension OpacityMatcher on WidgetMatcher<Opacity> {
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension OpacityGetter on WidgetMatcher<Opacity> {
+  /// Returns the opacity of the matched [Opacity] via [Widget.toDiagnosticsNode]
+  double getOpacity() {
+    return getDiagnosticProp<double>('opacity');
+  }
+
+  /// Returns the alwaysIncludeSemantics of the matched [Opacity] via [Widget.toDiagnosticsNode]
+  bool getAlwaysIncludeSemantics() {
+    return getDiagnosticProp<bool>('alwaysIncludeSemantics');
+  }
+
+  /// Returns the renderObject of the matched [Opacity] via [Widget.toDiagnosticsNode]
+  RenderOpacity getRenderObject() {
+    return getDiagnosticProp<RenderOpacity>('renderObject');
+  }
+}

--- a/lib/src/widgets/outlinedbutton.g.dart
+++ b/lib/src/widgets/outlinedbutton.g.dart
@@ -150,3 +150,21 @@ extension OutlinedButtonMatcher on WidgetMatcher<OutlinedButton> {
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension OutlinedButtonGetter on WidgetMatcher<OutlinedButton> {
+  /// Returns the enabled of the matched [OutlinedButton] via [Widget.toDiagnosticsNode]
+  bool getEnabled() {
+    return getDiagnosticProp<bool>('enabled');
+  }
+
+  /// Returns the style of the matched [OutlinedButton] via [Widget.toDiagnosticsNode]
+  ButtonStyle getStyle() {
+    return getDiagnosticProp<ButtonStyle>('style');
+  }
+
+  /// Returns the focusNode of the matched [OutlinedButton] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+}

--- a/lib/src/widgets/row.g.dart
+++ b/lib/src/widgets/row.g.dart
@@ -377,3 +377,46 @@ extension RowMatcher on WidgetMatcher<Row> {
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension RowGetter on WidgetMatcher<Row> {
+  /// Returns the direction of the matched [Row] via [Widget.toDiagnosticsNode]
+  Axis getDirection() {
+    return getDiagnosticProp<Axis>('direction');
+  }
+
+  /// Returns the mainAxisAlignment of the matched [Row] via [Widget.toDiagnosticsNode]
+  MainAxisAlignment getMainAxisAlignment() {
+    return getDiagnosticProp<MainAxisAlignment>('mainAxisAlignment');
+  }
+
+  /// Returns the mainAxisSize of the matched [Row] via [Widget.toDiagnosticsNode]
+  MainAxisSize getMainAxisSize() {
+    return getDiagnosticProp<MainAxisSize>('mainAxisSize');
+  }
+
+  /// Returns the crossAxisAlignment of the matched [Row] via [Widget.toDiagnosticsNode]
+  CrossAxisAlignment getCrossAxisAlignment() {
+    return getDiagnosticProp<CrossAxisAlignment>('crossAxisAlignment');
+  }
+
+  /// Returns the textDirection of the matched [Row] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the verticalDirection of the matched [Row] via [Widget.toDiagnosticsNode]
+  VerticalDirection getVerticalDirection() {
+    return getDiagnosticProp<VerticalDirection>('verticalDirection');
+  }
+
+  /// Returns the textBaseline of the matched [Row] via [Widget.toDiagnosticsNode]
+  TextBaseline getTextBaseline() {
+    return getDiagnosticProp<TextBaseline>('textBaseline');
+  }
+
+  /// Returns the renderObject of the matched [Row] via [Widget.toDiagnosticsNode]
+  RenderFlex getRenderObject() {
+    return getDiagnosticProp<RenderFlex>('renderObject');
+  }
+}

--- a/lib/src/widgets/safearea.g.dart
+++ b/lib/src/widgets/safearea.g.dart
@@ -194,3 +194,26 @@ extension SafeAreaMatcher on WidgetMatcher<SafeArea> {
         'bottom', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension SafeAreaGetter on WidgetMatcher<SafeArea> {
+  /// Returns the left of the matched [SafeArea] via [Widget.toDiagnosticsNode]
+  bool getLeft() {
+    return getDiagnosticProp<bool>('left');
+  }
+
+  /// Returns the top of the matched [SafeArea] via [Widget.toDiagnosticsNode]
+  bool getTop() {
+    return getDiagnosticProp<bool>('top');
+  }
+
+  /// Returns the right of the matched [SafeArea] via [Widget.toDiagnosticsNode]
+  bool getRight() {
+    return getDiagnosticProp<bool>('right');
+  }
+
+  /// Returns the bottom of the matched [SafeArea] via [Widget.toDiagnosticsNode]
+  bool getBottom() {
+    return getDiagnosticProp<bool>('bottom');
+  }
+}

--- a/lib/src/widgets/selectabletext.g.dart
+++ b/lib/src/widgets/selectabletext.g.dart
@@ -915,3 +915,106 @@ extension SelectableTextMatcher on WidgetMatcher<SelectableText> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension SelectableTextGetter on WidgetMatcher<SelectableText> {
+  /// Returns the text of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  String getText() {
+    return getDiagnosticProp<String>('data');
+  }
+
+  /// Returns the semanticsLabel of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  String getSemanticsLabel() {
+    return getDiagnosticProp<String>('semanticsLabel');
+  }
+
+  /// Returns the focusNode of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+
+  /// Returns the style of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  TextStyle getStyle() {
+    return getDiagnosticProp<TextStyle>('style');
+  }
+
+  /// Returns the autofocus of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  bool getAutofocus() {
+    return getDiagnosticProp<bool>('autofocus');
+  }
+
+  /// Returns the showCursor of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  bool getShowCursor() {
+    return getDiagnosticProp<bool>('showCursor');
+  }
+
+  /// Returns the minLines of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  int getMinLines() {
+    return getDiagnosticProp<int>('minLines');
+  }
+
+  /// Returns the maxLines of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  int getMaxLines() {
+    return getDiagnosticProp<int>('maxLines');
+  }
+
+  /// Returns the textAlign of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  TextAlign getTextAlign() {
+    return getDiagnosticProp<TextAlign>('textAlign');
+  }
+
+  /// Returns the textDirection of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the textScaleFactor of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  double getTextScaleFactor() {
+    return getDiagnosticProp<double>('textScaleFactor');
+  }
+
+  /// Returns the textScaler of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  TextScaler getTextScaler() {
+    return getDiagnosticProp<TextScaler>('textScaler');
+  }
+
+  /// Returns the cursorWidth of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  double getCursorWidth() {
+    return getDiagnosticProp<double>('cursorWidth');
+  }
+
+  /// Returns the cursorHeight of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  double getCursorHeight() {
+    return getDiagnosticProp<double>('cursorHeight');
+  }
+
+  /// Returns the cursorRadius of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  Radius getCursorRadius() {
+    return getDiagnosticProp<Radius>('cursorRadius');
+  }
+
+  /// Returns the cursorColor of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  Color getCursorColor() {
+    return getDiagnosticProp<Color>('cursorColor');
+  }
+
+  /// Returns the selectionEnabled of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  bool getSelectionEnabled() {
+    return getDiagnosticProp<bool>('selectionEnabled');
+  }
+
+  /// Returns the selectionControls of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  TextSelectionControls getSelectionControls() {
+    return getDiagnosticProp<TextSelectionControls>('selectionControls');
+  }
+
+  /// Returns the scrollPhysics of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  ScrollPhysics getScrollPhysics() {
+    return getDiagnosticProp<ScrollPhysics>('scrollPhysics');
+  }
+
+  /// Returns the textHeightBehavior of the matched [SelectableText] via [Widget.toDiagnosticsNode]
+  TextHeightBehavior getTextHeightBehavior() {
+    return getDiagnosticProp<TextHeightBehavior>('textHeightBehavior');
+  }
+}

--- a/lib/src/widgets/selectabletext.g.dart
+++ b/lib/src/widgets/selectabletext.g.dart
@@ -269,29 +269,6 @@ extension SelectableTextSelector on WidgetSelector<SelectableText> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Creates a [WidgetSelector] that finds all [SelectableText] where textScaler matches the condition.
-  ///
-  /// #### Example usage:
-  /// ```dart
-  /// spot<SelectableText>().whereTextScaler((it) => it.equals(your TextScaler value to match)).existsOnce();
-  /// ```
-  @useResult
-  WidgetSelector<SelectableText> whereTextScaler(MatchProp<TextScaler> match) {
-    return withDiagnosticProp<TextScaler>('textScaler', match);
-  }
-
-  /// Creates a [WidgetSelector] that finds all [SelectableText] where textScaler equals (==) [value].
-  ///
-  /// #### Example usage:
-  /// ```dart
-  /// spot<SelectableText>().withTextScaler(your TextScaler value to match).existsOnce();
-  /// ```
-  @useResult
-  WidgetSelector<SelectableText> withTextScaler(TextScaler? value) {
-    return withDiagnosticProp<TextScaler>(
-        'textScaler', (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
   /// Creates a [WidgetSelector] that finds all [SelectableText] where cursorWidth matches the condition.
   ///
   /// #### Example usage:
@@ -719,28 +696,6 @@ extension SelectableTextMatcher on WidgetMatcher<SelectableText> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Expects that textScaler of [SelectableText] matches the condition in [match].
-  ///
-  /// #### Example usage:
-  /// ```dart
-  /// spot<SelectableText>().existsOnce().hasTextScalerWhere((it) => it.equals(your TextScaler value to match));
-  /// ```
-  WidgetMatcher<SelectableText> hasTextScalerWhere(
-      MatchProp<TextScaler> match) {
-    return hasDiagnosticProp<TextScaler>('textScaler', match);
-  }
-
-  /// Expects that textScaler of [SelectableText] equals (==) [value].
-  ///
-  /// #### Example usage:
-  /// ```dart
-  /// spot<SelectableText>().existsOnce().hasTextScaler(your TextScaler value to match);
-  /// ```
-  WidgetMatcher<SelectableText> hasTextScaler(TextScaler? value) {
-    return hasDiagnosticProp<TextScaler>(
-        'textScaler', (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
   /// Expects that cursorWidth of [SelectableText] matches the condition in [match].
   ///
   /// #### Example usage:
@@ -971,11 +926,6 @@ extension SelectableTextGetter on WidgetMatcher<SelectableText> {
   /// Returns the textScaleFactor of the matched [SelectableText] via [Widget.toDiagnosticsNode]
   double getTextScaleFactor() {
     return getDiagnosticProp<double>('textScaleFactor');
-  }
-
-  /// Returns the textScaler of the matched [SelectableText] via [Widget.toDiagnosticsNode]
-  TextScaler getTextScaler() {
-    return getDiagnosticProp<TextScaler>('textScaler');
   }
 
   /// Returns the cursorWidth of the matched [SelectableText] via [Widget.toDiagnosticsNode]

--- a/lib/src/widgets/semantics.g.dart
+++ b/lib/src/widgets/semantics.g.dart
@@ -110,29 +110,6 @@ extension SemanticsSelector on WidgetSelector<Semantics> {
         'mixed', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Creates a [WidgetSelector] that finds all [Semantics] where expanded matches the condition.
-  ///
-  /// #### Example usage:
-  /// ```dart
-  /// spot<Semantics>().whereExpanded((it) => it.isTrue()).existsOnce();
-  /// ```
-  @useResult
-  WidgetSelector<Semantics> whereExpanded(MatchProp<bool> match) {
-    return withDiagnosticProp<bool>('expanded', match);
-  }
-
-  /// Creates a [WidgetSelector] that finds all [Semantics] where expanded equals (==) [value].
-  ///
-  /// #### Example usage:
-  /// ```dart
-  /// spot<Semantics>().withExpanded(true).existsOnce();
-  /// ```
-  @useResult
-  WidgetSelector<Semantics> withExpanded(bool? value) {
-    return withDiagnosticProp<bool>(
-        'expanded', (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
   /// Creates a [WidgetSelector] that finds all [Semantics] where selected matches the condition.
   ///
   /// #### Example usage:
@@ -595,27 +572,6 @@ extension SemanticsMatcher on WidgetMatcher<Semantics> {
         'mixed', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
-  /// Expects that expanded of [Semantics] matches the condition in [match].
-  ///
-  /// #### Example usage:
-  /// ```dart
-  /// spot<Semantics>().existsOnce().hasExpandedWhere((it) => it.isTrue());
-  /// ```
-  WidgetMatcher<Semantics> hasExpandedWhere(MatchProp<bool> match) {
-    return hasDiagnosticProp<bool>('expanded', match);
-  }
-
-  /// Expects that expanded of [Semantics] equals (==) [value].
-  ///
-  /// #### Example usage:
-  /// ```dart
-  /// spot<Semantics>().existsOnce().hasExpanded(true);
-  /// ```
-  WidgetMatcher<Semantics> hasExpanded(bool? value) {
-    return hasDiagnosticProp<bool>(
-        'expanded', (it) => value == null ? it.isNull() : it.equals(value));
-  }
-
   /// Expects that selected of [Semantics] matches the condition in [match].
   ///
   /// #### Example usage:
@@ -978,11 +934,6 @@ extension SemanticsGetter on WidgetMatcher<Semantics> {
   /// Returns the mixed of the matched [Semantics] via [Widget.toDiagnosticsNode]
   bool getMixed() {
     return getDiagnosticProp<bool>('mixed');
-  }
-
-  /// Returns the expanded of the matched [Semantics] via [Widget.toDiagnosticsNode]
-  bool getExpanded() {
-    return getDiagnosticProp<bool>('expanded');
   }
 
   /// Returns the selected of the matched [Semantics] via [Widget.toDiagnosticsNode]

--- a/lib/src/widgets/semantics.g.dart
+++ b/lib/src/widgets/semantics.g.dart
@@ -957,3 +957,111 @@ extension SemanticsMatcher on WidgetMatcher<Semantics> {
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension SemanticsGetter on WidgetMatcher<Semantics> {
+  /// Returns the container of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  bool getContainer() {
+    return getDiagnosticProp<bool>('container');
+  }
+
+  /// Returns the properties of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  SemanticsProperties getProperties() {
+    return getDiagnosticProp<SemanticsProperties>('properties');
+  }
+
+  /// Returns the checked of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  bool getChecked() {
+    return getDiagnosticProp<bool>('checked');
+  }
+
+  /// Returns the mixed of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  bool getMixed() {
+    return getDiagnosticProp<bool>('mixed');
+  }
+
+  /// Returns the expanded of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  bool getExpanded() {
+    return getDiagnosticProp<bool>('expanded');
+  }
+
+  /// Returns the selected of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  bool getSelected() {
+    return getDiagnosticProp<bool>('selected');
+  }
+
+  /// Returns the label of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getLabel() {
+    return getDiagnosticProp<String>('label');
+  }
+
+  /// Returns the attributedLabel of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getAttributedLabel() {
+    return getDiagnosticProp<String>('attributedLabel');
+  }
+
+  /// Returns the value of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getValue() {
+    return getDiagnosticProp<String>('value');
+  }
+
+  /// Returns the attributedValue of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getAttributedValue() {
+    return getDiagnosticProp<String>('attributedValue');
+  }
+
+  /// Returns the increasedValue of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getIncreasedValue() {
+    return getDiagnosticProp<String>('increasedValue');
+  }
+
+  /// Returns the attributedIncreasedValue of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getAttributedIncreasedValue() {
+    return getDiagnosticProp<String>('attributedIncreasedValue');
+  }
+
+  /// Returns the decreasedValue of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getDecreasedValue() {
+    return getDiagnosticProp<String>('decreasedValue');
+  }
+
+  /// Returns the attributedDecreasedValue of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getAttributedDecreasedValue() {
+    return getDiagnosticProp<String>('attributedDecreasedValue');
+  }
+
+  /// Returns the hint of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getHint() {
+    return getDiagnosticProp<String>('hint');
+  }
+
+  /// Returns the attributedHint of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getAttributedHint() {
+    return getDiagnosticProp<String>('attributedHint');
+  }
+
+  /// Returns the tooltip of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  String getTooltip() {
+    return getDiagnosticProp<String>('tooltip');
+  }
+
+  /// Returns the textDirection of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the sortKey of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  SemanticsSortKey getSortKey() {
+    return getDiagnosticProp<SemanticsSortKey>('sortKey');
+  }
+
+  /// Returns the hintOverrides of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  SemanticsHintOverrides getHintOverrides() {
+    return getDiagnosticProp<SemanticsHintOverrides>('hintOverrides');
+  }
+
+  /// Returns the renderObject of the matched [Semantics] via [Widget.toDiagnosticsNode]
+  RenderSemanticsAnnotations getRenderObject() {
+    return getDiagnosticProp<RenderSemanticsAnnotations>('renderObject');
+  }
+}

--- a/lib/src/widgets/sizedbox.g.dart
+++ b/lib/src/widgets/sizedbox.g.dart
@@ -153,3 +153,21 @@ extension SizedBoxMatcher on WidgetMatcher<SizedBox> {
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension SizedBoxGetter on WidgetMatcher<SizedBox> {
+  /// Returns the width of the matched [SizedBox] via [Widget.toDiagnosticsNode]
+  double getWidth() {
+    return getDiagnosticProp<double>('width');
+  }
+
+  /// Returns the height of the matched [SizedBox] via [Widget.toDiagnosticsNode]
+  double getHeight() {
+    return getDiagnosticProp<double>('height');
+  }
+
+  /// Returns the renderObject of the matched [SizedBox] via [Widget.toDiagnosticsNode]
+  RenderConstrainedBox getRenderObject() {
+    return getDiagnosticProp<RenderConstrainedBox>('renderObject');
+  }
+}

--- a/lib/src/widgets/slider.g.dart
+++ b/lib/src/widgets/slider.g.dart
@@ -502,3 +502,61 @@ extension SliderMatcher on WidgetMatcher<Slider> {
         'autofocus', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension SliderGetter on WidgetMatcher<Slider> {
+  /// Returns the value of the matched [Slider] via [Widget.toDiagnosticsNode]
+  double getValue() {
+    return getDiagnosticProp<double>('value');
+  }
+
+  /// Returns the secondaryTrackValue of the matched [Slider] via [Widget.toDiagnosticsNode]
+  double getSecondaryTrackValue() {
+    return getDiagnosticProp<double>('secondaryTrackValue');
+  }
+
+  /// Returns the min of the matched [Slider] via [Widget.toDiagnosticsNode]
+  double getMin() {
+    return getDiagnosticProp<double>('min');
+  }
+
+  /// Returns the max of the matched [Slider] via [Widget.toDiagnosticsNode]
+  double getMax() {
+    return getDiagnosticProp<double>('max');
+  }
+
+  /// Returns the divisions of the matched [Slider] via [Widget.toDiagnosticsNode]
+  int getDivisions() {
+    return getDiagnosticProp<int>('divisions');
+  }
+
+  /// Returns the label of the matched [Slider] via [Widget.toDiagnosticsNode]
+  String getLabel() {
+    return getDiagnosticProp<String>('label');
+  }
+
+  /// Returns the activeColor of the matched [Slider] via [Widget.toDiagnosticsNode]
+  Color getActiveColor() {
+    return getDiagnosticProp<Color>('activeColor');
+  }
+
+  /// Returns the inactiveColor of the matched [Slider] via [Widget.toDiagnosticsNode]
+  Color getInactiveColor() {
+    return getDiagnosticProp<Color>('inactiveColor');
+  }
+
+  /// Returns the secondaryActiveColor of the matched [Slider] via [Widget.toDiagnosticsNode]
+  Color getSecondaryActiveColor() {
+    return getDiagnosticProp<Color>('secondaryActiveColor');
+  }
+
+  /// Returns the focusNode of the matched [Slider] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+
+  /// Returns the autofocus of the matched [Slider] via [Widget.toDiagnosticsNode]
+  bool getAutofocus() {
+    return getDiagnosticProp<bool>('autofocus');
+  }
+}

--- a/lib/src/widgets/switch.g.dart
+++ b/lib/src/widgets/switch.g.dart
@@ -62,3 +62,11 @@ extension SwitchMatcher on WidgetMatcher<Switch> {
         'value', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension SwitchGetter on WidgetMatcher<Switch> {
+  /// Returns the value of the matched [Switch] via [Widget.toDiagnosticsNode]
+  bool getValue() {
+    return getDiagnosticProp<bool>('value');
+  }
+}

--- a/lib/src/widgets/text.g.dart
+++ b/lib/src/widgets/text.g.dart
@@ -460,3 +460,56 @@ extension TextMatcher on WidgetMatcher<Text> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension TextGetter on WidgetMatcher<Text> {
+  /// Returns the text of the matched [Text] via [Widget.toDiagnosticsNode]
+  String getText() {
+    return getDiagnosticProp<String>('data');
+  }
+
+  /// Returns the textAlign of the matched [Text] via [Widget.toDiagnosticsNode]
+  TextAlign getTextAlign() {
+    return getDiagnosticProp<TextAlign>('textAlign');
+  }
+
+  /// Returns the textDirection of the matched [Text] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the locale of the matched [Text] via [Widget.toDiagnosticsNode]
+  Locale getLocale() {
+    return getDiagnosticProp<Locale>('locale');
+  }
+
+  /// Returns the softWrap of the matched [Text] via [Widget.toDiagnosticsNode]
+  bool getSoftWrap() {
+    return getDiagnosticProp<bool>('softWrap');
+  }
+
+  /// Returns the overflow of the matched [Text] via [Widget.toDiagnosticsNode]
+  TextOverflow getOverflow() {
+    return getDiagnosticProp<TextOverflow>('overflow');
+  }
+
+  /// Returns the textScaleFactor of the matched [Text] via [Widget.toDiagnosticsNode]
+  double getTextScaleFactor() {
+    return getDiagnosticProp<double>('textScaleFactor');
+  }
+
+  /// Returns the maxLines of the matched [Text] via [Widget.toDiagnosticsNode]
+  int getMaxLines() {
+    return getDiagnosticProp<int>('maxLines');
+  }
+
+  /// Returns the textWidthBasis of the matched [Text] via [Widget.toDiagnosticsNode]
+  TextWidthBasis getTextWidthBasis() {
+    return getDiagnosticProp<TextWidthBasis>('textWidthBasis');
+  }
+
+  /// Returns the textHeightBehavior of the matched [Text] via [Widget.toDiagnosticsNode]
+  TextHeightBehavior getTextHeightBehavior() {
+    return getDiagnosticProp<TextHeightBehavior>('textHeightBehavior');
+  }
+}

--- a/lib/src/widgets/textbutton.g.dart
+++ b/lib/src/widgets/textbutton.g.dart
@@ -150,3 +150,21 @@ extension TextButtonMatcher on WidgetMatcher<TextButton> {
         'focusNode', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension TextButtonGetter on WidgetMatcher<TextButton> {
+  /// Returns the enabled of the matched [TextButton] via [Widget.toDiagnosticsNode]
+  bool getEnabled() {
+    return getDiagnosticProp<bool>('enabled');
+  }
+
+  /// Returns the style of the matched [TextButton] via [Widget.toDiagnosticsNode]
+  ButtonStyle getStyle() {
+    return getDiagnosticProp<ButtonStyle>('style');
+  }
+
+  /// Returns the focusNode of the matched [TextButton] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+}

--- a/lib/src/widgets/textfield.g.dart
+++ b/lib/src/widgets/textfield.g.dart
@@ -1825,3 +1825,207 @@ extension TextFieldMatcher on WidgetMatcher<TextField> {
         (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension TextFieldGetter on WidgetMatcher<TextField> {
+  /// Returns the controller of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextEditingController getController() {
+    return getDiagnosticProp<TextEditingController>('controller');
+  }
+
+  /// Returns the focusNode of the matched [TextField] via [Widget.toDiagnosticsNode]
+  FocusNode getFocusNode() {
+    return getDiagnosticProp<FocusNode>('focusNode');
+  }
+
+  /// Returns the undoController of the matched [TextField] via [Widget.toDiagnosticsNode]
+  UndoHistoryController getUndoController() {
+    return getDiagnosticProp<UndoHistoryController>('undoController');
+  }
+
+  /// Returns the enabled of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getEnabled() {
+    return getDiagnosticProp<bool>('enabled');
+  }
+
+  /// Returns the decoration of the matched [TextField] via [Widget.toDiagnosticsNode]
+  InputDecoration getDecoration() {
+    return getDiagnosticProp<InputDecoration>('decoration');
+  }
+
+  /// Returns the keyboardType of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextInputType getKeyboardType() {
+    return getDiagnosticProp<TextInputType>('keyboardType');
+  }
+
+  /// Returns the style of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextStyle getStyle() {
+    return getDiagnosticProp<TextStyle>('style');
+  }
+
+  /// Returns the autofocus of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getAutofocus() {
+    return getDiagnosticProp<bool>('autofocus');
+  }
+
+  /// Returns the obscuringCharacter of the matched [TextField] via [Widget.toDiagnosticsNode]
+  String getObscuringCharacter() {
+    return getDiagnosticProp<String>('obscuringCharacter');
+  }
+
+  /// Returns the obscureText of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getObscureText() {
+    return getDiagnosticProp<bool>('obscureText');
+  }
+
+  /// Returns the autocorrect of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getAutocorrect() {
+    return getDiagnosticProp<bool>('autocorrect');
+  }
+
+  /// Returns the smartDashesType of the matched [TextField] via [Widget.toDiagnosticsNode]
+  SmartDashesType getSmartDashesType() {
+    return getDiagnosticProp<SmartDashesType>('smartDashesType');
+  }
+
+  /// Returns the smartQuotesType of the matched [TextField] via [Widget.toDiagnosticsNode]
+  SmartQuotesType getSmartQuotesType() {
+    return getDiagnosticProp<SmartQuotesType>('smartQuotesType');
+  }
+
+  /// Returns the enableSuggestions of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getEnableSuggestions() {
+    return getDiagnosticProp<bool>('enableSuggestions');
+  }
+
+  /// Returns the maxLines of the matched [TextField] via [Widget.toDiagnosticsNode]
+  int getMaxLines() {
+    return getDiagnosticProp<int>('maxLines');
+  }
+
+  /// Returns the minLines of the matched [TextField] via [Widget.toDiagnosticsNode]
+  int getMinLines() {
+    return getDiagnosticProp<int>('minLines');
+  }
+
+  /// Returns the expands of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getExpands() {
+    return getDiagnosticProp<bool>('expands');
+  }
+
+  /// Returns the maxLength of the matched [TextField] via [Widget.toDiagnosticsNode]
+  int getMaxLength() {
+    return getDiagnosticProp<int>('maxLength');
+  }
+
+  /// Returns the maxLengthEnforcement of the matched [TextField] via [Widget.toDiagnosticsNode]
+  MaxLengthEnforcement getMaxLengthEnforcement() {
+    return getDiagnosticProp<MaxLengthEnforcement>('maxLengthEnforcement');
+  }
+
+  /// Returns the textInputAction of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextInputAction getTextInputAction() {
+    return getDiagnosticProp<TextInputAction>('textInputAction');
+  }
+
+  /// Returns the textCapitalization of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextCapitalization getTextCapitalization() {
+    return getDiagnosticProp<TextCapitalization>('textCapitalization');
+  }
+
+  /// Returns the textAlign of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextAlign getTextAlign() {
+    return getDiagnosticProp<TextAlign>('textAlign');
+  }
+
+  /// Returns the textAlignVertical of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextAlignVertical getTextAlignVertical() {
+    return getDiagnosticProp<TextAlignVertical>('textAlignVertical');
+  }
+
+  /// Returns the textDirection of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the cursorWidth of the matched [TextField] via [Widget.toDiagnosticsNode]
+  double getCursorWidth() {
+    return getDiagnosticProp<double>('cursorWidth');
+  }
+
+  /// Returns the cursorHeight of the matched [TextField] via [Widget.toDiagnosticsNode]
+  double getCursorHeight() {
+    return getDiagnosticProp<double>('cursorHeight');
+  }
+
+  /// Returns the cursorRadius of the matched [TextField] via [Widget.toDiagnosticsNode]
+  Radius getCursorRadius() {
+    return getDiagnosticProp<Radius>('cursorRadius');
+  }
+
+  /// Returns the cursorOpacityAnimates of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getCursorOpacityAnimates() {
+    return getDiagnosticProp<bool>('cursorOpacityAnimates');
+  }
+
+  /// Returns the cursorColor of the matched [TextField] via [Widget.toDiagnosticsNode]
+  Color getCursorColor() {
+    return getDiagnosticProp<Color>('cursorColor');
+  }
+
+  /// Returns the keyboardAppearance of the matched [TextField] via [Widget.toDiagnosticsNode]
+  Brightness getKeyboardAppearance() {
+    return getDiagnosticProp<Brightness>('keyboardAppearance');
+  }
+
+  /// Returns the scrollPadding of the matched [TextField] via [Widget.toDiagnosticsNode]
+  EdgeInsetsGeometry getScrollPadding() {
+    return getDiagnosticProp<EdgeInsetsGeometry>('scrollPadding');
+  }
+
+  /// Returns the selectionEnabled of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getSelectionEnabled() {
+    return getDiagnosticProp<bool>('selectionEnabled');
+  }
+
+  /// Returns the selectionControls of the matched [TextField] via [Widget.toDiagnosticsNode]
+  TextSelectionControls getSelectionControls() {
+    return getDiagnosticProp<TextSelectionControls>('selectionControls');
+  }
+
+  /// Returns the scrollController of the matched [TextField] via [Widget.toDiagnosticsNode]
+  ScrollController getScrollController() {
+    return getDiagnosticProp<ScrollController>('scrollController');
+  }
+
+  /// Returns the scrollPhysics of the matched [TextField] via [Widget.toDiagnosticsNode]
+  ScrollPhysics getScrollPhysics() {
+    return getDiagnosticProp<ScrollPhysics>('scrollPhysics');
+  }
+
+  /// Returns the clipBehavior of the matched [TextField] via [Widget.toDiagnosticsNode]
+  Clip getClipBehavior() {
+    return getDiagnosticProp<Clip>('clipBehavior');
+  }
+
+  /// Returns the scribbleEnabled of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getScribbleEnabled() {
+    return getDiagnosticProp<bool>('scribbleEnabled');
+  }
+
+  /// Returns the enableIMEPersonalizedLearning of the matched [TextField] via [Widget.toDiagnosticsNode]
+  bool getEnableIMEPersonalizedLearning() {
+    return getDiagnosticProp<bool>('enableIMEPersonalizedLearning');
+  }
+
+  /// Returns the spellCheckConfiguration of the matched [TextField] via [Widget.toDiagnosticsNode]
+  SpellCheckConfiguration getSpellCheckConfiguration() {
+    return getDiagnosticProp<SpellCheckConfiguration>(
+        'spellCheckConfiguration');
+  }
+
+  /// Returns the contentCommitMimeTypes of the matched [TextField] via [Widget.toDiagnosticsNode]
+  List<String> getContentCommitMimeTypes() {
+    return getDiagnosticProp<List<String>>('contentCommitMimeTypes');
+  }
+}

--- a/lib/src/widgets/tooltip.g.dart
+++ b/lib/src/widgets/tooltip.g.dart
@@ -592,3 +592,71 @@ extension TooltipMatcher on WidgetMatcher<Tooltip> {
         'textAlign', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension TooltipGetter on WidgetMatcher<Tooltip> {
+  /// Returns the message of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  String getMessage() {
+    return getDiagnosticProp<String>('message');
+  }
+
+  /// Returns the richMessage of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  String getRichMessage() {
+    return getDiagnosticProp<String>('richMessage');
+  }
+
+  /// Returns the height of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  double getHeight() {
+    return getDiagnosticProp<double>('height');
+  }
+
+  /// Returns the padding of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  EdgeInsetsGeometry getPadding() {
+    return getDiagnosticProp<EdgeInsetsGeometry>('padding');
+  }
+
+  /// Returns the margin of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  EdgeInsetsGeometry getMargin() {
+    return getDiagnosticProp<EdgeInsetsGeometry>('margin');
+  }
+
+  /// Returns the verticalOffset of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  double getVerticalOffset() {
+    return getDiagnosticProp<double>('vertical offset');
+  }
+
+  /// Returns the position of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  bool getPosition() {
+    return getDiagnosticProp<bool>('position');
+  }
+
+  /// Returns the semantics of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  bool getSemantics() {
+    return getDiagnosticProp<bool>('semantics');
+  }
+
+  /// Returns the waitDuration of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  Duration getWaitDuration() {
+    return getDiagnosticProp<Duration>('wait duration');
+  }
+
+  /// Returns the showDuration of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  Duration getShowDuration() {
+    return getDiagnosticProp<Duration>('show duration');
+  }
+
+  /// Returns the triggerMode of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  TooltipTriggerMode getTriggerMode() {
+    return getDiagnosticProp<TooltipTriggerMode>('triggerMode');
+  }
+
+  /// Returns the enableFeedback of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  bool getEnableFeedback() {
+    return getDiagnosticProp<bool>('enableFeedback');
+  }
+
+  /// Returns the textAlign of the matched [Tooltip] via [Widget.toDiagnosticsNode]
+  TextAlign getTextAlign() {
+    return getDiagnosticProp<TextAlign>('textAlign');
+  }
+}

--- a/lib/src/widgets/wrap.g.dart
+++ b/lib/src/widgets/wrap.g.dart
@@ -419,3 +419,51 @@ extension WrapMatcher on WidgetMatcher<Wrap> {
         'renderObject', (it) => value == null ? it.isNull() : it.equals(value));
   }
 }
+
+/// Retrieves the [DiagnosticsProperty] of the matched widget with [propName] of type [T]
+extension WrapGetter on WidgetMatcher<Wrap> {
+  /// Returns the direction of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  Axis getDirection() {
+    return getDiagnosticProp<Axis>('direction');
+  }
+
+  /// Returns the alignment of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  WrapAlignment getAlignment() {
+    return getDiagnosticProp<WrapAlignment>('alignment');
+  }
+
+  /// Returns the spacing of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  double getSpacing() {
+    return getDiagnosticProp<double>('spacing');
+  }
+
+  /// Returns the runAlignment of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  WrapAlignment getRunAlignment() {
+    return getDiagnosticProp<WrapAlignment>('runAlignment');
+  }
+
+  /// Returns the runSpacing of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  double getRunSpacing() {
+    return getDiagnosticProp<double>('runSpacing');
+  }
+
+  /// Returns the crossAxisAlignment of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  WrapCrossAlignment getCrossAxisAlignment() {
+    return getDiagnosticProp<WrapCrossAlignment>('crossAxisAlignment');
+  }
+
+  /// Returns the textDirection of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  TextDirection getTextDirection() {
+    return getDiagnosticProp<TextDirection>('textDirection');
+  }
+
+  /// Returns the verticalDirection of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  VerticalDirection getVerticalDirection() {
+    return getDiagnosticProp<VerticalDirection>('verticalDirection');
+  }
+
+  /// Returns the renderObject of the matched [Wrap] via [Widget.toDiagnosticsNode]
+  RenderWrap getRenderObject() {
+    return getDiagnosticProp<RenderWrap>('renderObject');
+  }
+}

--- a/test/selectors/diagnostic_prop_test.dart
+++ b/test/selectors/diagnostic_prop_test.dart
@@ -1,0 +1,123 @@
+// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+
+import '../util/assert_error.dart';
+
+void main() {
+  group('diagnostic prop', () {
+    testWidgets('getDiagnosticProp', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 4),
+        ),
+      );
+
+      final maxLines =
+          spot<Text>().existsOnce().getDiagnosticProp<int>('maxLines');
+      expect(maxLines, 4);
+    });
+
+    testWidgets('generated getDiagnosticProp', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 4),
+        ),
+      );
+
+      final maxLines2 = spot<Text>().existsOnce().getMaxLines();
+      expect(maxLines2, 4);
+    });
+
+    testWidgets('hasDiagnosticProp', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 4),
+        ),
+      );
+
+      spot<Text>()
+          .existsOnce()
+          .hasDiagnosticProp<int>('maxLines', (it) => it.equals(4));
+
+      expect(
+        () => spot<Text>()
+            .existsOnce()
+            .hasDiagnosticProp<int>('maxLines', (it) => it.equals(2)),
+        throwsSpotErrorContaining([
+          'Text with property maxLines',
+          'equals <2>, actual: <4>',
+        ]),
+      );
+    });
+
+    testWidgets('generated hasDiagnosticProp', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 4),
+        ),
+      );
+
+      spot<Text>()
+          .existsOnce()
+          .hasMaxLines(4)
+          .hasMaxLinesWhere((it) => it.equals(4));
+
+      expect(
+        () => spot<Text>().existsOnce().hasMaxLines(2),
+        throwsSpotErrorContaining([
+          'Text with property maxLines',
+          'equals <2>, actual: <4>',
+        ]),
+      );
+    });
+
+    testWidgets('withDiagnosticProp', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 4),
+        ),
+      );
+
+      spot<Text>()
+          .withDiagnosticProp<int>('maxLines', (it) => it.equals(4))
+          .existsOnce();
+
+      expect(
+        () => spot<Text>()
+            .withDiagnosticProp<int>('maxLines', (it) => it.equals(2))
+            .existsOnce(),
+        throwsSpotErrorContaining([
+          'Could not find Text with prop "maxLines" equals <2> in widget tree',
+          'A less specific search (Text) discovered 1 matches!',
+          'Text("a", maxLines: 4,',
+        ]),
+      );
+    });
+
+    testWidgets('generated withDiagnosticProp', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 4),
+        ),
+      );
+
+      spot<Text>().withMaxLines(4).existsOnce();
+      spot<Text>().whereMaxLines((it) => it.equals(4)).existsOnce();
+
+      spot<Text>().withMaxLines(3).doesNotExist();
+      spot<Text>().whereMaxLines((it) => it.equals(3)).doesNotExist();
+
+      expect(
+        () => spot<Text>().withMaxLines(2).existsOnce(),
+        throwsSpotErrorContaining([
+          'Could not find Text with prop "maxLines" equals <2> in widget tree',
+          'A less specific search (Text) discovered 1 matches!',
+          'Text("a", maxLines: 4,',
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Allows reading diagnostic properties values directly. This allows checking of deeper properties without complex `Subject<T>` extensions

```dart
      final value = spot<Text>().existsOnce().getTextHeightBehavior();
      expect(value.leadingDistribution, TextLeadingDistribution.even);
```