### PR TITLE
Don't execute font loading, when fonts are already known to engine

### DIFF
--- a/lib/src/screenshot/load_fonts.dart
+++ b/lib/src/screenshot/load_fonts.dart
@@ -76,8 +76,9 @@ Future<void> loadAppFonts() async {
   if (kIsWeb) {
     // ignore: avoid_print
     print('⚠️ - loadAppFonts is not supported on the web!');
-    _loadAppFontsFuture = Future.value();
-    return _loadAppFontsFuture!;
+    final future = Future<void>.value();
+    _loadAppFontsFuture = future;
+    return future;
   }
 
   final future = _loadAppFontsOnce();


### PR DESCRIPTION
Loading fonts again does nothing. Once they are known to the engine (or the main isolate) loading them again has zero effect, but takes significant amount of time.

On a larger project, I measured a 24% improvement
Before:  551.20s user 44.91s system 189% cpu 5:15.20 total
After:  417.77s user 37.46s system 189% cpu 3:59.68 total