### PR TITLE
Introduce `tapAt` to `act`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ visualizes the steps of a widget test as HTML report with automatic screenshots,
     - [Find offstage widgets](#find-offstage-widgets)
 - [act - tap, drag, type](#act-tap-drag-type-click)
   - [tap](#tap)
+  - [tapAt](#tapAt)
   - [enterText](#entertext)
   - [dragUntilVisible](#draguntilvisible)
   - [more act functions](#more-act-functions)
@@ -527,6 +528,18 @@ Tapping a widget looks almost identical to the `WidgetTester` API but with a few
 - Adds screenshot with crosshair annotation to the Timeline
 - pumps automatically after the tap
 - When multiple widgets are found, it prints a useful error message
+
+### tapAt
+
+```dart
+await act.tapAt(const Offset(100, 100));
+```
+
+Taps the screen (down + up) at `position` on the global coordinate system and pumps a frame.
+
+- Checks that `position` is within the window viewport
+- Lists all widgets reacting to the hitTest in the timeline
+- pumps automatically after the tap
 
 ### enterText
 

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -349,7 +349,7 @@ class Act {
     Offset position, {
     bool throwIfInvisible = true,
   }) {
-    final view = RendererBinding.instance.renderView;
+    final view = RendererBinding.instance.renderViews.first;
     final viewport = Offset.zero & view.size;
     final isInRenderView = viewport.contains(position);
     if (!isInRenderView && throwIfInvisible) {

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -349,12 +349,12 @@ class Act {
     Offset position, {
     bool throwIfInvisible = true,
   }) {
-    final view = RendererBinding.instance.renderViews.first;
-    final viewport = Offset.zero & view.size;
-    final isInRenderView = viewport.contains(position);
+    final HitTestResult result = HitTestResult();
+    TestWidgetsFlutterBinding.instance.hitTestInView(result, position, 0);
+    final isInRenderView = result.path.isNotEmpty;
     if (!isInRenderView && throwIfInvisible) {
       throw TestFailure(
-        "Tried to tapAt position ($position) which is outside the viewport ($viewport).",
+        "Tried to tapAt position ($position) which is outside the viewport (${TestWidgetsFlutterBinding.instance.renderViews.first.size}).",
       );
     }
     return isInRenderView;

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -143,12 +143,11 @@ class Act {
     });
   }
 
-  /// Triggers a tap event at the given position.
-  /// If a [Timeline] is running, an annotated screenshot, indicating the tap
-  /// position, is added to the timeline.
+  /// Taps the screen (down + up) at [position] on the global coordinate system
+  /// and pumps a frame.
   ///
-  /// See also:
-  /// - [Timeline]
+  /// - Checks that [position] is within the viewport.
+  /// - Lists all widgets at that position in the timeline
   Future<void> tapAt(Offset position) async {
     return TestAsyncUtils.guard<void>(() async {
       return _alwaysPropagateDevicePointerEvents(() async {

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -152,7 +152,7 @@ class Act {
   Future<void> tapAt(Offset position) async {
     return TestAsyncUtils.guard<void>(() async {
       final binding = TestWidgetsFlutterBinding.instance;
-      final inRenderView = _validatePositionOnViewBounds(position);
+      final inRenderView = _validatePositionInViewBounds(position);
       if (inRenderView) {
         if (timeline.mode != TimelineMode.off) {
           final screenshot = timeline.takeScreenshotSync(
@@ -345,7 +345,7 @@ class Act {
     return element?.renderObject;
   }
 
-  bool _validatePositionOnViewBounds(Offset position) {
+  bool _validatePositionInViewBounds(Offset position) {
     final HitTestResult result = HitTestResult();
     TestWidgetsFlutterBinding.instance.hitTestInView(result, position, 0);
     final isInRenderView = result.path.isNotEmpty;

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -151,49 +151,51 @@ class Act {
   /// - [Timeline]
   Future<void> tapAt(Offset position) async {
     return TestAsyncUtils.guard<void>(() async {
-      final binding = TestWidgetsFlutterBinding.instance;
-      _validatePositionInViewBounds(position);
-      if (timeline.mode != TimelineMode.off) {
-        final screenshot = timeline.takeScreenshotSync(
-          annotators: [
-            CrosshairAnnotator(centerPosition: position),
-          ],
-        );
-        final HitTestResult result = HitTestResult();
-        // ignore: deprecated_member_use
-        binding.hitTest(result, position);
-        final hits = result.path.map((e) => e.element).toList();
+      return _alwaysPropagateDevicePointerEvents(() async {
+        final binding = TestWidgetsFlutterBinding.instance;
+        _validatePositionInViewBounds(position);
+        if (timeline.mode != TimelineMode.off) {
+          final screenshot = timeline.takeScreenshotSync(
+            annotators: [
+              CrosshairAnnotator(centerPosition: position),
+            ],
+          );
+          final HitTestResult result = HitTestResult();
+          // ignore: deprecated_member_use
+          binding.hitTest(result, position);
+          final hits = result.path.map((e) => e.element).toList();
 
-        final widgetInProject = hits.mapNotNull((e) {
-          if (e == null) return null;
-          final debugWidgetLocation = e.debugWidgetLocation;
-          if (debugWidgetLocation == null ||
-              debugWidgetLocation.isUserCode == false) {
-            return null;
-          }
-          return "${e.widget.toStringShort()} at ${debugWidgetLocation.file.path}";
-        }).joinToString(prefix: '\n- ');
+          final widgetInProject = hits.mapNotNull((e) {
+            if (e == null) return null;
+            final debugWidgetLocation = e.debugWidgetLocation;
+            if (debugWidgetLocation == null ||
+                debugWidgetLocation.isUserCode == false) {
+              return null;
+            }
+            return "${e.widget.toStringShort()} at ${debugWidgetLocation.file.path}";
+          }).joinToString(prefix: '\n- ');
 
-        final allWidgets = hits.mapNotNull((e) {
-          if (e == null) return null;
-          return "${e.widget.toStringShort()} at ${e.debugWidgetLocation?.file.path}";
-        }).joinToString(prefix: '\n- ');
+          final allWidgets = hits.mapNotNull((e) {
+            if (e == null) return null;
+            return "${e.widget.toStringShort()} at ${e.debugWidgetLocation?.file.path}";
+          }).joinToString(prefix: '\n- ');
 
-        timeline.addEvent(
-          eventType: 'TapAt Event',
-          details: 'TapAt $position.\n'
-              'Relevant widgets at position: $widgetInProject'
-              '\n\n'
-              'Widgets at position: $allWidgets',
-          screenshot: screenshot,
-          color: Colors.blue,
-        );
-      }
-      final downEvent = PointerDownEvent(position: position);
-      binding.handlePointerEvent(downEvent);
-      final upEvent = PointerUpEvent(position: position);
-      binding.handlePointerEvent(upEvent);
-      await binding.pump();
+          timeline.addEvent(
+            eventType: 'TapAt Event',
+            details: 'TapAt $position.\n'
+                'Relevant widgets at position: $widgetInProject'
+                '\n\n'
+                'Widgets at position: $allWidgets',
+            screenshot: screenshot,
+            color: Colors.blue,
+          );
+        }
+        final downEvent = PointerDownEvent(position: position);
+        binding.handlePointerEvent(downEvent);
+        final upEvent = PointerUpEvent(position: position);
+        binding.handlePointerEvent(upEvent);
+        await binding.pump();
+      });
     });
   }
 

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -160,9 +160,14 @@ class Act {
               CrosshairAnnotator(centerPosition: position),
             ],
           );
+          final HitTestResult result = HitTestResult();
+          binding.hitTestInView(result, position, 0);
+          final hits = result.path.map((e) => e.element?.widget).toList();
+
           timeline.addEvent(
             eventType: 'TapAt Event',
-            details: 'TapAt $position',
+            details:
+                'TapAt $position. widgets at this position: ${hits.map((e) => e!.toStringShort())}',
             screenshot: screenshot,
             color: Colors.blue,
           );

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -169,6 +169,8 @@ class Act {
         }
         final downEvent = PointerDownEvent(position: position);
         binding.handlePointerEvent(downEvent);
+        final upEvent = PointerUpEvent(position: position);
+        binding.handlePointerEvent(upEvent);
         await binding.pump();
       }
     });

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -349,7 +349,7 @@ class Act {
     Offset position, {
     bool throwIfInvisible = true,
   }) {
-    final view = WidgetsBinding.instance.renderView;
+    final view = RendererBinding.instance.renderView;
     final viewport = Offset.zero & view.size;
     final isInRenderView = viewport.contains(position);
     if (!isInRenderView && throwIfInvisible) {

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -345,14 +345,11 @@ class Act {
     return element?.renderObject;
   }
 
-  bool _validatePositionOnViewBounds(
-    Offset position, {
-    bool throwIfInvisible = true,
-  }) {
+  bool _validatePositionOnViewBounds(Offset position) {
     final HitTestResult result = HitTestResult();
     TestWidgetsFlutterBinding.instance.hitTestInView(result, position, 0);
     final isInRenderView = result.path.isNotEmpty;
-    if (!isInRenderView && throwIfInvisible) {
+    if (!isInRenderView) {
       throw TestFailure(
         "Tried to tapAt position ($position) which is outside the viewport (${TestWidgetsFlutterBinding.instance.renderViews.first.size}).",
       );

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -310,6 +310,27 @@ void actTests() {
       }
       await future;
     });
+    testWidgets(
+      'tapAt ',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Stack(
+              children: [
+                Center(
+                  child: ColoredBox(color: Colors.blue, key: ValueKey(1)),
+                ),
+                Center(
+                  child: ColoredBox(color: Colors.red, key: ValueKey(2)),
+                ),
+              ],
+            ),
+          ),
+        );
+        act.tapAt(const Offset(100, 100));
+        print(timeline.events.last.details);
+      },
+    );
 
     testWidgets('tapAt throws if position not in view (lower bounds)',
         (tester) async {

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -241,120 +241,6 @@ void actTests() {
         ]),
       );
     });
-  });
-
-  group('tapAt', () {
-    testWidgets('tapAt', (tester) async {
-      Offset? tapPosition;
-      await tester.pumpWidget(
-        MaterialApp(
-          home: GestureDetector(
-            onTapDown: (details) => tapPosition = details.globalPosition,
-            child: const ColoredBox(color: Colors.blue),
-          ),
-        ),
-      );
-      await act.tapAt(const Offset(100, 100));
-      expect(tapPosition, const Offset(100, 100));
-    });
-
-    testWidgets('tapAt pumps a new frame', (tester) async {
-      await tester.pumpWidget(const ColorToggleApp());
-
-      final app = spot<MaterialApp>();
-      app.existsOnce().hasWidgetProp(
-            prop: widgetProp('color', (w) => w.color),
-            match: (it) => it.equals(Colors.blue),
-          );
-      final button = spot<ElevatedButton>();
-
-      // Get the RenderBox of the button
-      final renderBox = button.snapshotRenderBox();
-
-      // Calculate the center of the button
-      final center = renderBox.localToGlobal(
-        Offset(renderBox.size.width / 2, renderBox.size.height / 2),
-      );
-      await act.tapAt(center);
-      app.existsOnce().hasWidgetProp(
-            prop: widgetProp('color', (w) => w.color),
-            match: (it) => it.equals(Colors.red),
-          );
-    });
-
-    testWidgets('tapAt must be awaited', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Center(
-            child: ElevatedButton(
-              onPressed: () {},
-              child: const Text('Home'),
-            ),
-          ),
-        ),
-      );
-      final future = act.tapAt(Offset.zero);
-
-      try {
-        TestAsyncUtils.guardSync();
-        fail('Expected to throw');
-      } catch (e) {
-        check(e).isA<FlutterError>().has((it) => it.message, 'message')
-          ..contains(
-            'You must use "await" with all Future-returning test APIs.',
-          )
-          ..contains(
-            'The guarded method "tapAt" from class Act was called from',
-          )
-          ..contains('act_test.dart');
-      }
-      await future;
-    });
-    testWidgets(
-      'tapAt ',
-      (tester) async {
-        await tester.pumpWidget(
-          const MaterialApp(
-            home: Stack(
-              children: [
-                Center(
-                  child: ColoredBox(color: Colors.blue, key: ValueKey(1)),
-                ),
-                Center(
-                  child: ColoredBox(color: Colors.red, key: ValueKey(2)),
-                ),
-              ],
-            ),
-          ),
-        );
-        act.tapAt(const Offset(100, 100));
-        print(timeline.events.last.details);
-      },
-    );
-
-    testWidgets('tapAt throws if position not in view (lower bounds)',
-        (tester) async {
-      await tester.pumpWidget(const MaterialApp());
-
-      await expectLater(
-        () => act.tapAt(const Offset(-100, -100)),
-        throwsSpotErrorContaining([
-          "Tried to tapAt position (Offset(-100.0, -100.0)) which is outside the viewport ",
-        ]),
-      );
-    });
-    testWidgets('tapAt throws if position not in view (upper bounds)',
-        (tester) async {
-      await tester.pumpWidget(const MaterialApp());
-      final viewSize = tester.binding.renderViews.first.size;
-      final outOutside = viewSize.bottomRight(const Offset(100, 100));
-      await expectLater(
-        () => act.tapAt(outOutside),
-        throwsSpotErrorContaining([
-          "Tried to tapAt position ($outOutside) which is outside the viewport ",
-        ]),
-      );
-    });
 
     group('Visibility', () {
       testWidgets(
@@ -494,52 +380,177 @@ void actTests() {
         ]),
       );
     });
+  });
 
-    group('enter text', () {
-      testWidgets('enter text in text form field', (tester) async {
-        await tester.pumpWidget(
-          MaterialApp(home: Material(child: Form(child: TextFormField()))),
-        );
-        await act.enterText(spot<TextFormField>(), 'hello');
-        spotText('hello').existsOnce();
-      });
-
-      testWidgets('enter text in text field', (tester) async {
-        await tester
-            .pumpWidget(const MaterialApp(home: Material(child: TextField())));
-        await act.enterText(spot<TextField>(), 'hello');
-        spotText('hello').existsOnce();
-      });
-
-      testWidgets('spot a non existing widget throws an error', (tester) async {
-        await tester.pumpWidget(
-          const Directionality(
-            textDirection: TextDirection.ltr,
-            child: Text("any text"),
+  group('tapAt', () {
+    testWidgets('tapAt', (tester) async {
+      Offset? tapPosition;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: GestureDetector(
+            onTapDown: (details) => tapPosition = details.globalPosition,
+            child: const ColoredBox(color: Colors.blue),
           ),
-        );
-        await expectLater(
-          () => act.enterText(spot<TextField>(), 'hello'),
-          throwsSpotErrorContaining([
-            "Could not find TextField in widget tree",
-          ]),
-        );
-      });
+        ),
+      );
+      await act.tapAt(const Offset(100, 100));
+      expect(tapPosition, const Offset(100, 100));
+    });
 
-      testWidgets('spot a non editable text throws an error', (tester) async {
-        await tester.pumpWidget(
-          const Directionality(
-            textDirection: TextDirection.ltr,
-            child: Text("any text"),
+    testWidgets('tapAt pumps a new frame', (tester) async {
+      await tester.pumpWidget(const ColorToggleApp());
+
+      final app = spot<MaterialApp>();
+      app.existsOnce().hasWidgetProp(
+            prop: widgetProp('color', (w) => w.color),
+            match: (it) => it.equals(Colors.blue),
+          );
+      final button = spot<ElevatedButton>();
+
+      // Get the RenderBox of the button
+      final renderBox = button.snapshotRenderBox();
+
+      // Calculate the center of the button
+      final center = renderBox.localToGlobal(
+        Offset(renderBox.size.width / 2, renderBox.size.height / 2),
+      );
+      await act.tapAt(center);
+      app.existsOnce().hasWidgetProp(
+            prop: widgetProp('color', (w) => w.color),
+            match: (it) => it.equals(Colors.red),
+          );
+    });
+
+    testWidgets('tapAt must be awaited', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: ElevatedButton(
+              onPressed: () {},
+              child: const Text('Home'),
+            ),
           ),
-        );
-        await expectLater(
-          () => act.enterText(spot<Text>(), 'hello'),
-          throwsSpotErrorContaining([
-            "Widget 'Text' is not a descendant of EditableText.",
-          ]),
-        );
-      });
+        ),
+      );
+      final future = act.tapAt(Offset.zero);
+
+      try {
+        TestAsyncUtils.guardSync();
+        fail('Expected to throw');
+      } catch (e) {
+        check(e).isA<FlutterError>().has((it) => it.message, 'message')
+          ..contains(
+            'You must use "await" with all Future-returning test APIs.',
+          )
+          ..contains(
+            'The guarded method "tapAt" from class Act was called from',
+          )
+          ..contains('act_test.dart');
+      }
+      await future;
+    });
+    testWidgets('tapAt shows items in the timeline', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Stack(
+            fit: StackFit.expand,
+            children: [
+              ColoredBox(color: Colors.blue, key: ValueKey(1)),
+              ColoredBox(color: Colors.red, key: ValueKey(2)),
+              ColoredBox(color: Colors.green, key: ValueKey(3)),
+            ],
+          ),
+        ),
+      );
+      // tap
+      await act.tapAt(const Offset(100, 100));
+      final event = timeline.events.last;
+      expect(event.eventType.label, 'TapAt Event');
+      expect(
+        event.details,
+        stringContainsInOrder([
+          'Relevant widgets at position: ',
+          'ColoredBox-[<3>]',
+          'Stack',
+          'Widgets at position:',
+          'ColoredBox-[<3>]',
+          'Stack',
+          '_Theater',
+        ]),
+      );
+      expect(event.details, isNot(contains('ColoredBox-[<1>]')));
+      expect(event.details, isNot(contains('ColoredBox-[<2>]')));
+    });
+
+    testWidgets('tapAt throws if position not in view (lower bounds)',
+        (tester) async {
+      await tester.pumpWidget(const MaterialApp());
+
+      await expectLater(
+        () => act.tapAt(const Offset(-100, -100)),
+        throwsSpotErrorContaining([
+          "Tried to tapAt position (Offset(-100.0, -100.0)) which is outside the viewport ",
+        ]),
+      );
+    });
+    testWidgets('tapAt throws if position not in view (upper bounds)',
+        (tester) async {
+      await tester.pumpWidget(const MaterialApp());
+      final viewSize = tester.binding.renderViews.first.size;
+      final outOutside = viewSize.bottomRight(const Offset(100, 100));
+      await expectLater(
+        () => act.tapAt(outOutside),
+        throwsSpotErrorContaining([
+          "Tried to tapAt position ($outOutside) which is outside the viewport ",
+        ]),
+      );
+    });
+  });
+
+  group('enter text', () {
+    testWidgets('enter text in text form field', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(home: Material(child: Form(child: TextFormField()))),
+      );
+      await act.enterText(spot<TextFormField>(), 'hello');
+      spotText('hello').existsOnce();
+    });
+
+    testWidgets('enter text in text field', (tester) async {
+      await tester
+          .pumpWidget(const MaterialApp(home: Material(child: TextField())));
+      await act.enterText(spot<TextField>(), 'hello');
+      spotText('hello').existsOnce();
+    });
+
+    testWidgets('spot a non existing widget throws an error', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Text("any text"),
+        ),
+      );
+      await expectLater(
+        () => act.enterText(spot<TextField>(), 'hello'),
+        throwsSpotErrorContaining([
+          "Could not find TextField in widget tree",
+        ]),
+      );
+    });
+
+    testWidgets('spot a non editable text throws an error', (tester) async {
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Text("any text"),
+        ),
+      );
+      await expectLater(
+        () => act.enterText(spot<Text>(), 'hello'),
+        throwsSpotErrorContaining([
+          "Widget 'Text' is not a descendant of EditableText.",
+        ]),
+      );
     });
   });
 }

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -311,13 +311,26 @@ void actTests() {
       await future;
     });
 
