### PR TITLE
Automatically pump after act.tap()

### DIFF
--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -34,7 +34,7 @@ class Act {
     selector.snapshot().existsOnce();
 
     return TestAsyncUtils.guard<void>(() async {
-      final binding = WidgetsBinding.instance as TestWidgetsFlutterBinding;
+      final binding = TestWidgetsFlutterBinding.instance;
 
       final editableText = spot<EditableText>().withParent(selector);
       final element = editableText.snapshot().discoveredElement;
@@ -106,7 +106,7 @@ class Act {
           snapshot: snapshot,
         );
 
-        final binding = WidgetsBinding.instance;
+        final binding = TestWidgetsFlutterBinding.instance;
 
         // Finally, tap the widget by sending a down and up event.
         final downEvent = PointerDownEvent(position: centerPosition);
@@ -114,6 +114,8 @@ class Act {
 
         final upEvent = PointerUpEvent(position: centerPosition);
         binding.handlePointerEvent(upEvent);
+
+        await binding.pump();
       });
     });
   }

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -38,6 +38,24 @@ void actTests() {
       expect(i, 2);
     });
 
+    testWidgets('tap pumps a new frame', (tester) async {
+      await tester.pumpWidget(const ColorToggleApp());
+
+      final app = spot<MaterialApp>();
+      app.existsOnce().hasWidgetProp(
+            prop: widgetProp('color', (w) => w.color),
+            match: (it) => it.equals(Colors.blue),
+          );
+      final button = spot<ElevatedButton>();
+
+      await act.tap(button);
+      // without the automatic pump() inside tap(), the color would not have change
+      app.existsOnce().hasWidgetProp(
+            prop: widgetProp('color', (w) => w.color),
+            match: (it) => it.equals(Colors.red),
+          );
+    });
+
     testWidgets('tap must be awaited', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
@@ -290,6 +308,34 @@ void actTests() {
       });
     });
   });
+}
+
+class ColorToggleApp extends StatefulWidget {
+  const ColorToggleApp({super.key});
+
+  @override
+  State<ColorToggleApp> createState() => _ColorToggleAppState();
+}
+
+class _ColorToggleAppState extends State<ColorToggleApp> {
+  bool _red = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      color: _red ? Colors.red : Colors.blue,
+      home: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            setState(() {
+              _red = !_red;
+            });
+          },
+          child: null,
+        ),
+      ),
+    );
+  }
 }
 
 class _NonCartesianWidget extends StatelessWidget {


### PR DESCRIPTION
In 99% of all cases, doing a pump is the right call.

The rare cases where a pump is not required can be achieved using the finder API, or using `binding` directly.