### PR TITLE
Do not dump widget trees to console

### DIFF
--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -267,7 +267,8 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
           throw QuantityTestFailure(
             message:
                 'Could not find ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
-                'expected at least $minimumConstraint',
+                'expected at least $minimumConstraint.\n'
+                'Check the timeline at the very bottom for more information.',
             significantWidgetTree: significantWidgetTree(),
             snapshot: this,
           );
@@ -278,7 +279,8 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
           throw QuantityTestFailure(
             message:
                 'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
-                'expected at least $minimumConstraint',
+                'expected at least $minimumConstraint.\n'
+                'Check the timeline at the very bottom for more information.',
             significantWidgetTree: significantWidgetTree(),
             snapshot: this,
           );
@@ -290,7 +292,8 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
           throw QuantityTestFailure(
             message:
                 'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
-                'expected at most $maximumConstraint',
+                'expected at most $maximumConstraint.\n'
+                'Check the timeline at the very bottom for more information.',
             significantWidgetTree: significantWidgetTree(),
             snapshot: this,
           );
@@ -309,7 +312,8 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
               throw QuantityTestFailure(
                 message:
                     'Could not find ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
-                    'expected exactly $exactCount',
+                    'expected exactly $exactCount.\n'
+                    'Check the timeline at the very bottom for more information.',
                 significantWidgetTree: significantWidgetTree(),
                 snapshot: this,
               );
@@ -318,7 +322,8 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
               throw QuantityTestFailure(
                 message:
                     'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
-                    'expected exactly $exactCount',
+                    'expected exactly $exactCount.\n'
+                    'Check the timeline at the very bottom for more information.',
                 significantWidgetTree: significantWidgetTree(),
                 snapshot: this,
               );
@@ -329,7 +334,8 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
           throw QuantityTestFailure(
             message:
                 'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
-                'expected between $minimumConstraint and $maximumConstraint',
+                'expected between $minimumConstraint and $maximumConstraint.\n'
+                'Check the timeline at the very bottom for more information.',
             significantWidgetTree: significantWidgetTree(),
             snapshot: this,
           );
@@ -377,9 +383,10 @@ class QuantityTestFailure implements TestFailure {
 
   @override
   String toString() {
-    return '$message\n'
-        '$significantWidgetTree\n'
-        '$message';
+    return '$message';
+    // return '$message\n'
+    //     '$significantWidgetTree\n'
+    //     '$message';
   }
 }
 
@@ -438,7 +445,6 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
         final errorBuilder = StringBuffer();
         errorBuilder.writeln('Could not find $selector in widget tree');
         _dumpWidgetTree(errorBuilder);
-        errorBuilder.writeln('Could not find $selector in widget tree');
         timeline.addEvent(
           eventType: 'Assertion Failed',
           details: errorBuilder.toString(),
@@ -449,7 +455,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
             ],
           ),
         );
-        fail(errorBuilder.toString());
+        fail('Could not find $selector in widget tree');
       }
     }
 
@@ -602,7 +608,6 @@ void _tryMatchingLessSpecificCriteria(WidgetSnapshot snapshot) {
           details: '$errorBuilder\nFound in widget Tree:\n$significantTree',
         );
       }
-      errorBuilder.writeln('\nFound in widget Tree:\n$significantTree');
       fail(errorBuilder.toString());
     }
   }

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -383,10 +383,7 @@ class QuantityTestFailure implements TestFailure {
 
   @override
   String toString() {
-    return '$message';
-    // return '$message\n'
-    //     '$significantWidgetTree\n'
-    //     '$message';
+    return message;
   }
 }
 

--- a/lib/src/timeline/print_console.dart
+++ b/lib/src/timeline/print_console.dart
@@ -1,3 +1,4 @@
+import 'package:ci/ci.dart';
 import 'package:spot/src/timeline/timeline.dart';
 
 /// Extension that adds a method to print the timeline to the console.
