### PR TITLE
Improve shorthand errors

### DIFF
--- a/lib/src/spot/diagnostic_props.dart
+++ b/lib/src/spot/diagnostic_props.dart
@@ -54,14 +54,12 @@ extension DiagnosticPropWidgetSelector<W extends Widget> on WidgetSelector<W> {
             .getProperties()
             .firstOrNullWhere((e) => e.name == propName);
 
-        final unconstrainedSelector =
-            overrideQuantityConstraint(QuantityConstraint.unconstrained);
         final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
 
         void condition(Subject<T?> subject) {
           subject.context.nest<T>(
             () => [
-              unconstrainedSelector.toStringBreadcrumb(),
+              removeQuantityConstraints().toStringBreadcrumb(),
               'with prop "$propName"',
             ],
             (value) {
@@ -124,14 +122,11 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
         .getProperties()
         .firstOrNullWhere((e) => e.name == propName);
 
-    final unconstrainedSelector =
-        selector.overrideQuantityConstraint(QuantityConstraint.unconstrained);
     final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
-
     void condition(Subject<T?> subject) {
       subject.context.nest<T>(
         () => [
-          unconstrainedSelector.toStringBreadcrumb(),
+          selector.removeQuantityConstraints().toStringBreadcrumb(),
           'with property $propName',
         ],
         (value) {

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -677,7 +677,7 @@ extension SelectorToSnapshot<W extends Widget> on WidgetSelector<W> {
 extension ReadSingleSnapshot<W extends Widget> on WidgetSelector<W> {
   /// Convenience getter to access the [Widget] when evaluating the [WidgetSelector]
   W snapshotWidget() {
-    return snapshot_file.snapshot(this).single.widget;
+    return snapshot_file.snapshot(this).existsOnce().widget;
   }
 
   /// Convenience getter to access the [State] of a Widget found by the [WidgetSelector]

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -770,7 +770,7 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   MultiWidgetMatcher<W> existsAtLeastOnce() {
     final atLeastOne =
         copyWith(quantityConstraint: const QuantityConstraint.atLeast(1));
-    return snapshot(this).existsAtLeastOnce();
+    return snapshot(atLeastOne).existsAtLeastOnce();
   }
 
   /// Asserts that at most one widget of type [W] exists.
@@ -790,8 +790,8 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtLeastNTimes] asserts that at least `n` widgets of type [W] exist.
   /// - [existsAtMostNTimes] asserts that at most `n` widgets of type [W] exist.
   WidgetMatcher<W> existsAtMostOnce() {
-    // final atMostOne = copyWith(quantityConstraint: QuantityConstraint.single);
-    return snapshot(this).existsAtMostOnce();
+    final atMostOne = copyWith(quantityConstraint: QuantityConstraint.single);
+    return snapshot(atMostOne).existsAtMostOnce();
   }
 
   /// Asserts that no widgets of type [W] exist.
@@ -812,7 +812,7 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtMostNTimes] asserts that at most `n` widgets of type [W] exist.
   void doesNotExist() {
     final none = copyWith(quantityConstraint: QuantityConstraint.zero);
-    snapshot(this).doesNotExist();
+    snapshot(none).doesNotExist();
   }
 
   /// Asserts that exactly one widget of type [W] exists.
@@ -831,7 +831,7 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   WidgetMatcher<W> existsOnce() {
     final one =
         copyWith(quantityConstraint: const QuantityConstraint.exactly(1));
-    return snapshot(this).existsOnce();
+    return snapshot(one).existsOnce();
   }
 
   /// Asserts that exactly [n] widgets of type [W] exist.
@@ -850,7 +850,7 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   MultiWidgetMatcher<W> existsExactlyNTimes(int n) {
     final exactlyNTimes =
         copyWith(quantityConstraint: QuantityConstraint.exactly(n));
-    return snapshot(this).existsExactlyNTimes(n);
+    return snapshot(exactlyNTimes).existsExactlyNTimes(n);
   }
 
   /// Asserts that at least [n] widgets of type [W] exist.
@@ -868,7 +868,7 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtMostNTimes] asserts that at most [n] widgets of type [W] exist.
   MultiWidgetMatcher<W> existsAtLeastNTimes(int n) {
     final atLeast = copyWith(quantityConstraint: QuantityConstraint.atLeast(n));
-    return snapshot(this).existsAtLeastNTimes(n);
+    return snapshot(atLeast).existsAtLeastNTimes(n);
   }
 
   /// Asserts that at most [n] widgets of type [W] exist.
@@ -886,7 +886,7 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtMostOnce] asserts that at most one widget exists.
   MultiWidgetMatcher<W> existsAtMostNTimes(int n) {
     final atMostN = copyWith(quantityConstraint: QuantityConstraint.atMost(n));
-    return snapshot(this).existsAtMostNTimes(n);
+    return snapshot(atMostN).existsAtMostNTimes(n);
   }
 }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -768,18 +768,9 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtMostOnce] asserts that at most one widget exists.
   /// - [existsAtMostNTimes] asserts that at most `n` widgets of type [W] exist.
   MultiWidgetMatcher<W> existsAtLeastOnce() {
-    if (timeline.mode != TimelineMode.off) {
-      final screenshot = timeline.takeScreenshotSync();
-      timeline.addEvent(
-        eventType: 'Assertion',
-        screenshot: screenshot,
-        details: '${toStringBreadcrumb()} exists at least once.',
-        color: Colors.grey,
-      );
-    }
     final atLeastOne =
         copyWith(quantityConstraint: const QuantityConstraint.atLeast(1));
-    return snapshot(atLeastOne).multi;
+    return snapshot(this).existsAtLeastOnce();
   }
 
   /// Asserts that at most one widget of type [W] exists.
@@ -799,17 +790,8 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtLeastNTimes] asserts that at least `n` widgets of type [W] exist.
   /// - [existsAtMostNTimes] asserts that at most `n` widgets of type [W] exist.
   WidgetMatcher<W> existsAtMostOnce() {
-    if (timeline.mode != TimelineMode.off) {
-      final screenshot = timeline.takeScreenshotSync();
-      timeline.addEvent(
-        eventType: 'Assertion',
-        screenshot: screenshot,
-        details: '${toStringBreadcrumb()} exists at most once.',
-        color: Colors.grey,
-      );
-    }
-    final atMostOne = copyWith(quantityConstraint: QuantityConstraint.single);
-    return snapshot(atMostOne).single;
+    // final atMostOne = copyWith(quantityConstraint: QuantityConstraint.single);
+    return snapshot(this).existsAtMostOnce();
   }
 
   /// Asserts that no widgets of type [W] exist.
@@ -829,17 +811,8 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtMostOnce] asserts that at most one widget exists.
   /// - [existsAtMostNTimes] asserts that at most `n` widgets of type [W] exist.
   void doesNotExist() {
-    if (timeline.mode != TimelineMode.off) {
-      final screenshot = timeline.takeScreenshotSync();
-      timeline.addEvent(
-        eventType: 'Assertion',
-        screenshot: screenshot,
-        details: '${toStringBreadcrumb()} does not exist.',
-        color: Colors.grey,
-      );
-    }
     final none = copyWith(quantityConstraint: QuantityConstraint.zero);
-    snapshot(none);
+    snapshot(this).doesNotExist();
   }
 
   /// Asserts that exactly one widget of type [W] exists.
@@ -858,23 +831,7 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   WidgetMatcher<W> existsOnce() {
     final one =
         copyWith(quantityConstraint: const QuantityConstraint.exactly(1));
-    final widgetSnapshot = snapshot(one);
-
-    if (timeline.mode != TimelineMode.off) {
-      final screenshot = timeline.takeScreenshotSync(
-        annotators: [
-          HighlightAnnotator.elements(widgetSnapshot.discoveredElements),
-        ],
-      );
-      timeline.addEvent(
-        eventType: 'Assertion',
-        screenshot: screenshot,
-        details: '${toStringBreadcrumb()} exists once.',
-        color: Colors.grey,
-      );
-    }
-
-    return widgetSnapshot.single;
+    return snapshot(this).existsOnce();
   }
 
   /// Asserts that exactly [n] widgets of type [W] exist.
@@ -893,7 +850,7 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   MultiWidgetMatcher<W> existsExactlyNTimes(int n) {
     final exactlyNTimes =
         copyWith(quantityConstraint: QuantityConstraint.exactly(n));
-    return snapshot(exactlyNTimes).multi;
+    return snapshot(this).existsExactlyNTimes(n);
   }
 
   /// Asserts that at least [n] widgets of type [W] exist.
@@ -910,17 +867,8 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtMostOnce] asserts that at most one widget exists.
   /// - [existsAtMostNTimes] asserts that at most [n] widgets of type [W] exist.
   MultiWidgetMatcher<W> existsAtLeastNTimes(int n) {
-    if (timeline.mode != TimelineMode.off) {
-      final screenshot = timeline.takeScreenshotSync();
-      timeline.addEvent(
-        eventType: 'Assertion',
-        screenshot: screenshot,
-        details: '${toStringBreadcrumb()} exists at least $n times.',
-        color: Colors.grey,
-      );
-    }
     final atLeast = copyWith(quantityConstraint: QuantityConstraint.atLeast(n));
-    return snapshot(atLeast).multi;
+    return snapshot(this).existsAtLeastNTimes(n);
   }
 
   /// Asserts that at most [n] widgets of type [W] exist.
