### PR TITLE
Fix slow failing assertions for spotKey and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix: Assertions like `spotKey(key).existsOnce()` were extremely slow (tens of seconds) when no match was found in a large widget tree. The error output is now limited and match-all selectors are no longer suggested as "less specific" matches. #119
+
 ## 0.19.0
 
 - Fix: Shorten screenshot filenames to avoid issues on some filesystems #124

--- a/lib/src/spot/filters/widget_type_filter.dart
+++ b/lib/src/spot/filters/widget_type_filter.dart
@@ -9,6 +9,8 @@ class WidgetTypeFilter<W extends Widget> implements ElementFilter {
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     if (W == Widget) {
+      // [W] is the broadest possible type, this filter is a no-op that keeps
+      // all candidates.
       return candidates;
     }
     final type = _typeOf<W>();

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -775,9 +775,14 @@ void _tryMatchingLessSpecificCriteria(
       int index = 0;
       for (final Element match in lessSpecificSnapshot.discoveredElements) {
         index++;
-        errorBuilder.writeln(
-          'Possible match #$index:\n${match.toStringDeep(minLevel: DiagnosticLevel.info)}',
-        );
+        errorBuilder.writeln('Possible match #$index:\n$match');
+        const maxLength = 10000;
+        if (index > 10 && errorBuilder.length > maxLength) {
+          errorBuilder.writeln(
+            '... (truncated after $maxLength chars, too many matches found)',
+          );
+          break;
+        }
       }
       final significantTree =
           findCommonAncestor(lessSpecificSnapshot.discoveredElements.toSet())

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -299,6 +299,21 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
         return findCommonAncestor(set).toStringDeep();
       }
 
+      String discoveredElementsList() {
+        final buffer = StringBuffer();
+        int index = 0;
+        for (final element in discoveredElements) {
+          index++;
+          buffer.writeln('Match #$index: $element');
+          const maxLength = 10000;
+          if (index > 10 && buffer.length > maxLength) {
+            buffer.writeln('... (truncated, too many matches found)');
+            break;
+          }
+        }
+        return buffer.toString();
+      }
+
       if (minimumConstraint != null && maximumConstraint == null) {
         if (minimumConstraint > count) {
           _tryMatchingLessSpecificCriteria(this);
@@ -317,6 +332,7 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
               message:
                   'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
                   'expected at least $minimumConstraint.\n'
+                  '${discoveredElementsList()}'
                   'Check the timeline at the very bottom for more information.',
               significantWidgetTree: significantWidgetTree(),
               snapshot: this,
@@ -361,6 +377,7 @@ extension ValidateQuantity<W extends Widget> on WidgetSnapshot<W> {
                 message:
                     'Found $count elements matching ${unconstrainedSelector.toStringBreadcrumb()} in widget tree, '
                     'expected exactly $exactCount.\n'
+                    '${discoveredElementsList()}'
                     'Check the timeline at the very bottom for more information.',
                 significantWidgetTree: significantWidgetTree(),
                 snapshot: this,
@@ -845,10 +862,22 @@ extension LessSpecificSelectors<W extends Widget> on WidgetSelector<W> {
   /// - selector which only matches for parent SizedBox
   @visibleForTesting
   Iterable<WidgetSelector<W>> lessSpecificSelectors() sync* {
-    final List<WidgetSelector<W> Function(WidgetSelector<W>)> criteria = [
-      for (final stage in stages)
-        (s) => s.copyWith(stages: [...s.stages, stage]),
-    ];
+    final criteria = <WidgetSelector<W> Function(WidgetSelector<W>)>[];
+    for (final stage in stages) {
+      // A WidgetTypeFilter<Widget> matches any widget, it is not a real
+      // constraint. Permuting it only yields a selector matching the whole
+      // tree or one equal to the original, neither of which is a useful
+      // "less specific" suggestion.
+      //
+      // Compares runtimeType instead of `is WidgetTypeFilter<Widget>` because
+      // the latter would also match a WidgetTypeFilter<Center> (Center extends
+      // Widget). Only the exact match-all filter should be skipped.
+      final isMatchAllType = stage.runtimeType == WidgetTypeFilter<Widget>;
+      if (isMatchAllType) {
+        continue;
+      }
+      criteria.add((s) => s.copyWith(stages: [...s.stages, stage]));
+    }
     if (criteria.length <= 1) {
       return;
     }

--- a/test/spot/widget_selector_test.dart
+++ b/test/spot/widget_selector_test.dart
@@ -102,6 +102,15 @@ void main() {
             .toStringBreadcrumb(),
       );
     });
+
+    test('spotKey has no less specific selectors', () {
+      // spotKey only adds a key filter on top of the match-all type filter.
+      // Dropping either leaves a match-all selector or the original, so there
+      // are no useful less specific selectors.
+      final selector = spotKey(const ValueKey('a'));
+      final lessSpecificSelectors = selector.lessSpecificSelectors().toList();
+      expect(lessSpecificSelectors, isEmpty);
+    });
   });
 }
 


### PR DESCRIPTION
Fixes #119

Assertions like `spotKey(key).existsOnce()` took tens of seconds to fail on a large widget tree (vs. ~500ms in patrol).

### Root cause

When a selector finds no match, spot lists "possible matches" from a *less specific* search. Two things made this explode:

1. Each possible match was printed with `toStringDeep()` — a full subtree per match. With hundreds of matches the error string grew huge and froze IntelliJ and the CLI.
2. `spotKey()` carries a match-all `WidgetTypeFilter<Widget>` as its root stage. Dropping the key leaves *only* that filter, so the "less specific" search matched the **entire tree** (707 widgets in the reported case) — none of which is a useful suggestion.

### Changes

- Print a single line per possible match and truncate the listing past 10k chars.
- Treat a match-all type filter (`W == Widget`) as a non-constraint when building less specific selectors, so `spotKey()` yields none instead of "match every widget".
- Over-match errors (`Found N elements, expected …`) now list the matched elements directly, instead of relying on the less-specific dump that no longer runs for key selectors.

### Before / after

For a missing `spotKey` in a populated tree, the failure message went from a full-tree dump (hundreds of `toStringDeep` subtrees) to a single, bounded message.