### PR TITLE
Accept IndexedStack location for hidden Visibility tap

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   android-integration-test:
     name: Android Integration Tests
-    runs-on: blacksmith-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,14 +9,20 @@ on:
 jobs:
   android-integration-test:
     name: Android Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     timeout-minutes: 30
     defaults:
       run:
         working-directory: counter_app
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -30,6 +36,16 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34
+          target: google_apis
           arch: x86_64
+          profile: pixel_6
+          cores: 2
+          ram-size: 4096M
+          heap-size: 512M
+          force-avd-creation: false
+          emulator-boot-timeout: 900
+          disable-animations: true
+          disable-spellchecker: true
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           working-directory: counter_app
           script: flutter test integration_test -d emulator-5554

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -310,7 +310,10 @@ void actTests() {
           throwsSpotErrorContaining([
             "Widget 'ElevatedButton' is wrapped in IgnorePointer and doesn't receive pointer events",
             "The IgnorePointer is located at",
-            "widgets/visibility.dart:",
+            // On Flutter master, Visibility is implemented via IndexedStack,
+            // so the IgnorePointer's debugWidgetLocation points to
+            // indexed_stack.dart instead of visibility.dart.
+            RegExp(r'widgets/(visibility|indexed_stack)\.dart:'),
           ]),
         );
       });


### PR DESCRIPTION
Nightly fails on Flutter `master` channel because `Visibility` is now implemented via `IndexedStack`, moving the `IgnorePointer`'s `debugWidgetLocation` from `visibility.dart` to `indexed_stack.dart`. The spot error text is unchanged — only the file path matched by the test moved.

### Old assertion (master)

```
which has `toString()` with value 'Widget 'ElevatedButton' is wrapped in IgnorePointer ...
                                  'The IgnorePointer is located at .../widgets/indexed_stack.dart:458:16'
which does not contain 'widgets/visibility.dart:'
```

### Fix

Match either path:

```dart
RegExp(r'widgets/(visibility|indexed_stack)\.dart:')
```