### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ void main() {
   testWidgets('another test', (tester) async {
     // overwrites the global mode
     timeline.mode = TimelineMode.always;
-    // consle: View timeline here: file:///var/folders/0j/p0s0zrv91t...
+    // console: View timeline here: file:///var/folders/0j/p0s0zrv91t...
   });
 }
 ```


### PR DESCRIPTION
## Summary
- correct typo in the README example showing how to set `globalTimelineMode`

## Testing
- `dart format --set-exit-if-changed README.md` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685027320e24833392b5363f04e355c9