### PR TITLE
Ignore invisible whitespace in text matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- New: Text matching ignores invisible and special whitespace, so tests can use regular characters. `spotText`, `spotTextWhere`, `whereText`, `withText` and `hasText` strip invisible characters (zero width space, soft hyphen, word joiner, BOM) and fold every Unicode space separator (`Zs`, e.g. non-breaking space) to a regular space. Meaningful characters (zero width joiner, bidi controls, the `U+FFFC` WidgetSpan placeholder) and line breaks are kept. #138 (thx @MichaelTamm)
+  ```dart
+  spotText('foobar').existsOnce();  // matches Text('foo\u{200B}bar')
+  spotText('foo bar').existsOnce(); // matches Text('foo\u{00A0}bar')
+  ```
+  To match exact characters, pass `raw: true` to `spotText`/`spotTextWhere`, or use `whereRawText`/`withRawText`/`hasRawText` on `WidgetSelector<AnyText>`. Also exposes `AnyText.normalizeVisibleText`, `AnyText.extractText`, and `AnyTextContent` (`raw`/`normalized`).
+- Deprecated: `spotText(text, exact: true)` is now `spotText(text, whole: true)` — the flag controls whole-string vs. substring matching, not character handling. `exact` still works. #138
 - Fix: `loadAppFonts()` now also registers a package's own fonts under `packages/<self>/MyFont`, so fonts referenced via `package: '<self>'` render instead of falling back to Ahem. #141
 - Fix: Assertions like `spotKey(key).existsOnce()` were extremely slow (tens of seconds) when no match was found in a large widget tree. The error output is now limited and match-all selectors are no longer suggested as "less specific" matches. #119
 - Improvement: Untyped selectors (`spot`, `spotKey`, `spotWidget`, `spotElement`, `spotTexts`) no longer add a no-op `WidgetTypeFilter<Widget>` at the root.

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -79,7 +79,7 @@ export 'package:spot/src/spot/snapshot.dart'
         ToWidgetMatcher,
         WidgetSnapshot,
         WidgetSnapshotShorthands;
-export 'package:spot/src/spot/text/any_text.dart' show AnyText;
+export 'package:spot/src/spot/text/any_text.dart' show AnyText, AnyTextContent;
 export 'package:spot/src/spot/tree_snapshot.dart'
     show ScopedWidgetTreeSnapshot, WidgetTreeNode;
 export 'package:spot/src/spot/widget_matcher.dart'
@@ -321,8 +321,14 @@ WidgetSelector<W> spotElement<W extends Widget>(
 
 /// Finds text on the screen
 ///
-/// [spotText] compares text using 'contains'. For more control over the
-/// comparison, use [spotTextWhere] or set [exact] to `true`.
+/// By default [spotText] matches widgets whose text *contains* [text]. Set
+/// [whole] to `true` to require [text] to match the *entire* widget text
+/// instead. For full control over the comparison, use [spotTextWhere].
+///
+/// Matching ignores invisible and special whitespace characters (see
+/// [AnyText.normalizeVisibleText]); [whole] does not change that. To match the
+/// exact characters of a widget, use the raw selectors (`whereRawText` /
+/// `withRawText` / `hasRawText`).
 ///
 /// This method combines finding of [Text], [EditableText] and [SelectableText]
 /// widgets. Ultimately, all widgets show text as [RichText] widget.
@@ -339,12 +345,18 @@ WidgetSelector<AnyText> spotText(
   Pattern text, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
-  bool exact = false,
+  bool whole = false,
+  bool raw = false,
+  @Deprecated('Use whole instead. For exact-character matching, set raw: true.')
+  bool? exact,
 }) {
   return _global.spotText(
     text,
     parents: parents,
     children: children,
+    whole: whole,
+    raw: raw,
+    // ignore: deprecated_member_use_from_same_package
     exact: exact,
   );
 }
