### PR TITLE
Export stateProp

### DIFF
--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -55,6 +55,7 @@ export 'package:spot/src/spot/props.dart'
         WidgetSelectorProp,
         elementProp,
         renderObjectProp,
+        stateProp,
         widgetProp;
 export 'package:spot/src/spot/selectors.dart'
     show

--- a/test/spot/read_prop_test.dart
+++ b/test/spot/read_prop_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
-import 'package:spot/src/spot/props.dart';
 
 void main() {
   group('WidgetSelector', () {


### PR DESCRIPTION
Fixes #86

Add `stateProp` to the export list in `lib/spot.dart`.