### PR TITLE
Add hit-test position selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: Assertions like `spotKey(key).existsOnce()` were extremely slow (tens of seconds) when no match was found in a large widget tree. The error output is now limited and match-all selectors are no longer suggested as "less specific" matches. #119
 - Improvement: Untyped selectors (`spot`, `spotKey`, `spotWidget`, `spotElement`, `spotTexts`) no longer add a no-op `WidgetTypeFilter<Widget>` at the root.
+- New: `WidgetSelector.spotAtPosition` to query widgets on the hit-test path for a global screen position. #28
 
 ## 0.19.0
 
@@ -37,7 +38,7 @@ Changes for class `Screenshot` (big breaking update!)
 - New: `width`, `height`, `pixelRatio`, `name`
 - New: `readBytes()`, `readPngBytes()`, `readPngBytesSync()` gives access to raw bytes
 - Deprecated: `file` property. Still returns `File` but signature now returns `dynamic` for web support. Use `createTempPngFile()` or raw byte APIs instead
-- New: `createTempPngFile()` writes the screenshot to a temporary file and returns the absolute file path 
+- New: `createTempPngFile()` writes the screenshot to a temporary file and returns the absolute file path
 - New: `List<ScreenshotAnnotation> annotations`, `addAnnotation()`, `removeAnnotation()` each layer is now separately available
 - New: `flattenedImage()` merges all layers into a single image
 
@@ -56,7 +57,7 @@ Changes for class `Screenshot` (big breaking update!)
 - Add `snapshotRenderBox()`
 - Export `WidgetPresence`
 - Add `@useResult` to `.atMost(N)`, `.atLeast(N)`, `.amount(N)` and `.existsAtMostNTimes(N)` to prevent missing assertions
-- Fix `existsAtLeastNTimes` dumping the widget tree to console 
+- Fix `existsAtLeastNTimes` dumping the widget tree to console
 - Fix image rendering with `TimelineMode.always`
 - Add Timeline to `/README.md`
 - Add `act` to `/README.md`
@@ -69,7 +70,7 @@ Changes for class `Screenshot` (big breaking update!)
   - `spot<_MyContainer>().getStateProp(stateProp<String, _MyContainerState>('innerValue', (s) => s.innerValue));`
   - `spot<_MyContainer>().getRenderObjectProp(renderObjectProp<Size, RenderBox>('size', (r) => r.size));`
 - New `getStateProp` and `stateProp` to access state properties #71
-  `spot<_MyContainer>().existsOnce().getStateProp(stateProp('innerValue', (_MyContainerState s) => s.innerValue));` 
+  `spot<_MyContainer>().existsOnce().getStateProp(stateProp('innerValue', (_MyContainerState s) => s.innerValue));`
 - New `timeline` mode `TimelineMode.always` to always print a timeline after each test #68
 - Deprecate `TimelineMode.record` in favor of `TimelineMode.reportOnError` (which is the default) #68
 - Timeline now shows partial tap warnings #69
@@ -100,7 +101,7 @@ Changes for class `Screenshot` (big breaking update!)
 
 - Add support for Flutter 3.20
 - Update `checks` to 0.3.0 #48
-- Remove deprecated property `selector` from `withProp()` and `hasProp()`. Use `elementSelector` instead 
+- Remove deprecated property `selector` from `withProp()` and `hasProp()`. Use `elementSelector` instead
 - Widen `test_api` version range to include `0.7.X`
 
 ## 0.10.0
@@ -108,7 +109,7 @@ Changes for class `Screenshot` (big breaking update!)
 ### High-level API changes
 
 - **Breaking** `spotText('dash')` can now return multiple widgets
-- New: `.atLeast(n)` and `.atMost(n)` and `.amount(n)` to force the number of expected widgets. 
+- New: `.atLeast(n)` and `.atMost(n)` and `.amount(n)` to force the number of expected widgets.
   `.atMost(0)` can be used to test that a widget does not exist!
 - Deprecated: `spotSingle<W>()` is now deprecated. Use `spot<W>()` instead, or `spot<W>().atMost(1)` to indicate that only a single widget is expected.
 - Fix: `.first()` and `.last()`
@@ -125,18 +126,17 @@ Changes for class `Screenshot` (big breaking update!)
 Those changes can be breaking for packages that depend on `spot` or advanced usages, but should not affect most users.
 
 - **Breaking** `WidgetSelector` now has `List<ElementFilter> stages`, replacing the previous `props`, `parents`, `children` and `elementFilters`.