@@ -363,16 +375,22 @@ WidgetSelector<AnyText> spotText(
 /// spotTextWhere((it) => it.contains('Wo'));
 /// spotText('Wo');
 /// ```
+///
+/// By default [match] receives the text with invisible and special whitespace
+/// normalized (see [AnyText.normalizeVisibleText]). Set [raw] to `true` to
+/// match against the exact characters of the widget instead.
 @useResult
 WidgetSelector<AnyText> spotTextWhere(
   void Function(Subject<String>) match, {
   List<WidgetSelector> parents = const [],
   List<WidgetSelector> children = const [],
+  bool raw = false,
 }) {
   return _global.spotTextWhere(
     match,
     parents: parents,
     children: children,
+    raw: raw,
   );
 }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -218,8 +218,14 @@ mixin ChainableSelectors<T extends Widget> {
 
   /// Creates a [WidgetSelector] that finds text within the parent
   ///
-  /// [spotText] compares text using 'contains'. For more control over the
-  /// comparison, use [spotTextWhere] or set [exact] to `true`.
+  /// By default [spotText] matches widgets whose text *contains* [text]. Set
+  /// [whole] to `true` to require [text] to match the *entire* widget text
+  /// instead. For full control over the comparison, use [spotTextWhere].
+  ///
+  /// By default matching ignores invisible and special whitespace characters
+  /// (see [AnyText.normalizeVisibleText]); [whole] does not change that. Set
+  /// [raw] to `true` to match the exact characters of the widget instead, e.g.
+  /// to assert that a non-breaking space is really present.
   ///
   /// This method combines finding of [Text], [EditableText] and [SelectableText]
   /// widgets. Ultimately, all widgets show text as [RichText] widget.
@@ -237,17 +243,33 @@ mixin ChainableSelectors<T extends Widget> {
     Pattern text, {
     List<WidgetSelector> parents = const [],
     List<WidgetSelector> children = const [],
-    bool exact = false,
+    bool whole = false,
+    bool raw = false,
+    @Deprecated(
+      'Use whole instead. For exact-character matching, set raw: true.',
+    )
+    bool? exact,
   }) {
-    if (exact) {
-      if (text is! String) {
+    if (exact != null && whole) {
+      throw ArgumentError('Pass either `whole` or the deprecated `exact`.');
+    }
+    final matchWholeText = exact ?? whole;
+    // By default normalize string needles so 'foo bar' matches a widget that
+    // renders the same text using a non-breaking or zero width space. With
+    // raw: true the exact characters are matched. RegExp patterns are matched
+    // as-is against the (normalized or raw) widget text.
+    final needle =
+        (raw || text is! String) ? text : AnyText.normalizeVisibleText(text);
+    if (matchWholeText) {
+      if (needle is! String) {
         throw ArgumentError(
-          'Patterns are not supported for exact matching',
+          'Patterns are not supported when matching the whole text',
         );
       }
       return spotTextWhere(
-        (it) => it.equals(text),
-        description: 'with text "$text"',
+        (it) => it.equals(needle),
+        raw: raw,
+        description: 'with text "$needle"',
         parents: parents,
         children: children,
       );
@@ -255,8 +277,9 @@ mixin ChainableSelectors<T extends Widget> {
 
     // default with contains
     return spotTextWhere(
-      (it) => it.contains(text),
-      description: 'contains text "$text"',
+      (it) => it.contains(needle),
+      raw: raw,
+      description: 'contains text "$needle"',
       parents: parents,
       children: children,
     );
@@ -274,11 +297,16 @@ mixin ChainableSelectors<T extends Widget> {
   /// spotTextWhere((it) => it.contains('Wo'));
   /// spotText('Wo');
   /// ```
+  ///
+  /// By default [match] receives the text with invisible and special
+  /// whitespace normalized (see [AnyText.normalizeVisibleText]). Set [raw] to
+  /// `true` to match against the exact characters of the widget instead.
   @useResult
   WidgetSelector<AnyText> spotTextWhere(
     void Function(Subject<String>) match, {
     List<WidgetSelector> parents = const [],
     List<WidgetSelector> children = const [],
+    bool raw = false,
     String? description,
   }) {
     final String name = description ??
@@ -290,6 +318,7 @@ mixin ChainableSelectors<T extends Widget> {
         MatchTextFilter(
           match: (it) => match(it),
           description: 'Widget with text $name',
+          normalizeText: !raw,
         ),
         ..._childAndParentFilters(children, parents),
       ],

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -82,6 +82,56 @@ class AnyText extends LeafRenderObjectWidget {
     );
   }
 
+  /// Normalizes [text] to what a user visually perceives, so tests can match
+  /// text without worrying about invisible or special whitespace characters.
+  ///
+  /// Invisible characters with no visible glyph (zero width space, soft
+  /// hyphen, word joiner, BOM) are removed, and every Unicode space separator
+  /// (such as the non-breaking space) is folded to a regular space. Characters
+  /// that carry meaning (zero width joiner, bidi controls, the [WidgetSpan]
+  /// placeholder) and line structure (tabs, line breaks) are left untouched.
+  ///
+  /// This powers the forgiving matching of [spotText] and the `whereText` /
+  /// `withText` / `hasText` selectors. To match the exact characters of a
+  /// widget, use the raw variants (`whereRawText` / `withRawText` /
+  /// `hasRawText`).
+  static String normalizeVisibleText(String text) {
+    StringBuffer? result;
+    for (var i = 0; i < text.length; i++) {
+      final codeUnit = text.codeUnitAt(i);
+      final removed = _invisibleCodeUnits.contains(codeUnit);
+      final foldedToSpace =
+          !removed && _spaceSeparatorCodeUnits.contains(codeUnit);
+      if (!removed && !foldedToSpace) {
+        result?.writeCharCode(codeUnit);
+        continue;
+      }
+      // First special character: copy the untouched prefix into the buffer.
+      result ??= StringBuffer(text.substring(0, i));
+      if (foldedToSpace) {
+        result.write(' ');
+      }
+      // Removed characters are simply not written.
+    }
+    return result?.toString() ?? text;
+  }
+
+  /// Extracts the text from a text widget [element].
+  ///
+  /// Supports the text widgets spot recognizes: [EditableText] and [RichText],
+  /// which backs [Text] and [SelectableText]. Returns `null` for any other
+  /// widget.
+  static AnyTextContent? extractText(Element element) {
+    final widget = element.widget;
+    if (widget is EditableText) {
+      return AnyTextContent(widget.controller.text);
+    }
+    if (widget is RichText) {
+      return AnyTextContent(widget.text.toPlainText());
+    }
+    return null;
+  }
+
   /// The exact widget where the text was found
   final Widget widget;
 
@@ -164,7 +214,15 @@ class AnyText extends LeafRenderObjectWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(StringProperty('text', text));
+    final rawText = text;
+    final normalizedText =
+        rawText == null ? null : normalizeVisibleText(rawText);
+    // 'text' is normalized so matching ignores invisible/special whitespace
+    // (see [normalizeVisibleText]), while 'rawText' keeps the exact characters.
+    // Both are always added so the generator emits the `text` and `rawText`
+    // selector families.
+    properties.add(StringProperty('text', normalizedText));
+    properties.add(StringProperty('rawText', rawText));
     properties.add(
       EnumProperty<TextDirection>(
         'textDirection',
@@ -230,6 +288,71 @@ class AnyText extends LeafRenderObjectWidget {
   }
 }
 
+/// The text content of a text widget, available both as written ([raw]) and
+/// in a [normalized] form (see [AnyText.normalizeVisibleText]) suitable for
+/// matching. Returned by [AnyText.extractText].
+class AnyTextContent {
+  /// Creates an [AnyTextContent] from the [raw] text of a widget.
+  AnyTextContent(this.raw);
+
+  /// The text exactly as found in the widget, including invisible and special
+  /// whitespace characters.
+  final String raw;
+
+  /// The [raw] text run through [AnyText.normalizeVisibleText], matching what
+  /// a user visually perceives. Computed lazily and cached.
+  late final String normalized = AnyText.normalizeVisibleText(raw);
+
+  @override
+  String toString() => 'AnyTextContent(raw: "$raw", normalized: "$normalized")';
+}
+
+/// Code units that have no visible glyph and no semantic effect on plain
+/// text. [AnyText.normalizeVisibleText] removes them entirely.
+///
+/// Other invisible characters are deliberately **not** included because they
+/// carry meaning and removing them would change how the text renders:
+/// - `U+200C`/`U+200D` Zero Width Non-Joiner / Joiner drive emoji sequences
+///   (e.g. family emojis) and Indic/Arabic shaping.
+/// - `U+200E`/`U+200F` and other bidirectional controls change the visual
+///   order of mixed left-to-right and right-to-left text.
+/// - `U+FFFC` Object Replacement Character represents an embedded [WidgetSpan]
+///   and is meaningful content, not whitespace.
+const _invisibleCodeUnits = {
+  0x200B, // ZERO WIDTH SPACE: inserted to allow line breaks (flutter#18761)
+  0x00AD, // SOFT HYPHEN: invisible break hint, only renders when broken
+  0x2060, // WORD JOINER: invisible no-break glue
+  0xFEFF, // ZERO WIDTH NO-BREAK SPACE / BOM: invisible, often a stray prefix
+};
+
+/// Code units of Unicode Space_Separator (`Zs`) characters other than the
+/// regular space. [AnyText.normalizeVisibleText] folds them to a regular space
+/// because they all render as a blank of some width.
+///
+/// Each code point is listed explicitly (instead of a range) so a reader
+/// wondering what happens to e.g. `U+2004` can find it by searching the repo.
+///
+/// Tabs and line breaks (`U+0009`, `U+000A`, `U+000D`, ...) are intentionally
+/// left untouched: they are visually distinct structure, not spaces.
+const _spaceSeparatorCodeUnits = {
+  0x00A0, // NO-BREAK SPACE: glues words/units onto the same line
+  0x1680, // OGHAM SPACE MARK
+  0x2000, // EN QUAD
+  0x2001, // EM QUAD
+  0x2002, // EN SPACE
+  0x2003, // EM SPACE
+  0x2004, // THREE-PER-EM SPACE
+  0x2005, // FOUR-PER-EM SPACE
+  0x2006, // SIX-PER-EM SPACE
+  0x2007, // FIGURE SPACE
+  0x2008, // PUNCTUATION SPACE
+  0x2009, // THIN SPACE
+  0x200A, // HAIR SPACE
+  0x202F, // NARROW NO-BREAK SPACE: common in number/currency/locale formats
+  0x205F, // MEDIUM MATHEMATICAL SPACE
+  0x3000, // IDEOGRAPHIC SPACE: full-width CJK space
+};
+
 /// A [WidgetSelector] that matches any text on the screen, including:
 /// - [Text]
 /// - [SelectableText]
@@ -280,6 +403,7 @@ class MatchTextFilter implements ElementFilter {
   MatchTextFilter({
     required this.match,
     required this.description,
+    this.normalizeText = true,
   });
 
   /// The function that asserts the text content.
@@ -290,45 +414,29 @@ class MatchTextFilter implements ElementFilter {
   @override
   final String description;
 
+  /// When `true` (the default) [match] receives the [AnyTextContent.normalized]
+  /// text, ignoring invisible and special whitespace. When `false` it receives
+  /// the [AnyTextContent.raw] text, matching the exact characters.
+  final bool normalizeText;
+
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     return candidates.where((it) => _match(it.element));
   }
 
   bool _match(Element element) {
-    try {
-      final actual = _extractTextData(element);
-      final failure = softCheck(actual, match.hideNullability());
-      return failure == null;
-    } on _UnsupportedWidgetTypeException {
+    final content = AnyText.extractText(element);
+    if (content == null) {
+      // Not a text widget this filter understands.
       return false;
     }
-  }
-
-  String? _extractTextData(Element e) {
-    final widget = e.widget;
-    if (widget is EditableText) {
-      return widget.controller.text;
-    }
-    if (widget is RichText) {
-      return widget.text.toPlainText();
-    }
-    throw _UnsupportedWidgetTypeException(widget);
+    final actual = normalizeText ? content.normalized : content.raw;
+    final failure = softCheck(actual, match.hideNullability());
+    return failure == null;
   }
 
   @override
   String toString() {
     return 'MatchTextFilter which keeps $description';
-  }
-}
-
-class _UnsupportedWidgetTypeException implements Exception {
-  _UnsupportedWidgetTypeException(this.widget);
-
-  final Widget widget;
-
-  @override
-  String toString() {
-    return 'UnsupportedWidgetTypeException: ${widget.toStringShort()}';
   }
 }

--- a/lib/src/widgets/anytext.g.dart
+++ b/lib/src/widgets/anytext.g.dart
@@ -38,6 +38,29 @@ extension AnyTextSelector on WidgetSelector<AnyText> {
         'text', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
+  /// Creates a [WidgetSelector] that finds all [AnyText] where rawText matches the condition.
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// spot<AnyText>().whereRawText((it) => it.equals('foo')).existsOnce();
+  /// ```
+  @useResult
+  WidgetSelector<AnyText> whereRawText(MatchProp<String> match) {
+    return withDiagnosticProp<String>('rawText', match);
+  }
+
+  /// Creates a [WidgetSelector] that finds all [AnyText] where rawText equals (==) [value].
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// spot<AnyText>().withRawText('foo').existsOnce();
+  /// ```
+  @useResult
+  WidgetSelector<AnyText> withRawText(String? value) {
+    return withDiagnosticProp<String>(
+        'rawText', (it) => value == null ? it.isNull() : it.equals(value));
+  }
+
   /// Creates a [WidgetSelector] that finds all [AnyText] where textDirection matches the condition.
   ///
   /// #### Example usage:
@@ -641,6 +664,27 @@ extension AnyTextMatcher on WidgetMatcher<AnyText> {
         'text', (it) => value == null ? it.isNull() : it.equals(value));
   }
 
+  /// Expects that rawText of [AnyText] matches the condition in [match].
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// spot<AnyText>().existsOnce().hasRawTextWhere((it) => it.equals('foo'));
+  /// ```
+  WidgetMatcher<AnyText> hasRawTextWhere(MatchProp<String> match) {
+    return hasDiagnosticProp<String>('rawText', match);
+  }
+
+  /// Expects that rawText of [AnyText] equals (==) [value].
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// spot<AnyText>().existsOnce().hasRawText('foo');
+  /// ```
+  WidgetMatcher<AnyText> hasRawText(String? value) {
+    return hasDiagnosticProp<String>(
+        'rawText', (it) => value == null ? it.isNull() : it.equals(value));
+  }
+
   /// Expects that textDirection of [AnyText] matches the condition in [match].
   ///
   /// #### Example usage:
@@ -1176,6 +1220,11 @@ extension AnyTextGetter on WidgetMatcher<AnyText> {
   /// Returns the text of the matched [AnyText] via [Widget.toDiagnosticsNode]
   String getText() {
     return getDiagnosticProp<String>('text');
+  }
+
+  /// Returns the rawText of the matched [AnyText] via [Widget.toDiagnosticsNode]
+  String getRawText() {
+    return getDiagnosticProp<String>('rawText');
   }
 
   /// Returns the textDirection of the matched [AnyText] via [Widget.toDiagnosticsNode]

--- a/test/act/act_drag_test.dart
+++ b/test/act/act_drag_test.dart
@@ -24,9 +24,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 3', exact: true)
+        final firstItem = spotText('Item at index: 3', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 27', exact: true)
+        final secondItem = spotText('Item at index: 27', whole: true)
           ..doesNotExist();
         await act.dragUntilVisible(
           dragStart: firstItem,
@@ -48,9 +48,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 3', exact: true)
+        final firstItem = spotText('Item at index: 3', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 27', exact: true)
+        final secondItem = spotText('Item at index: 27', whole: true)
           ..existsOnce();
         await act.dragUntilVisible(
           dragStart: firstItem,
@@ -78,9 +78,9 @@ void dragTests() {
           const DragUntilVisibleSingleDirectionTestWidget(axis: Axis.vertical),
         );
 
-        final firstItem = spotText('Item at index: 3', exact: true)
+        final firstItem = spotText('Item at index: 3', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 27', exact: true)
+        final secondItem = spotText('Item at index: 27', whole: true)
           ..doesNotExist();
         await act.dragUntilVisible(
           dragStart: firstItem,
@@ -107,9 +107,9 @@ void dragTests() {
         await tester.pumpWidget(const NestedScrollDragUntilVisibleTestWidget());
 
         final firstItem =
-            spotText('ParentIndex: 0, Item at index: 3', exact: true);
+            spotText('ParentIndex: 0, Item at index: 3', whole: true);
         final secondItem =
-            spotText('ParentIndex: 2, Item at index: 4', exact: true);
+            spotText('ParentIndex: 2, Item at index: 4', whole: true);
         await act.dragUntilVisible(
           dragStart: firstItem,
           dragTarget: secondItem,
@@ -132,9 +132,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 2', exact: true)
+        final firstItem = spotText('Item at index: 2', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 10', exact: true)
+        final secondItem = spotText('Item at index: 10', whole: true)
           ..doesNotExist();
         await act.dragUntilVisible(
           dragStart: firstItem,
@@ -155,9 +155,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 2', exact: true)
+        final firstItem = spotText('Item at index: 2', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 10', exact: true)
+        final secondItem = spotText('Item at index: 10', whole: true)
           ..existsOnce();
         await act.dragUntilVisible(
           dragStart: firstItem,
@@ -187,9 +187,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 2', exact: true)
+        final firstItem = spotText('Item at index: 2', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 10', exact: true)
+        final secondItem = spotText('Item at index: 10', whole: true)
           ..doesNotExist();
         await act.dragUntilVisible(
           dragStart: firstItem,
@@ -220,9 +220,9 @@ void dragTests() {
         );
 
         final firstItem = spot<Container>()
-            .spotText('ParentIndex: 0, Item at index: 3', exact: true);
+            .spotText('ParentIndex: 0, Item at index: 3', whole: true);
         final secondItem =
-            spotText('ParentIndex: 2, Item at index: 4', exact: true);
+            spotText('ParentIndex: 2, Item at index: 4', whole: true);
         await act.dragUntilVisible(
           dragStart: firstItem,
           dragTarget: secondItem,
@@ -243,9 +243,9 @@ void dragTests() {
           const DragUntilVisibleSingleDirectionTestWidget(axis: Axis.vertical),
         );
 
-        final firstItem = spotText('Item at index: 3', exact: true)
+        final firstItem = spotText('Item at index: 3', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 27', exact: true)
+        final secondItem = spotText('Item at index: 27', whole: true)
           ..doesNotExist();
 
         const expectedErrorMessage =
@@ -277,9 +277,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 2', exact: true)
+        final firstItem = spotText('Item at index: 2', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 29', exact: true)
+        final secondItem = spotText('Item at index: 29', whole: true)
           ..doesNotExist();
 
         const expectedErrorMessage =
@@ -311,9 +311,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 2', exact: true)
+        final firstItem = spotText('Item at index: 2', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 29', exact: true)
+        final secondItem = spotText('Item at index: 29', whole: true)
           ..doesNotExist();
 
         await expectLater(
@@ -346,9 +346,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 2', exact: true)
+        final firstItem = spotText('Item at index: 2', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 29', exact: true)
+        final secondItem = spotText('Item at index: 29', whole: true)
           ..doesNotExist();
 
         await expectLater(
@@ -381,9 +381,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 2', exact: true)
+        final firstItem = spotText('Item at index: 2', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 29', exact: true)
+        final secondItem = spotText('Item at index: 29', whole: true)
           ..doesNotExist();
 
         await expectLater(
@@ -587,9 +587,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 3', exact: true)
+        final firstItem = spotText('Item at index: 3', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 27', exact: true)
+        final secondItem = spotText('Item at index: 27', whole: true)
           ..doesNotExist();
 
         await act.dragUntilVisible(
@@ -615,9 +615,9 @@ void dragTests() {
           ),
         );
 
-        final firstItem = spotText('Item at index: 2', exact: true)
+        final firstItem = spotText('Item at index: 2', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 20', exact: true)
+        final secondItem = spotText('Item at index: 20', whole: true)
           ..doesNotExist();
 
         await act.dragUntilVisible(
@@ -651,9 +651,9 @@ void dragTests() {
         // Items are 100 tall. Default cacheExtent is 250. Target item 8 sits
         // at content y=800 (outside initial cache [-250, 700]). A single drag
         // of -810 puts scroll past the target by 10 px — small final drag.
-        final firstItem = spotText('Item at index: 3', exact: true)
+        final firstItem = spotText('Item at index: 3', whole: true)
           ..existsOnce();
-        final secondItem = spotText('Item at index: 8', exact: true);
+        final secondItem = spotText('Item at index: 8', whole: true);
 
         await act.dragUntilVisible(
           dragStart: firstItem,

--- a/test/timeline/drag/act_drag_timeline_test_bodies.dart
+++ b/test/timeline/drag/act_drag_timeline_test_bodies.dart
@@ -10,8 +10,8 @@ import '../timeline_test_shared.dart' as shared;
 import 'drag_until_visible_test_widget.dart';
 
 class ActDragTimelineTestBodies {
-  static final _firstItemSelector = spotText('Item at index: 3', exact: true);
-  static final _secondItemSelector = spotText('Item at index: 27', exact: true);
+  static final _firstItemSelector = spotText('Item at index: 3', whole: true);
+  static final _secondItemSelector = spotText('Item at index: 27', whole: true);
 
   static const _failingDragAmount = 10;
   static const _failingOffset = Offset(0, -1000);
@@ -407,8 +407,8 @@ $globalInitiator
   testWidgets("$testTitle", (WidgetTester tester) async {
   $localInitiator
     await tester.pumpWidget(const DragUntilVisibleSingleDirectionTestWidget(axis: Axis.vertical));
-      final firstItem = spotText('Item at index: 3', exact: true)..existsOnce();
-      final secondItem = spotText('Item at index: 27', exact: true)
+      final firstItem = spotText('Item at index: 3', whole: true)..existsOnce();
+      final secondItem = spotText('Item at index: 27', whole: true)
         ..doesNotExist();
       await act.dragUntilVisible(
         dragStart: firstItem,

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -7,6 +7,8 @@ import 'package:spot/spot.dart';
 import '../spot/existence_comparison_test.dart';
 
 const testTextStyle = TextStyle(color: Colors.red);
+const zeroWidthSpace = '\u200B';
+const nonBreakingSpace = '\u00A0';
 
 void main() {
   // does inherit TextStyle
@@ -100,8 +102,8 @@ void main() {
 
         testWidgets('$widgetType exact', (tester) async {
           await tester.pumpWidget(tree.value);
-          spotText('foo', exact: true).existsOnce();
-          spotText('oo', exact: true).doesNotExist();
+          spotText('foo', whole: true).existsOnce();
+          spotText('oo', whole: true).doesNotExist();
         });
 
         testWidgets('$widgetType RegEx', (tester) async {
@@ -389,6 +391,180 @@ void main() {
           'font_size: null',
         ]),
       );
+    });
+  });
+
+  group('visible text normalization', () {
+    test('normalizeVisibleText removes invisible characters', () {
+      expect(AnyText.normalizeVisibleText('f\u200Bo\u200Bo'), 'foo'); // ZWSP
+      expect(AnyText.normalizeVisibleText('soft\u00ADhyphen'),
+          'softhyphen'); // SHY
+      expect(
+          AnyText.normalizeVisibleText('word\u2060joiner'), 'wordjoiner'); // WJ
+      expect(AnyText.normalizeVisibleText('\uFEFFbom'), 'bom'); // ZWNBSP / BOM
+    });
+
+    test('normalizeVisibleText folds space separators to a regular space', () {
+      expect(AnyText.normalizeVisibleText('foo\u00A0bar'), 'foo bar'); // NBSP
+      expect(
+          AnyText.normalizeVisibleText('1\u202F234'), '1 234'); // NARROW NBSP
+      expect(AnyText.normalizeVisibleText('thin\u2009space'), 'thin space');
+      expect(AnyText.normalizeVisibleText('em\u2003space'), 'em space');
+      expect(AnyText.normalizeVisibleText('ogham\u1680mark'), 'ogham mark');
+      expect(AnyText.normalizeVisibleText('math\u205Fspace'), 'math space');
+      expect(AnyText.normalizeVisibleText('full\u3000width'), 'full width');
+    });
+
+    test('normalizeVisibleText keeps meaningful and structural characters', () {
+      // Zero Width Joiner builds emoji sequences and must be preserved.
+      expect(AnyText.normalizeVisibleText('a\u200Db'), 'a\u200Db');
+      // Object Replacement Character represents an embedded WidgetSpan.
+      expect(AnyText.normalizeVisibleText('a\uFFFCb'), 'a\uFFFCb');
+      // Tabs and line breaks are structure, not spaces.
+      expect(AnyText.normalizeVisibleText('a\tb\nc'), 'a\tb\nc');
+      expect(AnyText.normalizeVisibleText('unchanged'), 'unchanged');
+    });
+
+    test('TextContent exposes both raw and normalized text', () {
+      final content = AnyTextContent('foo${nonBreakingSpace}bar');
+      expect(content.raw, 'foo${nonBreakingSpace}bar');
+      expect(content.normalized, 'foo bar');
+    });
+
+    testWidgets('extractTextContent reads raw and normalized from a widget',
+        (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('foo${nonBreakingSpace}bar')]),
+      );
+      final content =
+          AnyText.extractText(tester.element(find.byType(RichText).first));
+      expect(content, isNotNull);
+      expect(content!.raw, 'foo${nonBreakingSpace}bar');
+      expect(content.normalized, 'foo bar');
+    });
+
+    testWidgets('extractTextContent returns null for non-text widgets',
+        (tester) async {
+      await tester.pumpWidget(_stage(children: [Icon(Icons.add)]));
+      expect(
+        AnyText.extractText(tester.element(find.byIcon(Icons.add))),
+        isNull,
+      );
+    });
+
+    testWidgets('spotText ignores ZWSP', (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('f${zeroWidthSpace}o${zeroWidthSpace}o')]),
+      );
+      spotText('foo').existsOnce();
+      spot<Column>().spotText('foo').existsOnce();
+      // The needle is normalized too, so the raw spelling matches as well.
+      spotText('f${zeroWidthSpace}o${zeroWidthSpace}o').existsOnce();
+    });
+
+    testWidgets('spotText treats NBSP as a regular space', (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('foo${nonBreakingSpace}bar baz')]),
+      );
+      spotText('foo bar baz').existsOnce();
+      spotText('foo${nonBreakingSpace}bar baz').existsOnce();
+      spotText('foo bar${nonBreakingSpace}baz').existsOnce();
+    });
+
+    testWidgets('spotText with whole matches the entire text', (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('a${nonBreakingSpace}b')]),
+      );
+      spotText('a b', whole: true).existsOnce();
+      spotText('a${nonBreakingSpace}b', whole: true).existsOnce();
+      // whole requires the entire text, so a substring does not match.
+      spotText('a', whole: true).doesNotExist();
+      spotText('a').existsOnce();
+    });
+
+    testWidgets('deprecated exact still behaves like whole', (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('a${nonBreakingSpace}b')]),
+      );
+      spotText('a b', exact: true).existsOnce();
+      spotText('a', exact: true).doesNotExist();
+    });
+
+    testWidgets('spotText handles narrow NBSP and soft hyphen', (tester) async {
+      // '12<NNBSP>345' price formatting and a soft hyphen inside 'invisible'.
+      await tester.pumpWidget(
+        _stage(children: [Text('12\u202F345 \u20AC in\u00ADvisible')]),
+      );
+      spotText('12 345 \u20AC invisible').existsOnce();
+    });
+
+    testWidgets('spotText normalizes ZWSP inside Text.rich', (tester) async {
+      await tester.pumpWidget(
+        _stage(
+          children: [Text.rich(TextSpan(text: 'He${zeroWidthSpace}llo'))],
+        ),
+      );
+      spotText('Hello').existsOnce();
+    });
+
+    testWidgets('whereText/withText/hasText match the normalized text',
+        (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('foo${nonBreakingSpace}bar')]),
+      );
+      spotText('foo').whereText((it) => it.equals('foo bar')).existsOnce();
+      spotText('foo').withText('foo bar').existsOnce();
+      spotText('foo').existsOnce().hasText('foo bar');
+    });
+
+    testWidgets('whereRawText/withRawText/hasRawText match exact characters',
+        (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('foo${nonBreakingSpace}bar')]),
+      );
+      // The raw text keeps the NBSP, so a regular space does not match.
+      spotText('foo').withRawText('foo bar').doesNotExist();
+      spotText('foo').withRawText('foo${nonBreakingSpace}bar').existsOnce();
+      spotText('foo')
+          .whereRawText((it) => it.equals('foo${nonBreakingSpace}bar'))
+          .existsOnce();
+      spotText('foo').existsOnce().hasRawText('foo${nonBreakingSpace}bar');
+    });
+
+    testWidgets('spotTextWhere operates on the normalized text',
+        (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('foo${nonBreakingSpace}bar')]),
+      );
+      spotTextWhere((it) => it.contains('foo bar')).existsOnce();
+      spotTextWhere((it) => it.startsWith('foo b')).existsOnce();
+    });
+
+    testWidgets('spotText with raw matches the exact characters',
+        (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('foo${nonBreakingSpace}bar')]),
+      );
+      // The NBSP is matched literally; a regular space does not match.
+      spotText('foo${nonBreakingSpace}bar', raw: true).existsOnce();
+      spotText('foo bar', raw: true).doesNotExist();
+      // contains by default, whole requires the entire text
+      spotText('foo$nonBreakingSpace', raw: true).existsOnce();
+      spotText('foo$nonBreakingSpace', raw: true, whole: true).doesNotExist();
+      spotText('foo${nonBreakingSpace}bar', raw: true, whole: true)
+          .existsOnce();
+    });
+
+    testWidgets('spotTextWhere with raw operates on the raw text',
+        (tester) async {
+      await tester.pumpWidget(
+        _stage(children: [Text('foo${nonBreakingSpace}bar')]),
+      );
+      spotTextWhere((it) => it.equals('foo${nonBreakingSpace}bar'), raw: true)
+          .existsOnce();
+      spotTextWhere((it) => it.equals('foo bar'), raw: true).doesNotExist();
+      spotTextWhere((it) => it.startsWith('foo$nonBreakingSpace'), raw: true)
+          .existsOnce();
     });
   });
 }


### PR DESCRIPTION
Fixes #138

`spotText` and the `AnyText` text selectors now match what a user *sees*: invisible characters and characters that render as a space are ignored, so tests can use plain characters instead of escapes.

```dart
// Given Text('foo\u{200B}bar')  → ZWSP inserted for line breaks
spotText('foobar').existsOnce();

// Given Text('12\u{202F}345\u{00A0}€')  → narrow + non-breaking spaces
spotText('12 345 €').existsOnce();
```

### Normalization rule

`normalizeVisibleText(String)` applies a clear, two-part rule:

- **Removed** (invisible, no meaning): Zero Width Space `U+200B`, Soft Hyphen `U+00AD`, Word Joiner `U+2060`, BOM `U+FEFF`
- **Folded to a regular space**: every Unicode space separator (`Zs`) — Non-Breaking Space `U+00A0`, Narrow No-Break Space `U+202F`, thin/em/figure spaces, ideographic space, …

Deliberately left untouched, because they carry meaning or structure: Zero Width Joiner / Non-Joiner (emoji sequences, Indic/Arabic shaping), bidi controls, the `U+FFFC` `WidgetSpan` placeholder, tabs and line breaks.

### Matching the exact characters

When a test needs the literal bytes, `AnyText` now exposes a `rawText` property alongside the normalized `text`, generating a raw selector family:

```dart
// Text('foo\u{00A0}bar')
spotText('foo').withText('foo bar').existsOnce();           // normalized
spotText('foo').withRawText('foo\u{00A0}bar').existsOnce(); // exact
```

New: `whereRawText`, `withRawText`, `hasRawText`, `getRawText`, `hasRawTextWhere` on `WidgetSelector<AnyText>`, plus public `normalizeVisibleText`, `extractTextContent(Element)`, the `TextContent` holder (`raw`/`normalized`), and `zeroWidthSpace`/`nonBreakingSpace` constants.

### Scope

The concrete `spot<Text>()` / `spot<SelectableText>()` / `spot<EditableText>()` selectors read their native diagnostic props and are unchanged. Use `spotText` / `spot<AnyText>` for the normalized behavior.

Builds on the idea from #139 (thx @MichaelTamm), extended to a complete character set with a raw escape hatch.