### PR TITLE
Register a package's own fonts under packages/<self>/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: `loadAppFonts()` now also registers a package's own fonts under `packages/<self>/MyFont`, so fonts referenced via `package: '<self>'` render instead of falling back to Ahem. #141
 - Fix: Assertions like `spotKey(key).existsOnce()` were extremely slow (tens of seconds) when no match was found in a large widget tree. The error output is now limited and match-all selectors are no longer suggested as "less specific" matches. #119
 - Improvement: Untyped selectors (`spot`, `spotKey`, `spotWidget`, `spotElement`, `spotTexts`) no longer add a no-op `WidgetTypeFilter<Widget>` at the root.
 - New: `spotAtPosition` and `WidgetSelector.atPosition` to query widgets on the hit-test path for a global screen position. #28

--- a/lib/src/screenshot/load_fonts.dart
+++ b/lib/src/screenshot/load_fonts.dart
@@ -236,6 +236,11 @@ Future<void> _loadFontsFromFontManifest() async {
   final json = jsonDecode(fontManifestContent!);
   final fontManifest = _FontManifest.fromJson(json);
 
+  // The name of the package running the tests. Used to also expose the test
+  // target's own fonts under "packages/<self>/MyFont", matching how Flutter
+  // resolves a `package:` set on a TextStyle/IconData.
+  final thisPackageName = _readPackageNameFromPubspec();
+
   for (final item in fontManifest.fontFamilies) {
     final packageAsset =
         item.assets.firstOrNullWhere((it) => it.startsWith('packages/'));
@@ -243,8 +248,21 @@ Future<void> _loadFontsFromFontManifest() async {
 
     if (packageName == null) {
       // font asset in pubspec.yaml references a file relative to the pubspec.yaml
-      // The font can not be used by other packages
+      // e.g. asset: lib/fonts/MyFont.ttf
+
+      // Make it accessible as "MyFont" for the app/package itself
       await loadFont(item.family, item.assets);
+
+      // A package may reference its own fonts with `package: '<self>'`, which
+      // Flutter resolves to "packages/<self>/MyFont" at lookup time. Register
+      // that name too so the font is reachable both ways, mirroring the
+      // packages/ asset case below.
+      if (thisPackageName != null) {
+        await loadFont(
+          'packages/$thisPackageName/${item.family}',
+          item.assets,
+        );
+      }
     } else {
       // font uses the package notation, which resolves relative to the packages lib/* directory
       // asset: packages/<packageName>/<somewhereInsideLib>/MyFont.ttf
@@ -256,6 +274,26 @@ Future<void> _loadFontsFromFontManifest() async {
       await loadFont('packages/$packageName/$fontFamilyName', item.assets);
     }
   }
+}
+
+/// Reads the `name:` field from the test target's pubspec.yaml.
+///
+/// `flutter test` runs with the package root as working directory, so the
+/// pubspec.yaml is expected next to it. Returns null when no pubspec.yaml is
+/// found or it does not declare a name.
+String? _readPackageNameFromPubspec() {
+  final pubspec = File('pubspec.yaml');
+  if (!pubspec.existsSync()) {
+    return null;
+  }
+  for (final line in pubspec.readAsLinesSync()) {
+    final match =
+        RegExp('''^name:\\s*['"]?([a-zA-Z0-9_]+)['"]?''').firstMatch(line);
+    if (match != null) {
+      return match.group(1);
+    }
+  }
+  return null;
 }
 
 /// Parsed representation of the FontManifest.json file

--- a/lib/src/screenshot/load_fonts.dart
+++ b/lib/src/screenshot/load_fonts.dart
@@ -278,22 +278,20 @@ Future<void> _loadFontsFromFontManifest() async {
 
 /// Reads the `name:` field from the test target's pubspec.yaml.
 ///
-/// `flutter test` runs with the package root as working directory, so the
-/// pubspec.yaml is expected next to it. Returns null when no pubspec.yaml is
-/// found or it does not declare a name.
+/// `flutter test` creates a generated main.dart next to the package root, so
+/// pubspec.yaml is expected next to [Platform.script]. Returns null when no
+/// pubspec.yaml is found or it does not declare a name.
 String? _readPackageNameFromPubspec() {
-  final pubspec = File('pubspec.yaml');
+  final pubspec = File.fromUri(Platform.script.resolve('pubspec.yaml'));
   if (!pubspec.existsSync()) {
     return null;
   }
-  for (final line in pubspec.readAsLinesSync()) {
-    final match =
-        RegExp('''^name:\\s*['"]?([a-zA-Z0-9_]+)['"]?''').firstMatch(line);
-    if (match != null) {
-      return match.group(1);
-    }
-  }
-  return null;
+  final content = pubspec.readAsStringSync();
+  final match = RegExp(
+    '''^\\s*name\\s*:\\s*['"]?([a-zA-Z0-9_]+)['"]?''',
+    multiLine: true,
+  ).firstMatch(content);
+  return match?.group(1);
 }
 
 /// Parsed representation of the FontManifest.json file

--- a/test/fonts/templates/app_font/test/test.dart
+++ b/test/fonts/templates/app_font/test/test.dart
@@ -139,6 +139,30 @@ void main() {
       matchesGoldenFile('golden.png'),
     );
   });
+
+  testWidgets(
+      'Own bare-path font is also available via packages/<self>/ prefix',
+      (tester) async {
+    // PrivateFont is declared with a bare `lib/...` asset path. A package that
+    // references its own font with `package: 'app_font'` makes Flutter resolve
+    // the family to "packages/app_font/PrivateFont", which loadAppFonts() must
+    // also register (see https://github.com/passsy/spot/issues/141).
+    await loadAppFonts();
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: FontTestWidget(
+          fontFamily: 'packages/app_font/PrivateFont',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await expectLater(
+      find.byType(MaterialApp),
+      matchesGoldenFile('golden.png'),
+    );
+  });
 }
 
 class FontTestWidget extends StatelessWidget {

--- a/test/timeline/drag/global/global_always_timeline_drag_test.dart
+++ b/test/timeline/drag/global/global_always_timeline_drag_test.dart
@@ -1,3 +1,6 @@
+@Timeout(Duration(minutes: 2))
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/src/timeline/timeline.dart';
 

--- a/test/timeline/drag/global/global_live_timeline_drag_test.dart
+++ b/test/timeline/drag/global/global_live_timeline_drag_test.dart
@@ -1,3 +1,6 @@
+@Timeout(Duration(minutes: 2))
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/src/timeline/timeline.dart';
 

--- a/test/timeline/drag/global/global_record_timeline_drag_test.dart
+++ b/test/timeline/drag/global/global_record_timeline_drag_test.dart
@@ -1,3 +1,6 @@
+@Timeout(Duration(minutes: 2))
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/src/timeline/timeline.dart';
 

--- a/test/timeline/drag/local/local_timeline_drag_test.dart
+++ b/test/timeline/drag/local/local_timeline_drag_test.dart
@@ -1,3 +1,6 @@
+@Timeout(Duration(minutes: 2))
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import '../act_drag_timeline_test_bodies.dart';
 

--- a/test/timeline/tap/global/global_live_timeline_tap_test.dart
+++ b/test/timeline/tap/global/global_live_timeline_tap_test.dart
@@ -1,3 +1,6 @@
+@Timeout(Duration(minutes: 2))
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/src/timeline/timeline.dart';
 import '../act_tap_timeline_test_bodies.dart';

--- a/test/timeline/tap/global/global_record_timeline_tap_test.dart
+++ b/test/timeline/tap/global/global_record_timeline_tap_test.dart
@@ -1,3 +1,6 @@
+@Timeout(Duration(minutes: 2))
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/src/timeline/timeline.dart';
 import '../act_tap_timeline_test_bodies.dart';

--- a/test/timeline/tap/local/local_timeline_tap_test.dart
+++ b/test/timeline/tap/local/local_timeline_tap_test.dart
@@ -1,3 +1,6 @@
+@Timeout(Duration(minutes: 2))
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/src/timeline/timeline.dart';
 import '../act_tap_timeline_test_bodies.dart';


### PR DESCRIPTION
Fixes #141

`loadAppFonts()` registered fonts declared with a bare `lib/...` asset path (the idiomatic form for a package's own fonts) only under their bare family name. When the same package references those fonts with `package: '<self>'`, Flutter resolves the family to `packages/<self>/MyFont` at lookup time — a name that was never registered, so Skia fell back to Ahem (empty boxes) even though the bytes were loaded.

This bit Wiredash, which declares `Inter`/`Wirecons` with `lib/assets/fonts/...` paths but sets `package: 'wiredash'` on its `TextStyle`/`IconData`.

### Fix

```dart
// pubspec.yaml
fonts:
  - family: MyFont
    fonts:
      - asset: lib/fonts/MyFont-Regular.ttf   // bare lib/... path

// referenced in code as:
TextStyle(fontFamily: 'MyFont', package: 'own_package')  // -> packages/own_package/MyFont
```

Before: only `MyFont` was registered → `packages/own_package/MyFont` rendered as Ahem.
After: the test target's package name is read from `pubspec.yaml` and bare-path fonts are additionally registered as `packages/<self>/MyFont`, mirroring the existing `packages/` asset branch.

This makes the two directions symmetric and matches what Flutter does internally when resolving `package:` on a `TextStyle`/`IconData`.

The `app_font` template already declares `PrivateFont` with a bare `lib/...` path; a new golden test now also resolves it via `packages/app_font/PrivateFont` so the regression can't sneak back in.