@@ -937,17 +885,8 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
   /// - [existsAtLeastNTimes] asserts that at least [n] widgets of type [W] exist.
   /// - [existsAtMostOnce] asserts that at most one widget exists.
   MultiWidgetMatcher<W> existsAtMostNTimes(int n) {
-    if (timeline.mode != TimelineMode.off) {
-      final screenshot = timeline.takeScreenshotSync();
-      timeline.addEvent(
-        eventType: 'Assertion',
-        screenshot: screenshot,
-        details: '${toStringBreadcrumb()} exists at most $n times.',
-        color: Colors.grey,
-      );
-    }
     final atMostN = copyWith(quantityConstraint: QuantityConstraint.atMost(n));
-    return snapshot(atMostN).multi;
+    return snapshot(this).existsAtMostNTimes(n);
   }
 }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -701,18 +701,14 @@ extension ReadSingleSnapshot<W extends Widget> on WidgetSelector<W> {
 
   /// Convenience getter to access the [RenderObject] when evaluating the [WidgetSelector]
   RenderObject snapshotRenderObject() {
-    // There is not a single Element in the Flutter SDK that returns null for `renderObject`.
-    // So we can safely assume that this cast never fails.
-    return snapshot_file.snapshot(this).single.element.renderObject!;
+    final WidgetSnapshot snapshot = snapshot_file.snapshot(this)..existsOnce();
+    return snapshot.discoveredRenderObject;
   }
 
   /// Convenience getter to access the [RenderBox] when evaluating the [WidgetSelector]
   RenderBox snapshotRenderBox() {
-    final renderObject = snapshotRenderObject();
-    if (renderObject is! RenderBox) {
-      throw StateError('RenderObject $renderObject is not a RenderBox');
-    }
-    return renderObject;
+    final WidgetSnapshot snapshot = snapshot_file.snapshot(this)..existsOnce();
+    return snapshot.discoveredRenderBox;
   }
 }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -695,7 +695,8 @@ extension ReadSingleSnapshot<W extends Widget> on WidgetSelector<W> {
 
   /// Convenience getter to access the [Element] when evaluating the [WidgetSelector]
   Element snapshotElement() {
-    return snapshot_file.snapshot(this).single.element;
+    final snapshot = snapshot_file.snapshot(this)..existsOnce();
+    return snapshot.discoveredElement!;
   }
 
   /// Convenience getter to access the [RenderObject] when evaluating the [WidgetSelector]

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -682,7 +682,7 @@ extension ReadSingleSnapshot<W extends Widget> on WidgetSelector<W> {
 
   /// Convenience getter to access the [State] of a Widget found by the [WidgetSelector]
   S snapshotState<S extends State>() {
-    final matcher = snapshot_file.snapshot(this).single;
+    final matcher = snapshot_file.snapshot(this).existsOnce();
     final element = matcher.element;
     if (element is! StatefulElement) {
       throw StateError(

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -735,6 +735,12 @@ extension QuantitySelectors<W extends Widget> on WidgetSelector<W> {
     return self.overrideQuantityConstraint(QuantityConstraint.atMost(n));
   }
 
+  /// Sets the selector to match at most one widget.
+  @useResult
+  WidgetSelector<W> removeQuantityConstraints() {
+    return self.overrideQuantityConstraint(QuantityConstraint.unconstrained);
+  }
+
   /// Overrides the current quantity constraint with a new [constraint].
   ///
   /// This method allows for more flexible control over the number of widgets

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -2,7 +2,6 @@ import 'package:dartx/dartx.dart';
 import 'package:flutter/material.dart';
 import 'package:spot/spot.dart';
 import 'package:spot/src/checks/checks_nullability.dart';
-import 'package:spot/src/screenshot/screenshot_annotator.dart';
 import 'package:spot/src/spot/snapshot.dart' as snapshot_file show snapshot;
 import 'package:spot/src/spot/snapshot.dart';
 import 'package:spot/src/spot/text/any_text.dart';

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -535,7 +535,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
   /// the constraints.
   WidgetSnapshot<W> _exists({int? min, int? max}) {
     assert(min != null || max != null);
-    assert(min == null || min > 0);
+    assert(min == null || min >= 0);
     assert(max == null || max >= 0);
     assert(min == null || max == null || min <= max);
 

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -399,8 +399,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
     if (timeline.mode != TimelineMode.off) {
       timeline.addEvent(
         eventType: 'Assertion',
-        details:
-            'Found ${discovered.length} widgets matching $selector expected none.',
+        details: '${selector.removeQuantityConstraints()} does not exist.',
         color: Colors.grey,
         screenshot: timeline.takeScreenshotSync(
           annotators: [
@@ -417,8 +416,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
     if (timeline.mode != TimelineMode.off) {
       timeline.addEvent(
         eventType: 'Assertion',
-        details:
-            'Found ${discovered.length} widgets matching $selector expected only one.',
+        details: '${selector.removeQuantityConstraints()} exists once.',
         color: Colors.grey,
         screenshot: timeline.takeScreenshotSync(
           annotators: [
@@ -437,7 +435,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
       timeline.addEvent(
         eventType: 'Assertion',
         details:
-            'Found ${discovered.length} widgets matching $selector expected at least one.',
+            '${selector.removeQuantityConstraints()} exists at least once, found ${discovered.length}.',
         color: Colors.grey,
         screenshot: timeline.takeScreenshotSync(
           annotators: [
@@ -456,7 +454,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
       timeline.addEvent(
         eventType: 'Assertion',
         details:
-            'Found ${discovered.length} widgets matching $selector expected at most one.',
+            '${selector.removeQuantityConstraints()} exists at most once, found ${discovered.length}.',
         color: Colors.grey,
         screenshot: timeline.takeScreenshotSync(
           annotators: [
@@ -475,7 +473,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
       timeline.addEvent(
         eventType: 'Assertion',
         details:
-            'Found ${discovered.length} widgets matching $selector expected exactly $n.',
+            '${selector.removeQuantityConstraints()} exists exactly $n times, found ${discovered.length}.',
         color: Colors.grey,
         screenshot: timeline.takeScreenshotSync(
           annotators: [
@@ -494,7 +492,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
       timeline.addEvent(
         eventType: 'Assertion',
         details:
-            'Found ${discovered.length} widgets matching $selector expected at least $n.',
+            '${selector.removeQuantityConstraints()} exists at least $n times, found ${discovered.length}.',
         color: Colors.grey,
         screenshot: timeline.takeScreenshotSync(
           annotators: [
@@ -513,7 +511,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
       timeline.addEvent(
         eventType: 'Assertion',
         details:
-            'Found ${discovered.length} widgets matching $selector expected at most $n.',
+            '${selector.removeQuantityConstraints()} exists at most $n times, found ${discovered.length}.',
         color: Colors.grey,
         screenshot: timeline.takeScreenshotSync(
           annotators: [

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -254,8 +254,7 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
       final minimumConstraint = selector.quantityConstraint.min;
       final maximumConstraint = selector.quantityConstraint.max;
 
-      final unconstrainedSelector =
-          selector.overrideQuantityConstraint(QuantityConstraint.unconstrained);
+      final unconstrainedSelector = selector.removeQuantityConstraints();
 
       String significantWidgetTree() {
         final set = discoveredElements.toSet();
@@ -632,8 +631,7 @@ void _tryMatchingLessSpecificCriteria(WidgetSnapshot snapshot) {
   final selector = snapshot.selector;
   final count = snapshot.discovered.length;
   final errorBuilder = StringBuffer();
-  final unconstrainedSelector =
-      selector.overrideQuantityConstraint(QuantityConstraint.unconstrained);
+  final unconstrainedSelector = selector.removeQuantityConstraints();
   for (final lessSpecificSelector
       in unconstrainedSelector.lessSpecificSelectors()) {
     late final WidgetSnapshot lessSpecificSnapshot;
@@ -645,8 +643,7 @@ void _tryMatchingLessSpecificCriteria(WidgetSnapshot snapshot) {
     final lessSpecificCount = lessSpecificSnapshot.discovered.length;
     final minimumConstraint = selector.quantityConstraint.min;
     final maximumConstraint = selector.quantityConstraint.max;
-    final unconstrainedSelector =
-        selector.overrideQuantityConstraint(QuantityConstraint.unconstrained);
+    final unconstrainedSelector = selector.removeQuantityConstraints();
 
     // error that selector could not be found, but instead spot detected lessSpecificSnapshot, which might be useful
     if (lessSpecificCount > count) {

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -395,28 +395,136 @@ class QuantityTestFailure implements TestFailure {
 /// exist in the widget tree based on the snapshot's selector.
 extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
   /// Asserts that no widgets of type [W] exist.
-  void doesNotExist() => _exists(max: 0);
+  void doesNotExist() {
+    _exists(max: 0);
+    if (timeline.mode != TimelineMode.off) {
+      timeline.addEvent(
+        eventType: 'Assertion',
+        details:
+            'Found ${discovered.length} widgets matching $selector expected none.',
+        color: Colors.grey,
+        screenshot: timeline.takeScreenshotSync(
+          annotators: [
+            HighlightAnnotator.elements(discoveredElements),
+          ],
+        ),
+      );
+    }
+  }
 
   /// Asserts that exactly one widget of type [W] exists.
-  WidgetMatcher<W> existsOnce() =>
-      WidgetMatcher.fromSnapshot(_exists(min: 1, max: 1));
+  WidgetMatcher<W> existsOnce() {
+    final snapshot = _exists(min: 1, max: 1);
+    if (timeline.mode != TimelineMode.off) {
+      timeline.addEvent(
+        eventType: 'Assertion',
+        details:
+            'Found ${discovered.length} widgets matching $selector expected only one.',
+        color: Colors.grey,
+        screenshot: timeline.takeScreenshotSync(
+          annotators: [
+            HighlightAnnotator.elements(discoveredElements),
+          ],
+        ),
+      );
+    }
+    return WidgetMatcher.fromSnapshot(snapshot);
+  }
 
   /// Asserts that at least one widget of type [W] exists.
-  MultiWidgetMatcher<W> existsAtLeastOnce() => _exists(min: 1).multi;
+  MultiWidgetMatcher<W> existsAtLeastOnce() {
+    final snapshot = _exists(min: 1);
+    if (timeline.mode != TimelineMode.off) {
+      timeline.addEvent(
+        eventType: 'Assertion',
+        details:
+            'Found ${discovered.length} widgets matching $selector expected at least one.',
+        color: Colors.grey,
+        screenshot: timeline.takeScreenshotSync(
+          annotators: [
+            HighlightAnnotator.elements(discoveredElements),
+          ],
+        ),
+      );
+    }
+    return snapshot.multi;
+  }
 
   /// Asserts that at most one widget of type [W] exists.
-  WidgetMatcher<W> existsAtMostOnce() =>
-      WidgetMatcher.fromSnapshot(_exists(max: 1));
+  WidgetMatcher<W> existsAtMostOnce() {
+    final snapshot = _exists(max: 1);
+    if (timeline.mode != TimelineMode.off) {
+      timeline.addEvent(
+        eventType: 'Assertion',
+        details:
+            'Found ${discovered.length} widgets matching $selector expected at most one.',
+        color: Colors.grey,
+        screenshot: timeline.takeScreenshotSync(
+          annotators: [
+            HighlightAnnotator.elements(discoveredElements),
+          ],
+        ),
+      );
+    }
+    return WidgetMatcher.fromSnapshot(snapshot);
+  }
 
   /// Asserts that exactly [n] widgets of type [W] exist.
-  MultiWidgetMatcher<W> existsExactlyNTimes(int n) =>
-      _exists(min: n, max: n).multi;
+  MultiWidgetMatcher<W> existsExactlyNTimes(int n) {
+    final snapshot = _exists(min: n, max: n);
+    if (timeline.mode != TimelineMode.off) {
+      timeline.addEvent(
+        eventType: 'Assertion',
+        details:
+            'Found ${discovered.length} widgets matching $selector expected exactly $n.',
+        color: Colors.grey,
+        screenshot: timeline.takeScreenshotSync(
+          annotators: [
+            HighlightAnnotator.elements(discoveredElements),
+          ],
+        ),
+      );
+    }
+    return snapshot.multi;
+  }
 
   /// Asserts that at least [n] widgets of type [W] exist.
-  MultiWidgetMatcher<W> existsAtLeastNTimes(int n) => _exists(min: n).multi;
+  MultiWidgetMatcher<W> existsAtLeastNTimes(int n) {
+    final snapshot = _exists(min: n);
+    if (timeline.mode != TimelineMode.off) {
+      timeline.addEvent(
+        eventType: 'Assertion',
+        details:
+            'Found ${discovered.length} widgets matching $selector expected at least $n.',
+        color: Colors.grey,
+        screenshot: timeline.takeScreenshotSync(
+          annotators: [
+            HighlightAnnotator.elements(discoveredElements),
+          ],
+        ),
+      );
+    }
+    return snapshot.multi;
+  }
 
   /// Asserts that at most [n] widgets of type [W] exist.
-  MultiWidgetMatcher<W> existsAtMostNTimes(int n) => _exists(max: n).multi;
+  MultiWidgetMatcher<W> existsAtMostNTimes(int n) {
+    final snapshot = _exists(max: n);
+    if (timeline.mode != TimelineMode.off) {
+      timeline.addEvent(
+        eventType: 'Assertion',
+        details:
+            'Found ${discovered.length} widgets matching $selector expected at most $n.',
+        color: Colors.grey,
+        screenshot: timeline.takeScreenshotSync(
+          annotators: [
+            HighlightAnnotator.elements(discoveredElements),
+          ],
+        ),
+      );
+    }
+    return snapshot.multi;
+  }
 
   /// Internal method to check the existence of widgets with optional
   /// minimum and maximum limits.
@@ -441,7 +549,31 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
 
         // else fail with default message
         final errorBuilder = StringBuffer();
-        errorBuilder.writeln('Could not find $selector in widget tree');
+        if (count == 0) {
+          if (min == max) {
+            errorBuilder.writeln(
+              'Could not find $selector in widget tree, '
+              'expected exactly $min.',
+            );
+          } else {
+            errorBuilder.writeln(
+              'Could not find $selector in widget tree, '
+              'expected at least $min',
+            );
+          }
+        } else {
+          if (min == max) {
+            errorBuilder.writeln(
+              'Found $count elements matching $selector in widget tree, '
+              'expected exactly $min.',
+            );
+          } else {
+            errorBuilder.writeln(
+              'Found $count elements matching $selector in widget tree, '
+              'expected at least $min.',
+            );
+          }
+        }
         _dumpWidgetTree(errorBuilder);
         if (timeline.mode != TimelineMode.off) {
           timeline.addEvent(
@@ -464,7 +596,7 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
         final errorBuilder = StringBuffer();
         errorBuilder.writeln(
           'Found ${discovered.length} elements matching $selector in widget tree, '
-          'expected at most $max',
+          'expected at most $max.',
         );
 
         discovered.forEachIndexed((candidate, index) {
@@ -488,20 +620,6 @@ extension MultiWidgetSelectorMatcher<W extends Widget> on WidgetSnapshot<W> {
         }
         fail(errorBuilder.toString());
       }
-    }
-
-    if (timeline.mode != TimelineMode.off) {
-      timeline.addEvent(
-        eventType: 'Assertion',
-        details:
-            'Found ${discovered.length} widgets matching $selector.\nExpected: ${min != null ? "min:$min," : ''}${max != null ? "max:$max," : ''}',
-        color: Colors.grey,
-        screenshot: timeline.takeScreenshotSync(
-          annotators: [
-            HighlightAnnotator.elements(discoveredElements),
-          ],
-        ),
-      );
     }
     return this;
   }

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -126,6 +126,42 @@ extension WidgetSnapshotShorthands<W extends Widget> on WidgetSnapshot<W> {
   /// Use this list to access elements corresponding to the discovered widgets.
   List<Element> get discoveredElements =>
       discovered.map((e) => e.element).toList();
+
+  /// Shorthand to get the [RenderObject] of the first discovered widget.
+  RenderObject get discoveredRenderObject {
+    final renderObject = discoveredElement!.renderObject;
+    if (renderObject == null) {
+      // There is not a single Element in the Flutter SDK that returns null for `renderObject`.
+      // Please file a bug if you ever encounter this.
+      throw TestFailure(
+        "Widget '${selector.toStringBreadcrumb()}' has no associated RenderObject.\n",
+      );
+    }
+    return renderObject;
+  }
+
+  /// Shorthand to get all RenderObjects of the discovered widgets.
+  List<RenderObject> get discoveredRenderObjects {
+    return discoveredElements.mapNotNull((e) => e.renderObject).toList();
+  }
+
+  /// Shorthand to get the [RenderBox] of the first discovered widget.
+  RenderBox get discoveredRenderBox {
+    final renderObject = discoveredRenderObject;
+    if (renderObject is! RenderBox) {
+      throw TestFailure(
+        "Widget '${selector.toStringBreadcrumb()}' is associated to $renderObject which "
+        "is not a RenderObject in the 2D Cartesian coordinate system "
+        "(implements RenderBox).",
+      );
+    }
+    return renderObject;
+  }
+
+  /// Shorthand to get all RenderBoxes of the discovered widgets.
+  List<RenderBox> get discoveredRenderBoxes {
+    return discoveredRenderObjects.whereType<RenderBox>().toList();
+  }
 }
 
 /// prints debug information during [snapshot] that can be enabled in the

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -129,6 +129,7 @@ extension WidgetSnapshotShorthands<W extends Widget> on WidgetSnapshot<W> {
 
   /// Shorthand to get the [RenderObject] of the first discovered widget.
   RenderObject get discoveredRenderObject {
+    _exists(min: 1, max: 1);
     final renderObject = discoveredElement!.renderObject;
     if (renderObject == null) {
       // There is not a single Element in the Flutter SDK that returns null for `renderObject`.
@@ -147,6 +148,7 @@ extension WidgetSnapshotShorthands<W extends Widget> on WidgetSnapshot<W> {
 
   /// Shorthand to get the [RenderBox] of the first discovered widget.
   RenderBox get discoveredRenderBox {
+    _exists(min: 1, max: 1);
     final renderObject = discoveredRenderObject;
     if (renderObject is! RenderBox) {
       throw TestFailure(

--- a/lib/src/spot/widget_matcher.dart
+++ b/lib/src/spot/widget_matcher.dart
@@ -62,7 +62,7 @@ class _WidgetMatcherFromSnapshot<W extends Widget> implements WidgetMatcher<W> {
   W get widget => snapshot.discoveredWidgets.first;
 
   @override
-  Element get element => snapshot.discovered.single.element;
+  Element get element => snapshot.discovered.first.element;
 
   @override
   WidgetSelector<W> get selector => snapshot.selector;

--- a/test/selectors/selector_test.dart
+++ b/test/selectors/selector_test.dart
@@ -180,10 +180,39 @@ void main() {
       ),
     );
     final element = spotText('home').snapshotElement();
+    expect(element.widget, isA<RichText>());
     expect(element.size?.height, 14);
   });
 
-  testWidgets('snapshotRenderObject()', (tester) async {
+  testWidgets('snapshotElement() multiple widgets', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Row(
+          children: [
+            Text('home'),
+            Text('home'),
+          ],
+        ),
+      ),
+    );
+    expect(
+      () => spotText('home').snapshotElement(),
+      throwsSpotErrorContaining([
+        'Found 2 elements matching Widget with text contains text "home" in widget tree, expected at most 1'
+      ]),
+    );
+  });
+
+  testWidgets('snapshotRenderObject() zero widgets', (tester) async {
+    expect(
+      () => spotText('unknown').snapshotRenderObject(),
+      throwsSpotErrorContaining([
+        'Could not find Widget with text contains text "unknown" in widget tree'
+      ]),
+    );
+  });
+
+  testWidgets('snapshotRenderObject() one widget', (tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         builder: (_, __) => const Center(child: Text('home')),
@@ -191,10 +220,39 @@ void main() {
       ),
     );
     final renderObject = spotText('home').snapshotRenderObject();
+    expect(renderObject, isNotNull);
     expect(renderObject.isRepaintBoundary, isFalse);
   });
 
-  testWidgets('snapshotRenderBox()', (tester) async {
+  testWidgets('snapshotRenderObject() multiple widgets', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Row(
+          children: [
+            Text('home'),
+            Text('home'),
+          ],
+        ),
+      ),
+    );
+    expect(
+      () => spotText('home').snapshotRenderObject(),
+      throwsSpotErrorContaining([
+        'Found 2 elements matching Widget with text contains text "home" in widget tree, expected at most 1'
+      ]),
+    );
+  });
+
+  testWidgets('snapshotRenderBox() zero widgets', (tester) async {
+    expect(
+      () => spotText('unknown').snapshotRenderBox(),
+      throwsSpotErrorContaining([
+        'Could not find Widget with text contains text "unknown" in widget tree'
+      ]),
+    );
+  });
+
+  testWidgets('snapshotRenderBox() one widget', (tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         builder: (_, __) => const Center(child: Text('home')),

--- a/test/selectors/selector_test.dart
+++ b/test/selectors/selector_test.dart
@@ -260,7 +260,27 @@ void main() {
       ),
     );
     final renderBox = spotText('home').snapshotRenderBox();
+    expect(renderBox, isA<RenderBox>());
     expect(renderBox.localToGlobal(Offset.zero), const Offset(372.0, 293.0));
+  });
+
+  testWidgets('snapshotRenderBox() multiple widgets', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Row(
+          children: [
+            Text('home'),
+            Text('home'),
+          ],
+        ),
+      ),
+    );
+    expect(
+      () => spotText('home').snapshotRenderBox(),
+      throwsSpotErrorContaining([
+        'Found 2 elements matching Widget with text contains text "home" in widget tree, expected at most 1'
+      ]),
+    );
   });
 }
 

--- a/test/selectors/selector_test.dart
+++ b/test/selectors/selector_test.dart
@@ -116,14 +116,22 @@ void main() {
     );
   });
 
-  testWidgets('snapshotState()', (tester) async {
+  testWidgets('snapshotState() zero widgets', (tester) async {
+    expect(
+      () => spot<_MyContainer>().snapshotState(),
+      throwsSpotErrorContaining(['Could not find _MyContainer in widget tree']),
+    );
+  });
+
+  testWidgets('snapshotState() one widget', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(home: _MyContainer(color: Colors.red)),
     );
     final state = spot<_MyContainer>().snapshotState<_MyContainerState>();
     expect(state.innerValue, 'stateValue');
-    final plainState = spot<_MyContainer>().snapshotState();
-    expect(plainState.mounted, isTrue);
+
+    // Test for non-stateful widget
+    await tester.pumpWidget(const MaterialApp(home: Text('test')));
     expect(
       () => spot<DefaultTextStyle>().snapshotState(),
       throwsA(
@@ -136,7 +144,35 @@ void main() {
     );
   });
 
-  testWidgets('snapshotElement()', (tester) async {
+  testWidgets('snapshotState() multiple widgets', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Row(
+          children: [
+            _MyContainer(color: Colors.red),
+            _MyContainer(color: Colors.blue),
+          ],
+        ),
+      ),
+    );
+    expect(
+      () => spot<_MyContainer>().snapshotState(),
+      throwsSpotErrorContaining([
+        'Found 2 elements matching _MyContainer in widget tree, expected at most 1'
+      ]),
+    );
+  });
+
+  testWidgets('snapshotElement() zero widgets', (tester) async {
+    expect(
+      () => spotText('unknown').snapshotElement(),
+      throwsSpotErrorContaining([
+        'Could not find Widget with text contains text "unknown" in widget tree'
+      ]),
+    );
+  });
+
+  testWidgets('snapshotElement() one widget', (tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         builder: (_, __) => const Center(child: Text('home')),

--- a/test/selectors/selector_test.dart
+++ b/test/selectors/selector_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
 
+import '../util/assert_error.dart';
+
 void main() {
   testWidgets('.single keeps all information', (tester) async {
     final multiSelector = spot<Center>(
@@ -80,10 +82,38 @@ void main() {
     expect(multiMap.runtimeType, singleMap.runtimeType);
   });
 
-  testWidgets('snapshotWidget()', (tester) async {
+  testWidgets('snapshotWidget() zero widgets', (tester) async {
+    expect(
+      () => spotText('unknown').snapshotWidget(),
+      throwsSpotErrorContaining([
+        'Could not find Widget with text contains text "unknown" in widget tree'
+      ]),
+    );
+  });
+
+  testWidgets('snapshotWidget() one widget', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: Text('home')));
     final widget = spotText('home').snapshotWidget();
     expect(widget.text, 'home');
+  });
+
+  testWidgets('snapshotWidget() multiple widgets', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Column(
+          children: [
+            Text('home'),
+            Text('home'),
+          ],
+        ),
+      ),
+    );
+    expect(
+      () => spotText('home').snapshotWidget(),
+      throwsSpotErrorContaining([
+        'Found 2 elements matching Widget with text contains text "home" in widget tree, expected at most 1'
+      ]),
+    );
   });
 
   testWidgets('snapshotState()', (tester) async {

--- a/test/timeline/tap/act_tap_timeline_test_bodies.dart
+++ b/test/timeline/tap/act_tap_timeline_test_bodies.dart
@@ -301,7 +301,7 @@ Example: timeline.mode = $globalTimelineModeToSwitch;
       output,
       isNot(contains('Tap ${_clearButtonSelector.toStringBreadcrumb()}')),
     );
-    _testTimeLineContent(output: output, tapCount: 2, assertionCount: 10);
+    _testTimeLineContent(output: output, tapCount: 2, assertionCount: 6);
     expect(output, contains('⏸︎ - Timeline recording is off'));
   }
 
@@ -369,7 +369,7 @@ Example: timeline.mode = $globalTimelineModeToSwitch;
         'Details: ${spotText('Counter: 3')} exists once',
       ),
     );
-    _testTimeLineContent(output: output, tapCount: 2, assertionCount: 10);
+    _testTimeLineContent(output: output, tapCount: 2, assertionCount: 6);
   }
 
   static void _testTimeLineContent({

--- a/test/timeline/widget_assertions.dart
+++ b/test/timeline/widget_assertions.dart
@@ -1,0 +1,349 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+
+void main() {
+  testWidgets('existsOnce adds to timeline', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(),
+        ),
+      ),
+    );
+    spot<AppBar>().existsOnce();
+    final existsOnceEvent = timeline.events.single;
+    expect(
+      existsOnceEvent.details,
+      contains('Found 1 widgets matching AppBar expected only one'),
+    );
+  });
+
+  testWidgets('existsOnce adds to timeline - error', (tester) async {
+    try {
+      spot<AppBar>().existsOnce();
+    } catch (e) {
+      // ignore error
+    }
+    final existsOnceEvent = timeline.events.single;
+    expect(
+      existsOnceEvent.details,
+      contains('Could not find AppBar in widget tree'),
+    );
+  });
+
+  group('QuantityMatchers timeline events', () {
+    testWidgets('existsAtLeastOnce adds to timeline', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Column(
+            children: [
+              Text('Text 1'),
+              Text('Text 2'),
+            ],
+          ),
+        ),
+      );
+
+      spot<Text>().existsAtLeastOnce();
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Found 2 widgets matching Text expected at least one',
+        ),
+      );
+    });
+
+    testWidgets('existsAtLeastOnce adds to timeline - error', (tester) async {
+      // No Text widgets in the tree
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(child: SizedBox()),
+        ),
+      );
+
+      try {
+        spot<Text>().existsAtLeastOnce();
+      } catch (e) {
+        // ignore error
+      }
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion Failed');
+      expect(
+        timelineEvent.details,
+        contains('Could not find Text in widget tree, expected at least 1'),
+      );
+    });
+
+    testWidgets('existsAtMostOnce adds to timeline', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Text('Hello'),
+        ),
+      );
+
+      spot<Text>().existsAtMostOnce();
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Found 1 widgets matching Text expected at most one',
+        ),
+      );
+    });
+
+    testWidgets('existsAtMostOnce adds to timeline - error', (tester) async {
+      // Multiple Text widgets in the tree
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Column(
+            children: [
+              Text('Text 1'),
+              Text('Text 2'),
+            ],
+          ),
+        ),
+      );
+
+      try {
+        spot<Text>().existsAtMostOnce();
+      } catch (e) {
+        // ignore error
+      }
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion Failed');
+      expect(
+          timelineEvent.details,
+          contains(
+              'Found 2 elements matching Text in widget tree, expected at most 1'));
+    });
+
+    testWidgets('doesNotExist adds to timeline', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(child: SizedBox()),
+        ),
+      );
+
+      spot<Text>().doesNotExist();
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion');
+      expect(
+        timelineEvent.details,
+        contains('Found 0 widgets matching Text expected none.'),
+      );
+    });
+
+    testWidgets('doesNotExist adds to timeline - error', (tester) async {
+      // Text widget exists when it shouldn't
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Text('Hello'),
+        ),
+      );
+
+      try {
+        spot<Text>().doesNotExist();
+      } catch (e) {
+        // ignore error
+      }
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion Failed');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Found 1 elements matching Text in widget tree, expected at most 0.',
+        ),
+      );
+    });
+
+    testWidgets('existsExactlyNTimes adds to timeline', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Column(
+            children: [
+              Text('Text 1'),
+              Text('Text 2'),
+            ],
+          ),
+        ),
+      );
+
+      spot<Text>().existsExactlyNTimes(2);
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion');
+      expect(
+        timelineEvent.details,
+        contains('Found 2 widgets matching Text expected exactly 2.'),
+      );
+    });
+
+    testWidgets('existsExactlyNTimes adds to timeline - error', (tester) async {
+      // Wrong number of Text widgets in the tree
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Column(
+            children: [
+              Text('Text 1'),
+              Text('Text 2'),
+            ],
+          ),
+        ),
+      );
+
+      try {
+        spot<Text>().existsExactlyNTimes(3);
+      } catch (e) {
+        // ignore error
+      }
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion Failed');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Found 2 elements matching Text in widget tree, expected exactly 3.',
+        ),
+      );
+    });
+
+    testWidgets('existsAtLeastNTimes adds to timeline', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Column(
+            children: [
+              Text('Text 1'),
+              Text('Text 2'),
+              Text('Text 3'),
+            ],
+          ),
+        ),
+      );
+
+      spot<Text>().existsAtLeastNTimes(2);
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Found 3 widgets matching Text expected at least 2.',
+        ),
+      );
+    });
+
+    testWidgets('existsAtLeastNTimes adds to timeline - error', (tester) async {
+      // Too few Text widgets in the tree
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Column(
+            children: [
+              Text('Text 1'),
+            ],
+          ),
+        ),
+      );
+
+      try {
+        spot<Text>().existsAtLeastNTimes(2);
+      } catch (e) {
+        // ignore error
+      }
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion Failed');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Found 1 elements matching Text in widget tree, expected at least 2.',
+        ),
+      );
+    });
+
+    testWidgets('existsAtMostNTimes adds to timeline', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Column(
+            children: [
+              Text('Text 1'),
+            ],
+          ),
+        ),
+      );
+
+      spot<Text>().existsAtMostNTimes(2);
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Found 1 widgets matching Text expected at most 2.',
+        ),
+      );
+    });
+
+    testWidgets('existsAtMostNTimes adds to timeline - error', (tester) async {
+      // Too many Text widgets in the tree
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Column(
+            children: [
+              Text('Text 1'),
+              Text('Text 2'),
+              Text('Text 3'),
+            ],
+          ),
+        ),
+      );
+
+      try {
+        spot<Text>().existsAtMostNTimes(2);
+      } catch (e) {
+        // ignore error
+      }
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion Failed');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Found 3 elements matching Text in widget tree, expected at most 2.',
+        ),
+      );
+    });
+
+    testWidgets('failure cases add error events to timeline', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(child: SizedBox()),
+        ),
+      );
+
+      try {
+        spot<Text>().existsOnce();
+      } catch (e) {
+        // ignore error
+      }
+
+      final timelineEvent = timeline.events.single;
+      expect(timelineEvent.eventType.label, 'Assertion Failed');
+      expect(
+        timelineEvent.details,
+        contains(
+          'Could not find Text in widget tree, expected exactly 1.',
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
shorthands like `.snapshotWidget()`, `.snapshotState()`, `.snapshotElement()`, `.snapshotRenderBox()` and `.snapshotRenderObject()` have been reporting inconsistent error messages and multiple events in the timeline.

Each shorthand now adds only one event to the timeline and has a proper error message in case there have been multiple or no widgets been found.

```dart
    // previous error
    // ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
    // The following StateError was thrown running a test:
    // Bad state: No element
    //
    // When the exception was thrown, this was the stack:
    // #0      List.first (dart:core-patch/growable_array.dart:352:5)
    // #1      _WidgetMatcherFromSnapshot.widget (package:spot/src/spot/widget_matcher.dart:62:46)
    // #2      ReadSingleSnapshot.snapshotWidget (package:spot/src/spot/selectors.dart:680:48)
    // #3      main.<anonymous closure> (file:///Users/pascalwelsch/Projects/passsy/spot/test/selectors/selector_test.dart:90:40)
    // #4      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:193:29)
    // <asynchronous suspension>
    // #5      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1064:5)
    // <asynchronous suspension>
    // <asynchronous suspension>
    // (elided one frame from package:stack_trace)
```
```dart
    // New error
    // ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
    // The following TestFailure was thrown running a test:
    // Could not find Widget with text contains text "unknown" in widget tree
    //
    // When the exception was thrown, this was the stack:
    // #0      fail (package:matcher/src/expect/expect.dart:149:31)
    // #1      MultiWidgetSelectorMatcher._exists (package:spot/src/spot/snapshot.dart:494:9)
    // #2      MultiWidgetSelectorMatcher.existsOnce (package:spot/src/spot/snapshot.dart:438:34)
    // #3      ReadSingleSnapshot.snapshotWidget (package:spot/src/spot/selectors.dart:680:41)
    // #4      main.<anonymous closure> (file:///Users/pascalwelsch/Projects/passsy/spot/test/selectors/selector_test.dart:109:40)
    // #5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:193:29)
    // <asynchronous suspension>
    // #6      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:1064:5)
    // <asynchronous suspension>
    // <asynchronous suspension>
    // (elided one frame from package:stack_trace)
```