-- **Breaking** `WidgetSelector` constructor and `copyWith` signature changed, reflecting the new properties. 
+- **Breaking** `WidgetSelector` constructor and `copyWith` signature changed, reflecting the new properties.
   `createElementFilters()`, `createCandidateGenerator()` and `toStringWithoutParents()` have been removed.
 - `WidgetSelector` now has a `quantityConstraint` property (deprecates `expectedQuantity`) that allows setting the `min` and `max` number of expected widgets.
 - `WidgetSelector` replaces `SingleWidgetSelector` and `MultiWidgetSelector`
-- **Breaking** Quantity assertions like `.doesNotExist()` or `.existsOnce()` now return `WidgetMatcher`/`MultiWidgetMatcher` instead of `WidgetSnapshot`. 
+- **Breaking** Quantity assertions like `.doesNotExist()` or `.existsOnce()` now return `WidgetMatcher`/`MultiWidgetMatcher` instead of `WidgetSnapshot`.
   To get the `WidgetSnapshot` use `snapshot()` instead.
 - **Breaking** Remove `WidgetSelector.cast` because it lost information and was untested
 - **Breaking** `PropFilter` has been renamed to `PredicateFilter`
 - **Breaking** `PredicateWithDescription` has been removed
 - **Breaking** `CandidateGenerator` has been removed
 - Explicitly export all classes/extensions/functions to prevent accidental leaks of internal APIs
-
 
 ## 0.10.0-beta.3
 
@@ -153,14 +153,12 @@ The end-user `spot` API is not affected.
 - `WidgetSelector.toString()` has been improved, has now separators for stages and adds braces. Example: `Center with child SizedBox ❯ with parent (Scaffold ᗕ Row)`
 - Fix `.atIndex(n)` to be executed at the right time, not after all other filters.
 
-
 ## 0.10.0-beta.2
 
 - New `getDiagnosticProp<T>('name')` for easy access to the values of a diagnostic property #40
 - New `hasEffectiveTextStyle`, `withEffectiveTextStyleMatching()`, `withEffectiveTextStyle()` #36, #38
 - Tons of documentation and examples #37, #39
 - Restructure of internal files
-
 
 ## 0.10.0-beta.1
 
@@ -175,11 +173,10 @@ Eventually **Breaking**, but only the class names. The end user API stays the sa
 - `spotText('a')` can now return multiple widgets
 - **Breaking** remove `WidgetSelector.cast` because it lost information and was untested
 
-
 ## 0.7.0
 
 - New prop API with `hasWidgetProp()` makes it easy to filter and assert properties of Widgets.
-  This replaces the old `hasProp()` method which was based on way to complicated package:checks context. 
+  This replaces the old `hasProp()` method which was based on way to complicated package:checks context.
   ```dart
   // Old ⛈️
   spotSingle<Checkbox>().existsOnce().hasProp(
@@ -198,43 +195,43 @@ Eventually **Breaking**, but only the class names. The end user API stays the sa
     );
   ```
 
-  The prop API is also available for `Element` and `RenderObject`. 
+  The prop API is also available for `Element` and `RenderObject`.
   <summary>
     <details>
-  
-  ```
-  ├── Interface "NamedWidgetProp" added 
-  ├── Interface "NamedElementProp" added 
-  ├── Interface "NamedRenderObjectProp" added 
-  ├── Function "widgetProp" added 
-  ├── Function "elementProp" added 
-  ├── Function "renderObjectProp" added 
+
+  ```text
+  ├── Interface "NamedWidgetProp" added
+  ├── Interface "NamedElementProp" added
+  ├── Interface "NamedRenderObjectProp" added
+  ├── Function "widgetProp" added
+  ├── Function "elementProp" added
+  ├── Function "renderObjectProp" added
   ├─┬ Class SelectorQueries
-  │ ├── Method "whereWidgetProp" added 
-  │ ├── Method "whereElementProp" added 
-  │ └── Method "whereRenderObjectProp" added 
+  │ ├── Method "whereWidgetProp" added
+  │ ├── Method "whereElementProp" added
+  │ └── Method "whereRenderObjectProp" added
   └─┬ Class WidgetMatcherExtensions
