### PR TITLE
Drop no-op match-all type filter from untyped selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: Assertions like `spotKey(key).existsOnce()` were extremely slow (tens of seconds) when no match was found in a large widget tree. The error output is now limited and match-all selectors are no longer suggested as "less specific" matches. #119
+- Improvement: Untyped selectors (`spot`, `spotKey`, `spotWidget`, `spotElement`, `spotTexts`) no longer add a no-op `WidgetTypeFilter<Widget>` at the root.
 
 ## 0.19.0
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -67,13 +67,9 @@ mixin ChainableSelectors<T extends Widget> {
   }) {
     final selector = WidgetSelector<W>(
       stages: [
-        if (W == Widget)
-          PredicateFilter(
-            predicate: (e) => true,
-            description: 'any Widget',
-          )
-        else
-          WidgetTypeFilter<W>(),
+        // A WidgetTypeFilter<Widget> would match every widget and constrain
+        // nothing, so it is only added for a concrete type.
+        if (W != Widget) WidgetTypeFilter<W>(),
         ..._childAndParentFilters(children, parents),
       ],
     );
@@ -158,7 +154,7 @@ mixin ChainableSelectors<T extends Widget> {
   }) {
     final selector = WidgetSelector<W>(
       stages: [
-        WidgetTypeFilter<W>(),
+        if (W != Widget) WidgetTypeFilter<W>(),
         PredicateFilter(
           predicate: (Element e) => identical(e.widget, widget),
           description: 'Widget === $widget',
@@ -209,7 +205,7 @@ mixin ChainableSelectors<T extends Widget> {
   }) {
     final selector = WidgetSelector<W>(
       stages: [
-        WidgetTypeFilter<W>(),
+        if (W != Widget) WidgetTypeFilter<W>(),
         PredicateFilter(
           predicate: (Element e) => identical(e, element),
           description: 'Element === $element',
@@ -337,7 +333,7 @@ mixin ChainableSelectors<T extends Widget> {
   }) {
     final selector = WidgetSelector<W>(
       stages: [
-        WidgetTypeFilter<W>(),
+        if (W != Widget) WidgetTypeFilter<W>(),
         PredicateFilter(
           predicate: (Element e) {
             if (e.widget is Text) {
@@ -435,7 +431,7 @@ mixin ChainableSelectors<T extends Widget> {
   }) {
     final selector = WidgetSelector<W>(
       stages: [
-        WidgetTypeFilter<W>(),
+        if (W != Widget) WidgetTypeFilter<W>(),
         PredicateFilter(
           predicate: (Element e) => e.widget.key == key,
           description: 'with key: "$key"',

--- a/lib/src/spot/widget_selector.dart
+++ b/lib/src/spot/widget_selector.dart
@@ -138,9 +138,34 @@ class WidgetSelector<W extends Widget> with ChainableSelectors<W> {
     return false;
   }
 
+  /// An implicit `Widget ` subject for untyped selectors that dropped their
+  /// `WidgetTypeFilter`.
+  ///
+  /// Without it the description would dangle, e.g. `spotKey` would read
+  /// `with key: …` instead of `Widget with key: …`. Only added when no stage
+  /// already names a subject (a type filter, or a description like
+  /// `any Widget` / `Widget === …`).
+  String get _implicitWidgetSubject {
+    if (W != Widget) {
+      return '';
+    }
+    if (stages.any((stage) => stage is WidgetTypeFilter)) {
+      return '';
+    }
+    final constraints = stages
+        .where((stage) => stage is! ParentFilter && stage is! ChildFilter)
+        .toList();
+    if (constraints.isEmpty ||
+        constraints.first.description.startsWith('with ')) {
+      return 'Widget ';
+    }
+    return '';
+  }
+
   @override
   String toString() {
     final sb = StringBuffer();
+    sb.write(_implicitWidgetSubject);
 
     for (int i = 0; i < stages.length; i++) {
       final stage = stages[i];
@@ -204,6 +229,7 @@ class WidgetSelector<W extends Widget> with ChainableSelectors<W> {
   /// hierarchy of the selection.
   String toStringBreadcrumb() {
     var sb = StringBuffer();
+    sb.write(_implicitWidgetSubject);
 
     for (int i = 0; i < stages.length; i++) {
       final stage = stages[i];

--- a/test/spot/widget_selector_test.dart
+++ b/test/spot/widget_selector_test.dart
@@ -61,7 +61,7 @@ void main() {
       );
       expect(
         lessSpecificSelectors[1].toStringBreadcrumb(),
-        spot().withParent(spot<Center>()).toStringBreadcrumb(),
+        allCasted().withParent(spot<Center>()).toStringBreadcrumb(),
       );
     });
 
@@ -104,13 +104,25 @@ void main() {
     });
 
     test('spotKey has no less specific selectors', () {
-      // spotKey only adds a key filter on top of the match-all type filter.
-      // Dropping either leaves a match-all selector or the original, so there
-      // are no useful less specific selectors.
+      // spotKey only adds a key filter, no match-all type filter on top.
+      // Dropping it leaves the original, so there are no useful less specific
+      // selectors.
       final selector = spotKey(const ValueKey('a'));
       final lessSpecificSelectors = selector.lessSpecificSelectors().toList();
       expect(lessSpecificSelectors, isEmpty);
     });
+  });
+
+  test('untyped selectors do not add a match-all type filter', () {
+    // A WidgetTypeFilter<Widget> would match everything and constrain nothing,
+    // so untyped selectors (W == Widget) add no type filter at all.
+    expect(spot().stages.whereType<WidgetTypeFilter>(), isEmpty);
+    expect(
+      spotKey(const ValueKey('a')).stages.whereType<WidgetTypeFilter>(),
+      isEmpty,
+    );
+    // A typed selector keeps its type filter.
+    expect(spot<Center>().stages.whereType<WidgetTypeFilter>(), isNotEmpty);
   });
 }
 


### PR DESCRIPTION
`spotKey()`, `spotWidget()`, `spotElement()` and `spotTexts()` always added a `WidgetTypeFilter<W>()` as their root stage. When called without an explicit type (`W == Widget`) that filter matches every widget and constrains nothing — a no-op. `spot()` already avoided this by using a match-all `PredicateFilter` for the untyped case; these four constructors never got the same treatment.

### Change

Introduce a single shared `WidgetSelector.anyWidgetFilter` (the match-all filter already used by `WidgetSelector.all`) and use it for the untyped case in `spot()` and the four constructors. Because it is one shared instance, the less specific search recognizes and skips it via `identical()`, so key/text/widget/element selectors no longer generate a "match every widget" suggestion.

### Before / after

```
spotKey('key').existsOnce()
- Could not find Widget with key: "[<'key'>]" in widget tree
+ Could not find any Widget with key: "[<'key'>]" in widget tree

spot<Center>().spotKey('key')
- Could not find Center ᗕ Widget with key: "[<'key'>]" in widget tree
+ Could not find Center ᗕ any Widget with key: "[<'key'>]" in widget tree
```

This matches what bare `spot()` already prints (`any Widget`).