### PR TITLE
Allow updating timeline events with more information

### DIFF
--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -101,6 +101,7 @@ export 'package:spot/src/timeline/timeline.dart'
     show
         Timeline,
         TimelineEvent,
+        TimelineEventId,
         TimelineEventType,
         TimelineMode,
         globalTimelineMode,

--- a/lib/src/timeline/print_console.dart
+++ b/lib/src/timeline/print_console.dart
@@ -31,9 +31,6 @@ extension ConsoleTimelinePrinter on Timeline {
     if (details != null) {
       buffer.writeln('Details: $details');
     }
-    if (event.description != null) {
-      buffer.writeln('Description: ${event.description}');
-    }
     buffer.writeln('Caller: $caller');
     if (event.screenshot != null) {
       buffer.writeln('Screenshot: file://${event.screenshot!.file.path}');

--- a/lib/src/timeline/timeline.dart
+++ b/lib/src/timeline/timeline.dart
@@ -2,8 +2,10 @@
 
 import 'package:ci/ci.dart';
 import 'package:clock/clock.dart';
+import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nanoid2/nanoid2.dart';
 import 'package:spot/src/screenshot/screenshot.dart';
 import 'package:spot/src/spot/tree_snapshot.dart';
 import 'package:spot/src/timeline/html/print_html.dart';
@@ -130,15 +132,19 @@ class Timeline {
   }
 
   /// Adds an event to the timeline.
-  void addEvent({
+  ///
+  /// Returns a unique identifier for the event which can be used to update
+  /// its details later.
+  TimelineEventId addEvent({
     required String details,
     required String eventType,
     Screenshot? screenshot,
     Frame? initiator,
     Color? color,
-    String? description,
   }) {
+    final id = TimelineEventId.random();
     final event = TimelineEvent(
+      id: id,
       details: details,
       screenshot: screenshot,
       initiator: mostRelevantCaller(
@@ -153,6 +159,73 @@ class Timeline {
       ),
     );
     _addRawEvent(event);
+    return id;
+  }
+
+  /// Removes a previously added event from the timeline.
+  void removeEvent(TimelineEventId id) {
+    _events.removeWhere((event) => event.id == id);
+  }
+
+  /// Allows updating an event with more information after it has been added.
+  ///
+  /// With this message assertions can be added and later updated when they
+  /// failed with additional information about the error.
+  late void Function({
+    required TimelineEventId id,
+    String? eventType,
+    String? details,
+    Screenshot? screenshot,
+    Color? color,
+    String? description,
+  }) updateEvent = _updateEvent;
+
+  void _updateEvent({
+    required TimelineEventId id,
+    Object? eventType = _undefined,
+    Object? details = _undefined,
+    Object? screenshot = _undefined,
+    Object? color = _undefined,
+    Object? description = _undefined,
+  }) {
+    final event = _events.firstOrNullWhere((event) => event.id == id);
+    if (event == null) {
+      throw StateError('Event with id $id not found');
+    }
+
+    if (!event.treeSnapshot.isFromThisFrame) {
+      throw StateError(
+        'You can not update an event after a new frame has been rendered',
+      );
+    }
+
+    // ignore: cast_nullable_to_non_nullable
+    final updatedColor = color == _undefined ? event.color : color as Color;
+    final updatedDetails =
+        // ignore: cast_nullable_to_non_nullable
+        details == _undefined ? event.details : details as String;
+    final updatedEventType = eventType == _undefined
+        ? event.eventType
+        : TimelineEventType(
+            // ignore: cast_nullable_to_non_nullable
+            label: eventType as String,
+            color: updatedColor,
+          );
+    final updatedScreenshot =
+        screenshot == _undefined ? event.screenshot : screenshot as Screenshot?;
+
+    final updated = TimelineEvent(
+      id: id,
+      details: updatedDetails,
+      eventType: updatedEventType,
+      color: updatedColor,
+      screenshot: updatedScreenshot,
+      timestamp: event.timestamp,
+      treeSnapshot: event.treeSnapshot,
+      initiator: event.initiator,
+    );
+    final index = _events.indexOf(event);
+    _events[index] = updated;
   }
 
   /// Adds an event to the timeline.
@@ -255,15 +328,18 @@ class TimelineEventType {
 class TimelineEvent {
   /// Creates a new timeline event.
   const TimelineEvent({
+    required this.id,
     required this.timestamp,
     required this.treeSnapshot,
     required this.details,
     required this.eventType,
-    this.description,
     this.initiator,
     this.screenshot,
     required this.color,
   });
+
+  /// The unique identifier of the event used to update the event later.
+  final TimelineEventId id;
 
   /// The type of event that occurred.
   final TimelineEventType eventType;
@@ -283,11 +359,20 @@ class TimelineEvent {
   /// The frame that initiated the event.
   final Frame? initiator;
 
-  /// Custom plain-text information about the event.
-  final String? description;
-
   /// The color of the event.
   final Color color;
+}
+
+/// A unique identifier for a [TimelineEvent].
+class TimelineEventId {
+  /// Creates a fixed id for a [TimelineEvent].
+  const TimelineEventId(this.value);
+
+  /// Creates a new unique id for a [TimelineEvent].
+  TimelineEventId.random() : value = nanoid();
+
+  /// The actual value of the id.
+  final String value;
 }
 
 /// The mode of the [Timeline] and how it should be generated
@@ -327,3 +412,5 @@ Frame? mostRelevantCaller({Trace? trace, Frame? fallback}) {
 
   return preferredFrame;
 }
+
+const Object _undefined = Object();

--- a/lib/src/timeline/timeline.dart
+++ b/lib/src/timeline/timeline.dart
@@ -219,7 +219,11 @@ final class _Timeline extends Timeline {
   /// Removes a previously added event from the timeline.
   @override
   void removeEvent(TimelineEventId id) {
-    _events.removeWhere((event) => event.id == id);
+    final event = _events.firstOrNullWhere((event) => event.id == id);
+    if (event == null) {
+      throw StateError("Event with id '${id.value}' not found");
+    }
+    _events.remove(event);
   }
 
   @override
@@ -233,7 +237,7 @@ final class _Timeline extends Timeline {
   }) {
     final event = _events.firstOrNullWhere((event) => event.id == id);
     if (event == null) {
-      throw StateError('Event with id $id not found');
+      throw StateError("Event with id '${id.value}' not found");
     }
 
     if (!event.treeSnapshot.isFromThisFrame) {
@@ -406,6 +410,11 @@ class TimelineEvent {
 
   /// The color of the event.
   final Color color;
+
+  @override
+  String toString() {
+    return 'TimelineEvent{id: $id, eventType: $eventType, screenshot: $screenshot, details: $details, timestamp: $timestamp, treeSnapshot: $treeSnapshot, initiator: $initiator, color: $color}';
+  }
 }
 
 /// A unique identifier for a [TimelineEvent].
@@ -418,6 +427,21 @@ class TimelineEventId {
 
   /// The actual value of the id.
   final String value;
+
+  @override
+  String toString() {
+    return value;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TimelineEventId &&
+          runtimeType == other.runtimeType &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 /// The mode of the [Timeline] and how it should be generated

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   test_api: ">=0.5.0 <0.8.0"
 
 dev_dependencies:
-  image: ^4.0.0
+  image: ">=4.0.0 <4.4.0"
   lint: ^2.1.0
   test: ^1.24.0
   test_process: ^2.1.0

--- a/test/timeline/timeline_test.dart
+++ b/test/timeline/timeline_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+
+void main() {
+  testWidgets('Add event', (_) async {
+    final id = timeline.addEvent(
+      details: 'details',
+      eventType: 'type 1',
+      color: Colors.indigo,
+    );
+    final latestEvent = timeline.events.last;
+    expect(latestEvent.details, 'details');
+    expect(latestEvent.eventType.label, 'type 1');
+    expect(latestEvent.eventType.color, Colors.indigo);
+    expect(latestEvent.id, id);
+  });
+
+  testWidgets('Remove event', (_) async {
+    final id = timeline.addEvent(
+      details: 'details',
+      eventType: 'type 1',
+    );
+    expect(timeline.events, hasLength(1));
+
+    timeline.removeEvent(id);
+    expect(timeline.events, isEmpty);
+  });
+
+  testWidgets('Update event', (_) async {
+    final id = timeline.addEvent(
+      details: 'a',
+      eventType: 'type 1',
+      color: Colors.yellow,
+    );
+    final a = timeline.events.first;
+    expect(a.id, id);
+    expect(a.details, 'a');
+    expect(a.eventType.label, 'type 1');
+    expect(a.eventType.color, Colors.yellow);
+
+    timeline.updateEvent(
+      id: id,
+      details: 'b',
+      eventType: 'type 2',
+      description: 'asc',
+      color: Colors.red,
+    );
+    final b = timeline.events.first;
+    expect(b.id, id);
+    expect(b.details, 'b');
+    expect(b.eventType.label, 'type 2');
+    expect(b.eventType.color, Colors.red);
+    expect(timeline.events, hasLength(1));
+  });
+}

--- a/test/timeline/timeline_test.dart
+++ b/test/timeline/timeline_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: prefer_const_constructors
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
@@ -27,6 +29,19 @@ void main() {
     expect(timeline.events, isEmpty);
   });
 
+  testWidgets('Remove unknown event', (_) async {
+    expect(
+      () => timeline.removeEvent(const TimelineEventId('a')),
+      throwsA(
+        isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains("Event with id 'a' not found"),
+        ),
+      ),
+    );
+  });
+
   testWidgets('Update event', (_) async {
     final id = timeline.addEvent(
       details: 'a',
@@ -52,5 +67,26 @@ void main() {
     expect(b.eventType.label, 'type 2');
     expect(b.eventType.color, Colors.red);
     expect(timeline.events, hasLength(1));
+  });
+
+  testWidgets('Update unknown event', (_) async {
+    expect(
+      () => timeline.updateEvent(id: const TimelineEventId('a')),
+      throwsA(
+        isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains("Event with id 'a' not found"),
+        ),
+      ),
+    );
+  });
+
+  test('TimelineEventId.toString()', () {
+    expect(TimelineEventId('a').toString(), 'a');
+  });
+  test('TimelineEventId.equals', () {
+    expect(TimelineEventId('a'), TimelineEventId('a'));
+    expect(TimelineEventId('a'), isNot(TimelineEventId('b')));
   });
 }


### PR DESCRIPTION
Often the timeline has two or more similar event entries for the same actual event. 

```
1. Assert something
2. The assertion when wrong, here's the actual value
```

```
1. Assert something
2. The assertion succeeded
```

### Act actions

```
1. trigger the action
2. do a check
4. do another check
5. Check failed!
```

```
1. trigger the action
2. do a check
4. do another check
5. The action was performed
```

The new `timeline.updateEvent()` methods allows updating events so that actions can first declare their intention and then continously add more content and eventually change their type to an error.