### PR TITLE
Remove unused dependencies

### DIFF
--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -1,4 +1,4 @@
-import 'package:collection/collection.dart';
+import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:spot/spot.dart';
@@ -203,7 +203,7 @@ class AnyText extends LeafRenderObjectWidget {
     textStyle?.debugFillProperties(properties, prefix: 'font_');
 
     // set default value for font_size
-    final textSize = properties.properties.firstWhereOrNull((it) {
+    final textSize = properties.properties.firstOrNullWhere((it) {
       return it.name == 'font_size';
     }) as DoubleProperty?;
     if (textSize != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
   flutter: '>=3.10.0 <4.0.0'
 
 dependencies:
-  collection: ^1.17.0
   checks: ^0.3.0
   dartx: ^1.1.0
   flutter:
@@ -20,10 +19,9 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   nanoid2: ^2.0.0
-  test: ^1.24.0
-  test_api: '>=0.5.0 <0.8.0'
   stack_trace: ^1.11.0
 
 dev_dependencies:
   image: ^4.0.0
   lint: ^2.1.0
+  test: ^1.24.0


### PR DESCRIPTION
This fixes error like this:

```
Because spot ^0.3.2 depends on test_api >=0.3.0 <0.7.0 and spot >=0.4.0 <0.11.0 depends on checks ^0.2.2, spot >=0.3.2 <0.11.0 requires test_api >=0.3.0 <0.7.0 or checks ^0.2.2.
Because checks 0.2.2 depends on test_api >=0.5.0 <0.7.0 and no versions of checks match >0.2.2 <0.3.0, checks ^0.2.2 requires test_api >=0.5.0 <0.7.0.
Thus, spot >=0.3.2 <0.11.0 requires test_api >=0.3.0 <0.7.0.
And because every version of flutter_test from sdk depends on test_api 0.7.0, spot >=0.3.2 <0.11.0 is incompatible with flutter_test from sdk.
So, because wiredash depends on both flutter_test from sdk and spot >=0.3.2 <0.5.0, version solving failed.
```