### PR TITLE
Don't dump the tree to console when existsAtLeastNTimes fails

### DIFF
--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -469,16 +469,11 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
           errorBuilder.writeln(candidate.element.widget.toStringDeep());
         });
 
-        errorBuilder
-            .writeln(findCommonAncestor(discoveredElements).toStringDeep());
-
-        errorBuilder.writeln(
-          'Found ${discovered.length} elements matching $selector in widget tree, '
-          'expected at most $max',
-        );
+        final tree = findCommonAncestor(discoveredElements).toStringDeep();
         timeline.addEvent(
           eventType: 'Assertion Failed',
-          details: errorBuilder.toString(),
+          details: '$errorBuilder\n'
+              '$tree',
           color: Colors.red,
           screenshot: timeline.takeScreenshotSync(
             annotators: [


### PR DESCRIPTION
Don't dump the tree to console when existsAtLeastNTimes fails
This is hopefully the last validator that did this