### PR TITLE
Fix typo in hit test failure message

### DIFF
--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -635,7 +635,7 @@ void _throwHitTestFailureReport({
   throw TestFailure(
     "Widget '${snapshot.discoveredWidget!.toStringShort()}' can not be interacted with at position $position where its RenderObject $target was found.\n"
     "The exact reason, why it doesn't receive hitTest events is unknown.\n"
-    "If you think this case needs a a better error message, create an issue https://github.com/passsy/spot for anyone else running in a similar issue.\n"
+    "If you think this case needs a better error message, create an issue https://github.com/passsy/spot for anyone else running in a similar issue.\n"
     "A small example would be highly appreciated.",
   );
 }


### PR DESCRIPTION
## Summary
- fix a typo in `_throwHitTestFailureReport`

## Testing
- `dart format lib/src/act/act.dart --output=none` *(fails: dart not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68502712e70883339cd640083bf4524d