### PR TITLE
Fix WidgetSnapshot.toString string

### DIFF
--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -58,7 +58,7 @@ class WidgetSnapshot<W extends Widget> {
 
   @override
   String toString() {
-    return 'SpotSnapshot of $selector (${discoveredElements.length} matches)}';
+    return 'SpotSnapshot of $selector (${discoveredElements.length} matches)';
   }
 }
 


### PR DESCRIPTION
## Summary
- fix widget snapshot string formatting typo

## Testing
- `dart format lib/src/spot/snapshot.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6850272198808333847fc46aaa16d137