-  ├── Method "getWidgetProp" added 
-  ├── Method "hasWidgetProp" added 
-  ├── Method "getElementProp" added 
-  ├── Method "hasElementProp" added 
-  ├── Method "getRenderObjectProp" added 
-  └── Method "hasRenderObjectProp" added 
+  ├── Method "getWidgetProp" added
+  ├── Method "hasWidgetProp" added
+  ├── Method "getElementProp" added
+  ├── Method "hasElementProp" added
+  ├── Method "getRenderObjectProp" added
+  └── Method "hasRenderObjectProp" added
   ```
     </details>
   </summary>
-  
+
 - Never miss asserting your `WidgetSelector`.
   All methods returning a `WidgetSelector` are now annotated with `@useResult`.
   This will cause a lint warning when you only define a `WidgetSelector` without asserting it.
   ```dart
   spot<FloatingActionButton>().withChild(spotIcon(Icons.add)); // warning, no assertion
-  
+
   final plusFab = spot<FloatingActionButton>().withChild(spotIcon(Icons.add)); // ok, assigned
   spot<FloatingActionButton>().withChild(spotIcon(Icons.add)).existsOnce(); // ok, asserted
   ```
-  
-- It is now easy to directly access the Widget of a `SingleWidgetSelector` with `snapshotWidget()`. 
+
+- It is now easy to directly access the Widget of a `SingleWidgetSelector` with `snapshotWidget()`.
   It also works for the associated `Element` and `RenderObject`. Use `snapshotElement()` and `snapshotRenderObject()`.
 
   ```diff
@@ -269,11 +266,11 @@ Eventually **Breaking**, but only the class names. The end user API stays the sa
   ```dart
   /// Takes a screenshot of the entire window
   await takeScreenshot();
-  
+
   /// Takes a screenshot of a single Screen/Widget
   final homePage = spotSingle<HomePage>();
   await takeScreenshot(selector: homePage);
-  
+
   /// Use it as extension
   await spotSingle<HomePage>().takeScreenshot();
   ```
@@ -290,7 +287,7 @@ Eventually **Breaking**, but only the class names. The end user API stays the sa
 - Widen test_api range to support Flutter 3.22
 
 ## 0.3.2
-- Export all types from `checks.dart` which are required to use `hasProp` 
+- Export all types from `checks.dart` which are required to use `hasProp`
 
 ## 0.3.1
 - Fix compilation error with Flutter 3.0.0
@@ -299,7 +296,7 @@ Eventually **Breaking**, but only the class names. The end user API stays the sa
 - `spotTexts` now matches `EditableText` and `SelectableText` #5
 - `spotTexts` now has generic type `<W>` instead of static `Text`. This changes the return type from  `MultiWidgetSelector<Text>` -> `MultiWidgetSelector<W>` #5
 - Changed signature of `SingleWidgetSelector.withProp` and `MultiWidgetSelector.withProp`.
-- New matchers for `EditableText`, `ListTile`, `SelectableText` 
+- New matchers for `EditableText`, `ListTile`, `SelectableText`
 
 ## 0.2.2
 - Support for Flutter 3.0.0 / Dart 2.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix: Assertions like `spotKey(key).existsOnce()` were extremely slow (tens of seconds) when no match was found in a large widget tree. The error output is now limited and match-all selectors are no longer suggested as "less specific" matches. #119
 - Improvement: Untyped selectors (`spot`, `spotKey`, `spotWidget`, `spotElement`, `spotTexts`) no longer add a no-op `WidgetTypeFilter<Widget>` at the root.
-- New: `WidgetSelector.spotAtPosition` to query widgets on the hit-test path for a global screen position. #28
+- New: `spotAtPosition` and `WidgetSelector.atPosition` to query widgets on the hit-test path for a global screen position. #28
 
 ## 0.19.0
 

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -36,6 +36,7 @@ export 'package:spot/src/spot/effective/effective_text.dart'
     show EffectiveTextMatcher, EffectiveTextSelector, TextStyleSubject;
 export 'package:spot/src/spot/filters/child_filter.dart' show ChildFilter;
 export 'package:spot/src/spot/filters/parent_filter.dart' show ParentFilter;
+export 'package:spot/src/spot/filters/position_filter.dart' show PositionFilter;
 export 'package:spot/src/spot/filters/predicate_filter.dart'
     show PredicateFilter;
 export 'package:spot/src/spot/filters/widget_type_filter.dart'
@@ -61,6 +62,7 @@ export 'package:spot/src/spot/props.dart'
         widgetProp;
 export 'package:spot/src/spot/selectors.dart'
     show
