### PR TITLE
Use local paths for screenshot images

### DIFF
--- a/lib/src/timeline/html/print_html.dart
+++ b/lib/src/timeline/html/print_html.dart
@@ -55,7 +55,6 @@ extension HtmlTimelinePrinter on Timeline {
 
     final events = spotTempDir.file('events.json');
     final jsonTimelineEvents = this.events.map((e) {
-      
       // save screenshots relative to the events.json file in screenshots/
       if (e.screenshot != null) {
         final name = e.screenshot!.file.name;
@@ -67,7 +66,9 @@ extension HtmlTimelinePrinter on Timeline {
         eventType: e.eventType.label,
         details: e.details,
         timestamp: e.timestamp.toIso8601String(),
-        screenshotUrl: e.screenshot != null ? './$screenshotsDirName/${e.screenshot!.file.name}' : null,
+        screenshotUrl: e.screenshot != null
+            ? './$screenshotsDirName/${e.screenshot!.file.name}'
+            : null,
         color: e.color == flt.Colors.grey
             ? null
             // ignore: deprecated_member_use

--- a/lib/src/timeline/html/print_html.dart
+++ b/lib/src/timeline/html/print_html.dart
@@ -48,16 +48,18 @@ extension HtmlTimelinePrinter on Timeline {
       spotTempDir.deleteSync(recursive: true);
     }
     spotTempDir.createSync(recursive: true);
-    final screenshotsDir = spotTempDir.directory('screenshots');
+
+    const screenshotsDirName = 'screenshots';
+    final screenshotsDir = spotTempDir.directory(screenshotsDirName);
     screenshotsDir.createSync(recursive: true);
 
     final events = spotTempDir.file('events.json');
     final jsonTimelineEvents = this.events.map((e) {
+      
       // save screenshots relative to the events.json file in screenshots/
-      File? screenshotFile;
       if (e.screenshot != null) {
         final name = e.screenshot!.file.name;
-        screenshotFile = screenshotsDir.file(name);
+        final screenshotFile = screenshotsDir.file(name);
         screenshotFile.writeAsBytesSync(e.screenshot!.file.readAsBytesSync());
       }
 
@@ -65,7 +67,7 @@ extension HtmlTimelinePrinter on Timeline {
         eventType: e.eventType.label,
         details: e.details,
         timestamp: e.timestamp.toIso8601String(),
-        screenshotUrl: screenshotFile?.path,
+        screenshotUrl: e.screenshot != null ? './$screenshotsDirName/${e.screenshot!.file.name}' : null,
         color: e.color == flt.Colors.grey
             ? null
             // ignore: deprecated_member_use

--- a/lib/src/timeline/html/render_timeline.dart
+++ b/lib/src/timeline/html/render_timeline.dart
@@ -48,9 +48,10 @@ Future<String> renderTimelineWithJaspr(
         timelineEvents: events,
       ),
     ),
+    standalone: true,
   );
 
-  return html;
+  return '<!DOCTYPE html>\n$html';
 }
 
 /// Returns the test name including the group hierarchy.

--- a/lib/src/timeline/html/sources/script.js.g.dart
+++ b/lib/src/timeline/html/sources/script.js.g.dart
@@ -4,7 +4,6 @@
 /// Generate it with `dart run tool/compile_js.dart`
 /// Using Dart SDK version: 3.6.0 (stable) (Thu Dec 5 07:46:24 2024 -0800) on "macos_arm64"
 
-
 // language=javascript
 const String timelineJS = r'''
 (function dartProgram(){function copyProperties(a,b){var s=Object.keys(a)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  jaspr: ^0.15.1
+  jaspr: ^0.15.2
   meta: ^1.8.0
   nanoid2: ^2.0.0
   stack_trace: ^1.11.0


### PR DESCRIPTION
Currently the screenshot images in the timeline use absolute paths, which breaks the timeline if its moved or copied somewhere else than the original directory.

This makes all paths relative.

---

The change to jaspr makes it so that no `<base>` tag is rendered, otherwise this would break relative file paths.