@@ -23,10 +24,16 @@ extension ConsoleTimelinePrinter on Timeline {
     final caller = frame != null
         ? 'at ${frame.member} ${frame.uri}:${frame.line}:${frame.column}'
         : 'N/A';
-    final details = event.details.split('\n').first;
+    final details =
+        isCI ? event.details : event.details.split('\n').firstOrNull;
     buffer.writeln('==================== Timeline Event ====================');
     buffer.writeln('Event Type: ${event.eventType}');
-    buffer.writeln('Details: $details');
+    if (details != null) {
+      buffer.writeln('Details: $details');
+    }
+    if (event.description != null) {
+      buffer.writeln('Description: ${event.description}');
+    }
     buffer.writeln('Caller: $caller');
     if (event.screenshot != null) {
       buffer.writeln('Screenshot: file://${event.screenshot!.file.path}');

--- a/test/spot/existence_comparison_test.dart
+++ b/test/spot/existence_comparison_test.dart
@@ -292,7 +292,13 @@ void main() {
             .whereText((text) => text.startsWith('a'))
             .existsExactlyNTimes(3),
         throwsSpotErrorContaining([
-          'Found 4 elements matching Text with prop "data" starts with \'a\' in widget tree, expected exactly 3',
+          'Found 4 elements matching Text with prop "data" starts with \'a\' in widget tree, expected exactly 3.',
+          'Check the timeline at the very bottom for more information.',
+        ]),
+      );
+      expect(
+        timeline.events.last.details,
+        stringContainsInOrder([
           'Text("aa"',
           'Text("ab"',
           'Text("ac"',

--- a/test/spot/exists_once_test.dart
+++ b/test/spot/exists_once_test.dart
@@ -79,44 +79,58 @@ void main() {
     );
     expect(
       () => spot<Text>().existsOnce(),
-      throwsSpotErrorContaining(
-        [
-          'Found 2 elements',
-          'expected exactly 1',
-          '\nWrap(', // at the beginning of the line, common ancestor
-          'Text("World"',
-          'Text("Hello"',
-        ],
-        not: ['root'],
-      ),
+      throwsSpotErrorContaining([
+        'Found 2 elements',
+        'expected exactly 1',
+      ]),
     );
     expect(
-      () => spot<Text>().amount(1).existsOnce(),
-      throwsSpotErrorContaining(
-        [
-          'Found 2 elements',
-          'expected exactly 1',
-          '\nWrap(', // at the beginning of the line, common ancestor
-          'Text("World"',
-          'Text("Hello"',
-        ],
-        not: ['root'],
-      ),
+      timeline.events.last.details,
+      stringContainsInOrder([
+        'Found 2 elements',
+        'expected exactly 1',
+        '\nWrap(', // at the beginning of the line, common ancestor
+        'Text("Hello"',
+        'Text("World"',
+      ]),
     );
+    expect(timeline.events.last.details, isNot(contains('root')));
+    expect(
+      () => spot<Text>().amount(1).existsOnce(),
+      throwsSpotErrorContaining([
+        'Found 2 elements',
+        'expected exactly 1',
+      ]),
+    );
+    expect(
+      timeline.events.last.details,
+      stringContainsInOrder([
+        'Found 2 elements',
+        'expected exactly 1',
+        '\nWrap(', // at the beginning of the line, common ancestor
+        'Text("Hello"',
+        'Text("World"',
+      ]),
+    );
+    expect(timeline.events.last.details, isNot(contains('root')));
     expect(
       () => spot<Text>(parents: [spot<Wrap>()]).amount(1).existsOnce(),
       throwsSpotErrorContaining(
-        [
-          'Found 2 elements',
-          "Wrap ᗕ Text",
-          'expected exactly 1',
-          '\nWrap(', // at the beginning of the line, common ancestor
-          'Text("World"',
-          'Text("Hello"',
-        ],
-        not: ['root'],
+        ['Found 2 elements', "Wrap ᗕ Text", 'expected exactly 1'],
       ),
     );
+    expect(
+      timeline.events.last.details,
+      stringContainsInOrder([
+        'Found 2 elements',
+        "Wrap ᗕ Text",
+        'expected exactly 1',
+        '\nWrap(', // at the beginning of the line, common ancestor
+        'Text("Hello"',
+        'Text("World"',
+      ]),
+    );
+    expect(timeline.events.last.details, isNot(contains('root')));
   });
   testWidgets('existsOnce() finds the correct widget differentiating by props',
       (tester) async {


### PR DESCRIPTION
Big widget trees disrupt the flow more than that they help. This PR moves them from being printed to console to the timline.
On CI, the widget tree is sill printed to keep every possible piece of information in the log.

Before:
![Screen-Shot-2024-11-12-22-06-43 81](https://github.com/user-attachments/assets/76c1d205-e33b-4d7c-af4f-37a0eaa49e4f)
The tree could be 1000s of lines long

After:
![Screen-Shot-2024-11-12-22-06-58 04](https://github.com/user-attachments/assets/c6689989-0223-4ed0-9e53-180aed7b9a72)
![Screen-Shot-2024-11-12-22-05-35 95](https://github.com/user-attachments/assets/c950a5f1-cc14-43a6-bedd-211081a5ab6f)