+        PositionFilterSelector,
         QuantityMatchers,
         QuantitySelectors,
         ReadSingleSnapshot,

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -176,6 +176,16 @@ WidgetSelector<Widget> get allWidgets => WidgetSelector.all;
 /// ```
 WidgetSelector<Widget> spotAllWidgets() => WidgetSelector.all;
 
+/// Creates a [WidgetSelector] for widgets on the hit-test path at [position].
+///
+/// [position] is a global screen coordinate.
+/// Flutter hit testing decides which widgets match, so widgets that overlap the
+/// coordinate but do not receive hit-test events are not included.
+@useResult
+WidgetSelector<Widget> spotAtPosition(Offset position) {
+  return spot().atPosition(position);
+}
+
 /// Creates a chainable [WidgetSelector] that matches a single [Widget] of
 /// type [W].
 ///

--- a/lib/src/spot/filters/position_filter.dart
+++ b/lib/src/spot/filters/position_filter.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:spot/src/spot/widget_selector.dart';
+
+/// Filters widgets that are hit at a given global [position].
+class PositionFilter implements ElementFilter {
+  /// Creates a filter that keeps widgets hit by a hit test at [position].
+  PositionFilter(this.position);
+
+  /// The global screen position used for hit testing.
+  final Offset position;
+
+  @override
+  Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
+    final HitTestResult result = HitTestResult();
+    // Flutter 3.10 does not expose the view-aware hitTestInView API yet.
+    // When support for Flutter 3.10 is dropped, use
+    // RendererBinding.instance.hitTestInView() so the hit test can target the
+    // intended FlutterView explicitly instead of relying on the implicit view.
+    // ignore: deprecated_member_use
+    WidgetsBinding.instance.hitTest(result, position);
+    final hits = result.path
+        .map((entry) => _elementFromHitTarget(entry.target))
+        .whereType<Element>()
+        .toList();
+    final hitElements = <Element>[];
+    final hitElementSet = <Element>{};
+    for (final element in hits) {
+      if (!hitElementSet.add(element)) {
+        continue;
+      }
+      hitElements.add(element);
+    }
+
+    final matchedByElement = <Element, WidgetTreeNode>{};
+    for (final node in candidates) {
+      if (!hitElementSet.contains(node.element)) {
+        continue;
+      }
+      matchedByElement[node.element] = node;
+    }
+
+    return hitElements
+        .map((element) => matchedByElement[element])
+        .whereType<WidgetTreeNode>();
+  }
+
+  @override
+  String get description => 'at position $position';
+
+  @override
+  String toString() => 'PositionFilter($position)';
+}
+
+Element? _elementFromHitTarget(HitTestTarget target) {
+  if (target is! RenderObject) {
+    return null;
+  }
+  final debugCreator = target.debugCreator;
+  if (debugCreator is! DebugCreator) {
+    return null;
+  }
+  return debugCreator.element;
+}

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -967,8 +967,12 @@ extension RelativeSelectors<W extends Widget> on WidgetSelector<W> {
 extension PositionFilterSelector<W extends Widget> on WidgetSelector<W> {
   /// Keeps widgets from this selector that are on the hit-test path at
   /// [position].
+  ///
+  /// [position] is a global screen coordinate.
+  /// Flutter hit testing decides which widgets match, so widgets that overlap
+  /// the coordinate but do not receive hit-test events are not included.
   @useResult
-  WidgetSelector<W> spotAtPosition(Offset position) {
+  WidgetSelector<W> atPosition(Offset position) {
     return addStage(PositionFilter(position));
   }
 }

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -962,3 +962,13 @@ extension RelativeSelectors<W extends Widget> on WidgetSelector<W> {
     return addStage(ChildFilter(children));
   }
 }
+
+/// Filters an existing selector by a global screen coordinate.
+extension PositionFilterSelector<W extends Widget> on WidgetSelector<W> {
+  /// Keeps widgets from this selector that are on the hit-test path at
+  /// [position].
+  @useResult
+  WidgetSelector<W> spotAtPosition(Offset position) {
+    return addStage(PositionFilter(position));
+  }
+}

--- a/test/spot/widget_at_position_test.dart
+++ b/test/spot/widget_at_position_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+
+void main() {
+  testWidgets('spotAtPosition finds widgets on hit-test path', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 100,
+            height: 100,
+            child: ColoredBox(
+              key: ValueKey('target'),
+              color: Colors.green,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    spot<ColoredBox>()
+        .spotAtPosition(const Offset(400, 300))
+        .withKey(const ValueKey('target'))
+        .existsOnce();
+    spot<SizedBox>().spotAtPosition(const Offset(400, 300)).existsOnce();
+  });
+
+  testWidgets('spotAtPosition finds all widgets on hit-test path',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 100,
+            height: 100,
+            child: ColoredBox(
+              key: ValueKey('target'),
+              color: Colors.green,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final widgetsAtPosition = spot().spotAtPosition(const Offset(400, 300));
+    widgetsAtPosition.existsAtLeastNTimes(2);
+    widgetsAtPosition
+        .whereWidget(
+          (widget) => widget.key == const ValueKey('target'),
+          description: 'target widget',
+        )
+        .existsOnce();
+  });
+
+  testWidgets('spotAtPosition filters typed selectors', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Row(
+          children: [
+            SizedBox(
+              width: 100,
+              height: 100,
+              child: ColoredBox(
+                key: ValueKey('blue'),
+                color: Colors.blue,
+              ),
+            ),
+            SizedBox(
+              width: 100,
+              height: 100,
+              child: ColoredBox(
+                key: ValueKey('green'),
+                color: Colors.green,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final selector = spot<ColoredBox>()
+        .withKey(const ValueKey('green'))
+        .spotAtPosition(const Offset(150, 300));
+    selector.existsOnce();
+    final box = selector.snapshotWidget();
+    expect(box.color, Colors.green);
+  });
+
+  testWidgets('spotAtPosition returns no widgets outside the view',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: ColoredBox(color: Colors.green),
+      ),
+    );
+
+    spot<ColoredBox>().spotAtPosition(const Offset(-1, -1)).doesNotExist();
+  });
+}

--- a/test/spot/widget_at_position_test.dart
+++ b/test/spot/widget_at_position_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
 
 void main() {
-  testWidgets('spotAtPosition finds widgets on hit-test path', (tester) async {
+  testWidgets('atPosition finds widgets on hit-test path', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Center(
@@ -20,10 +20,10 @@ void main() {
     );
 
     spot<ColoredBox>()
-        .spotAtPosition(const Offset(400, 300))
+        .atPosition(const Offset(400, 300))
         .withKey(const ValueKey('target'))
         .existsOnce();
-    spot<SizedBox>().spotAtPosition(const Offset(400, 300)).existsOnce();
+    spot<SizedBox>().atPosition(const Offset(400, 300)).existsOnce();
   });
 
   testWidgets('spotAtPosition finds all widgets on hit-test path',
@@ -43,7 +43,7 @@ void main() {
       ),
     );
 
-    final widgetsAtPosition = spot().spotAtPosition(const Offset(400, 300));
+    final widgetsAtPosition = spotAtPosition(const Offset(400, 300));
     widgetsAtPosition.existsAtLeastNTimes(2);
     widgetsAtPosition
         .whereWidget(
@@ -53,7 +53,7 @@ void main() {
         .existsOnce();
   });
 
-  testWidgets('spotAtPosition filters typed selectors', (tester) async {
+  testWidgets('atPosition filters typed selectors', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Row(
@@ -81,20 +81,19 @@ void main() {
 
     final selector = spot<ColoredBox>()
         .withKey(const ValueKey('green'))
-        .spotAtPosition(const Offset(150, 300));
+        .atPosition(const Offset(150, 300));
     selector.existsOnce();
     final box = selector.snapshotWidget();
     expect(box.color, Colors.green);
   });
 
-  testWidgets('spotAtPosition returns no widgets outside the view',
-      (tester) async {
+  testWidgets('atPosition returns no widgets outside the view', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: ColoredBox(color: Colors.green),
       ),
     );
 
-    spot<ColoredBox>().spotAtPosition(const Offset(-1, -1)).doesNotExist();
+    spot<ColoredBox>().atPosition(const Offset(-1, -1)).doesNotExist();
   });
 }


### PR DESCRIPTION
Adds hit-test based position selectors for widgets at a global screen coordinate.

```dart
spotAtPosition(const Offset(400, 300)).existsAtLeastNTimes(1);
spot<ColoredBox>().atPosition(const Offset(400, 300)).existsOnce();
```

`spotAtPosition` starts a selector from a global position.
`atPosition` narrows an existing selector by the Flutter hit-test path.
The selectors follow Flutter hit testing, so overlapping siblings that do not receive the hit are not reported.

Fixes #28