### PR TITLE
Always process image when requested

### DIFF
--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -183,22 +183,19 @@ extension TimelineSyncScreenshot on Timeline {
     // At the end of the test, do the actual screenshot processing, because runAsync must be awaited or it crashes
     timeline.addScreenshotProcessing(() async {
       final binding = TestWidgetsFlutterBinding.instance;
-      if (timeline.mode == TimelineMode.live ||
-          !timeline.test.state.result.isPassing) {
-        await binding.runAsync(() async {
-          ui.Image imageToCapture = plainImage;
-          for (final annotator in annotators ?? <ScreenshotAnnotator>[]) {
-            imageToCapture = await annotator.annotate(imageToCapture);
-          }
-          final byteData =
-              await imageToCapture.toByteData(format: ui.ImageByteFormat.png);
-          if (byteData == null) {
-            throw 'Could not take screenshot';
-          }
-          final image = byteData.buffer.asUint8List();
-          file.writeAsBytesSync(image);
-        });
-      }
+      await binding.runAsync(() async {
+        ui.Image imageToCapture = plainImage;
+        for (final annotator in annotators ?? <ScreenshotAnnotator>[]) {
+          imageToCapture = await annotator.annotate(imageToCapture);
+        }
+        final byteData =
+            await imageToCapture.toByteData(format: ui.ImageByteFormat.png);
+        if (byteData == null) {
+          throw 'Could not take screenshot';
+        }
+        final image = byteData.buffer.asUint8List();
+        file.writeAsBytesSync(image);
+      });
 
       plainImage.dispose();
     });

--- a/test/timeline/tap/act_tap_timeline_test_bodies.dart
+++ b/test/timeline/tap/act_tap_timeline_test_bodies.dart
@@ -147,10 +147,19 @@ Example: timeline.mode = $globalTimelineModeToSwitch;
       timeline[start + 3],
       startsWith('Screenshot: file://'),
     );
-    final screenshotPath = timeline[start + 3].split('Screenshot: ').last;
-    final screenshotFile = File.fromUri(Uri.parse(screenshotPath));
-    expect(screenshotFile.existsSync(), isTrue);
-    expect(screenshotFile.readAsBytesSync(), isNotEmpty);
+    final screenshotPath =
+        timeline[start + 3].split('Screenshot: ').last.split('file://').last;
+    final screenshotFile = File(screenshotPath);
+    expect(
+      screenshotFile.existsSync(),
+      isTrue,
+      reason: 'Screenshot file does not exist at $screenshotPath',
+    );
+    expect(
+      screenshotFile.readAsBytesSync(),
+      isNotEmpty,
+      reason: 'file is empty, no data written',
+    );
 
     expect(
       timeline[start + 4],

--- a/test/timeline/tap/act_tap_timeline_test_bodies.dart
+++ b/test/timeline/tap/act_tap_timeline_test_bodies.dart
@@ -147,6 +147,11 @@ Example: timeline.mode = $globalTimelineModeToSwitch;
       timeline[start + 3],
       startsWith('Screenshot: file://'),
     );
+    final screenshotPath = timeline[start + 3].split('Screenshot: ').last;
+    final screenshotFile = File.fromUri(Uri.parse(screenshotPath));
+    expect(screenshotFile.existsSync(), isTrue);
+    expect(screenshotFile.readAsBytesSync(), isNotEmpty);
+
     expect(
       timeline[start + 4],
       startsWith('Timestamp:'),


### PR DESCRIPTION
Always process image when requested. Removes old logic. The timline now decides when to process. Process doesn't run always anymore.