-    testWidgets('tapAt throws if position not in view', (tester) async {
+    testWidgets('tapAt throws if position not in view (lower bounds)',
+        (tester) async {
       await tester.pumpWidget(const MaterialApp());
 
       await expectLater(
         () => act.tapAt(const Offset(-100, -100)),
         throwsSpotErrorContaining([
           "Tried to tapAt position (Offset(-100.0, -100.0)) which is outside the viewport ",
+        ]),
+      );
+    });
+    testWidgets('tapAt throws if position not in view (upper bounds)',
+        (tester) async {
+      await tester.pumpWidget(const MaterialApp());
+      final viewSize = tester.binding.renderViews.first.size;
+      final outOutside = viewSize.bottomRight(const Offset(100, 100));
+      await expectLater(
+        () => act.tapAt(outOutside),
+        throwsSpotErrorContaining([
+          "Tried to tapAt position ($outOutside) which is outside the viewport ",
         ]),
       );
     });

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -496,7 +496,9 @@ void actTests() {
     testWidgets('tapAt throws if position not in view (upper bounds)',
         (tester) async {
       await tester.pumpWidget(const MaterialApp());
-      final viewSize = tester.binding.renderViews.first.size;
+
+      // ignore: deprecated_member_use
+      final viewSize = tester.binding.renderView.size;
       final outOutside = viewSize.bottomRight(const Offset(100, 100));
       await expectLater(
         () => act.tapAt(outOutside),


### PR DESCRIPTION
This introduces the `tapAt` method to `act` so it's possible to tap at positions not only selectors.