### PR TITLE
Speed up relative selector queries by walking up the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   To match exact characters, pass `raw: true` to `spotText`/`spotTextWhere`, or use `whereRawText`/`withRawText`/`hasRawText` on `WidgetSelector<AnyText>`. Also exposes `AnyText.normalizeVisibleText`, `AnyText.extractText`, and `AnyTextContent` (`raw`/`normalized`).
 - Deprecated: `spotText(text, exact: true)` is now `spotText(text, whole: true)` — the flag controls whole-string vs. substring matching, not character handling. `exact` still works. #138
 - Improvement: Queries with `withParent`/`withChild` and chained selectors are drastically faster (up to 200x on big widget trees). Relationships are now resolved by walking up the tree instead of searching the subtree of every parent. #148
+- New: `WidgetSnapshot.queryStats` reports how much work the query engine performed to evaluate a selector, useful to debug slow queries. #148
 - Fix: `loadAppFonts()` now also registers a package's own fonts under `packages/<self>/MyFont`, so fonts referenced via `package: '<self>'` render instead of falling back to Ahem. #141
 - Fix: Assertions like `spotKey(key).existsOnce()` were extremely slow (tens of seconds) when no match was found in a large widget tree. The error output is now limited and match-all selectors are no longer suggested as "less specific" matches. #119
 - Improvement: Untyped selectors (`spot`, `spotKey`, `spotWidget`, `spotElement`, `spotTexts`) no longer add a no-op `WidgetTypeFilter<Widget>` at the root.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   ```
   To match exact characters, pass `raw: true` to `spotText`/`spotTextWhere`, or use `whereRawText`/`withRawText`/`hasRawText` on `WidgetSelector<AnyText>`. Also exposes `AnyText.normalizeVisibleText`, `AnyText.extractText`, and `AnyTextContent` (`raw`/`normalized`).
 - Deprecated: `spotText(text, exact: true)` is now `spotText(text, whole: true)` — the flag controls whole-string vs. substring matching, not character handling. `exact` still works. #138
+- Improvement: Queries with `withParent`/`withChild` and chained selectors are drastically faster (up to 200x on big widget trees). Relationships are now resolved by walking up the tree instead of searching the subtree of every parent. #148
 - Fix: `loadAppFonts()` now also registers a package's own fonts under `packages/<self>/MyFont`, so fonts referenced via `package: '<self>'` render instead of falling back to Ahem. #141
 - Fix: Assertions like `spotKey(key).existsOnce()` were extremely slow (tens of seconds) when no match was found in a large widget tree. The error output is now limited and match-all selectors are no longer suggested as "less specific" matches. #119
 - Improvement: Untyped selectors (`spot`, `spotKey`, `spotWidget`, `spotElement`, `spotTexts`) no longer add a no-op `WidgetTypeFilter<Widget>` at the root.

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -101,6 +101,7 @@ export 'package:spot/src/spot/widget_selector.dart'
         QuantityConstraint,
         // ignore: deprecated_member_use_from_same_package
         SingleWidgetSelector,
+        SpotCacheKey,
         WidgetPresence,
         WidgetSelector;
 export 'package:spot/src/timeline/timeline.dart'

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -60,6 +60,7 @@ export 'package:spot/src/spot/props.dart'
         renderObjectProp,
         stateProp,
         widgetProp;
+export 'package:spot/src/spot/query_stats.dart' show QueryStats;
 export 'package:spot/src/spot/selectors.dart'
     show
         PositionFilterSelector,

--- a/lib/src/spot/filters/child_filter.dart
+++ b/lib/src/spot/filters/child_filter.dart
@@ -18,6 +18,19 @@ class ChildFilter implements ElementFilter {
   final List<WidgetSelector> childSelectors;
 
   @override
+  Object? get cacheKey {
+    final childKeys = <Object>[];
+    for (final childSelector in childSelectors) {
+      final key = childSelector.cacheKey;
+      if (key == null) {
+        return null;
+      }
+      childKeys.add(key);
+    }
+    return SpotCacheKey(ChildFilter, childKeys);
+  }
+
+  @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     if (childSelectors.isEmpty) {
       return candidates;

--- a/lib/src/spot/filters/child_filter.dart
+++ b/lib/src/spot/filters/child_filter.dart
@@ -50,7 +50,7 @@ class ChildFilter implements ElementFilter {
         // Start above the match, a widget is not its own child
         WidgetTreeNode? ancestor = match.parent;
         while (ancestor != null) {
-          QueryStats.relationChecks++;
+          QueryStatsCounter.relationChecks++;
           matchesBelowNode[ancestor] = (matchesBelowNode[ancestor] ?? 0) + 1;
           ancestor = ancestor.parent;
         }
@@ -62,7 +62,7 @@ class ChildFilter implements ElementFilter {
     for (final WidgetTreeNode candidate in candidates) {
       bool allChildrenMatch = true;
       for (int i = 0; i < matchSelectors.length; i++) {
-        QueryStats.relationChecks++;
+        QueryStatsCounter.relationChecks++;
         final int matchCount = matchCountsPerSelector[i][candidate] ?? 0;
         if (!_matchesQuantityConstraint(matchSelectors[i], matchCount)) {
           allChildrenMatch = false;

--- a/lib/src/spot/filters/child_filter.dart
+++ b/lib/src/spot/filters/child_filter.dart
@@ -1,5 +1,5 @@
 import 'package:dartx/dartx.dart';
-import 'package:flutter/widgets.dart';
+import 'package:spot/src/spot/query_stats.dart';
 import 'package:spot/src/spot/snapshot.dart';
 import 'package:spot/src/spot/widget_selector.dart';
 
@@ -22,10 +22,10 @@ class ChildFilter implements ElementFilter {
     if (childSelectors.isEmpty) {
       return candidates;
     }
-    final tree = currentWidgetTreeSnapshot();
 
     // First check all negate selectors (where maxQuantity == 0)
-    final negates = childSelectors.where((e) => e.quantityConstraint.max == 0);
+    final negates =
+        childSelectors.where((e) => e.quantityConstraint.max == 0).toList();
     for (final negate in negates) {
       final s = snapshot(negate, validateQuantity: false);
       if (s.discovered.isNotEmpty) {
@@ -34,56 +34,44 @@ class ChildFilter implements ElementFilter {
       }
     }
 
+    final List<WidgetSelector> matchSelectors = childSelectors - negates;
+
+    // Snapshot each child selector once (the result is independent of the
+    // candidates). Then walk from every discovered child up to the root and
+    // count the matches below each ancestor, instead of searching the
+    // subtree of every candidate over and over again.
+    final List<Map<WidgetTreeNode, int>> matchCountsPerSelector = [];
+    for (final WidgetSelector childSelector in matchSelectors) {
+      final WidgetSnapshot childSnapshot =
+          snapshot(childSelector, validateQuantity: false);
+
+      final Map<WidgetTreeNode, int> matchesBelowNode = Map.identity();
+      for (final WidgetTreeNode match in childSnapshot.discovered) {
+        // Start above the match, a widget is not its own child
+        WidgetTreeNode? ancestor = match.parent;
+        while (ancestor != null) {
+          QueryStats.relationChecks++;
+          matchesBelowNode[ancestor] = (matchesBelowNode[ancestor] ?? 0) + 1;
+          ancestor = ancestor.parent;
+        }
+      }
+      matchCountsPerSelector.add(matchesBelowNode);
+    }
+
     final List<WidgetTreeNode> matchingChildNodes = [];
-
-    // Then check for every queryMatch if the children and props match
     for (final WidgetTreeNode candidate in candidates) {
-      final Map<WidgetSelector, List<WidgetTreeNode>> matchesPerChild = {};
-
-      final ScopedWidgetTreeSnapshot subtree = tree.scope(candidate);
-      final List<WidgetTreeNode> subtreeNodes = subtree.allNodes;
-      for (final WidgetSelector<Widget> childSelector
-          in childSelectors - negates) {
-        matchesPerChild[childSelector] = [];
-        // TODO instead of searching the children, starting from the root widget, find a way to reverse the search and
-        //  start form the subtree.
-        //  Keep in mind, each child selector might be defined with parents which are outside of the subtree
-        final WidgetSnapshot ss =
-            snapshot(childSelector, validateQuantity: false);
-
-        final minConstraint = childSelector.quantityConstraint.min;
-        final maxConstraint = childSelector.quantityConstraint.max;
-
-        final discoveredInSubtree =
-            ss.discovered.where((node) => subtreeNodes.contains(node)).toList();
-
-        if (minConstraint == null &&
-            maxConstraint == null &&
-            discoveredInSubtree.isEmpty) {
-          // This childSelector doesn't match any child
-          continue;
+      bool allChildrenMatch = true;
+      for (int i = 0; i < matchSelectors.length; i++) {
+        QueryStats.relationChecks++;
+        final int matchCount = matchCountsPerSelector[i][candidate] ?? 0;
+        if (!_matchesQuantityConstraint(matchSelectors[i], matchCount)) {
+          allChildrenMatch = false;
+          break;
         }
-
-        if (minConstraint != null &&
-            minConstraint > discoveredInSubtree.length) {
-          // not a match found less than the minimum required
-          continue;
-        }
-        if (maxConstraint != null &&
-            maxConstraint < discoveredInSubtree.length) {
-          // not a match because found more than the maximum allowed
-          continue;
-        }
-
-        // consider it as a match
-        matchesPerChild[childSelector] = discoveredInSubtree;
       }
-      // TODO early exist the loop above instead of adding an empty list to the map
-      if (matchesPerChild.values.any((list) => list.isEmpty)) {
-        // not all children match
-        continue;
+      if (allChildrenMatch) {
+        matchingChildNodes.add(candidate);
       }
-      matchingChildNodes.add(candidate);
     }
     return matchingChildNodes;
   }
@@ -100,4 +88,29 @@ class ChildFilter implements ElementFilter {
   String toString() {
     return 'ChildFilter $description';
   }
+}
+
+/// Whether [matchCount] children found below a candidate satisfy the
+/// [QuantityConstraint] of [childSelector].
+///
+/// At least one child has to match, even when the constraint allows zero
+/// matches (e.g. `atMost(2)`).
+bool _matchesQuantityConstraint(
+  WidgetSelector childSelector,
+  int matchCount,
+) {
+  if (matchCount == 0) {
+    return false;
+  }
+  final minConstraint = childSelector.quantityConstraint.min;
+  if (minConstraint != null && minConstraint > matchCount) {
+    // found less than the minimum required
+    return false;
+  }
+  final maxConstraint = childSelector.quantityConstraint.max;
+  if (maxConstraint != null && maxConstraint < matchCount) {
+    // found more than the maximum allowed
+    return false;
+  }
+  return true;
 }

--- a/lib/src/spot/filters/onstage_filter.dart
+++ b/lib/src/spot/filters/onstage_filter.dart
@@ -8,7 +8,7 @@ class OnstageFilter implements ElementFilter {
     final List<WidgetTreeNode> onstage = [];
 
     for (final WidgetTreeNode candidate in candidates) {
-      QueryStats.candidateChecks++;
+      QueryStatsCounter.candidateChecks++;
       if (!candidate.isOffstage) {
         onstage.add(candidate);
       }
@@ -34,7 +34,7 @@ class OffstageFilter implements ElementFilter {
     final List<WidgetTreeNode> offstage = [];
 
     for (final WidgetTreeNode candidate in candidates) {
-      QueryStats.candidateChecks++;
+      QueryStatsCounter.candidateChecks++;
       if (candidate.isOffstage) {
         offstage.add(candidate);
       }

--- a/lib/src/spot/filters/onstage_filter.dart
+++ b/lib/src/spot/filters/onstage_filter.dart
@@ -4,6 +4,9 @@ import 'package:spot/src/spot/widget_selector.dart';
 /// Removes all [WidgetTreeNode] that are offstage
 class OnstageFilter implements ElementFilter {
   @override
+  Object get cacheKey => OnstageFilter;
+
+  @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     final List<WidgetTreeNode> onstage = [];
 
@@ -29,6 +32,9 @@ class OnstageFilter implements ElementFilter {
 
 /// Removes all [WidgetTreeNode] that are onstage
 class OffstageFilter implements ElementFilter {
+  @override
+  Object get cacheKey => OffstageFilter;
+
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     final List<WidgetTreeNode> offstage = [];

--- a/lib/src/spot/filters/onstage_filter.dart
+++ b/lib/src/spot/filters/onstage_filter.dart
@@ -1,3 +1,4 @@
+import 'package:spot/src/spot/query_stats.dart';
 import 'package:spot/src/spot/widget_selector.dart';
 
 /// Removes all [WidgetTreeNode] that are offstage
@@ -7,6 +8,7 @@ class OnstageFilter implements ElementFilter {
     final List<WidgetTreeNode> onstage = [];
 
     for (final WidgetTreeNode candidate in candidates) {
+      QueryStats.candidateChecks++;
       if (!candidate.isOffstage) {
         onstage.add(candidate);
       }
@@ -32,6 +34,7 @@ class OffstageFilter implements ElementFilter {
     final List<WidgetTreeNode> offstage = [];
 
     for (final WidgetTreeNode candidate in candidates) {
+      QueryStats.candidateChecks++;
       if (candidate.isOffstage) {
         offstage.add(candidate);
       }

--- a/lib/src/spot/filters/parent_filter.dart
+++ b/lib/src/spot/filters/parent_filter.dart
@@ -1,6 +1,5 @@
-import 'package:dartx/dartx.dart';
 import 'package:flutter/widgets.dart';
-import 'package:spot/spot.dart';
+import 'package:spot/src/spot/query_stats.dart';
 import 'package:spot/src/spot/snapshot.dart';
 import 'package:spot/src/spot/widget_selector.dart';
 
@@ -22,9 +21,10 @@ class ParentFilter implements ElementFilter {
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
-    final tree = currentWidgetTreeSnapshot();
-
-    final List<WidgetSnapshot<Widget>> parentSnapshots = [];
+    // The elements each parent selector discovered. A candidate matches a
+    // parent selector when the candidate itself, or one of its ancestors,
+    // was discovered by that selector.
+    final List<Set<Element>> parentSets = [];
     for (final selector in parents) {
       final WidgetSnapshot<Widget> widgetSnapshot =
           snapshot(selector, validateQuantity: false);
@@ -34,84 +34,23 @@ class ParentFilter implements ElementFilter {
         throw UnimplementedError(
           'Parents can not be negated, yet. Please upvote https://github.com/passsy/spot/issues/49',
         );
-      } else {
-        widgetSnapshot.validateQuantity();
-        parentSnapshots.add(widgetSnapshot);
       }
+      widgetSnapshot.validateQuantity();
+      parentSets.add(
+        widgetSnapshot.discovered.map((node) => node.element).toSet(),
+      );
     }
 
-    final List<Map<WidgetTreeNode, List<WidgetSnapshot>>> discoveryByParent =
-        [];
-
-    for (final parentSnapshot in parentSnapshots) {
-      final Map<WidgetTreeNode, List<WidgetSnapshot>> groups = {};
-      if (parentSnapshot.discovered.isEmpty) {
-        discoveryByParent.add(groups);
-        continue;
+    // Instead of searching downwards from every discovered parent (which
+    // visits whole subtrees), walk from each candidate up to the root. The
+    // path to the root is short (the tree depth), and each step is a single
+    // hash lookup per parent selector.
+    final List<WidgetTreeNode> remaining = [];
+    for (final candidate in candidates) {
+      if (_isWithinAllParents(candidate, parentSets)) {
+        remaining.add(candidate);
       }
-
-      // remove elements when the parent is already in the list. This prevents searching all element of a subtree, resulting in always the same items
-      final rootNodes = parentSnapshot.discovered
-          .whereNot(
-            (element) => parentSnapshot.discovered.contains(element.parent),
-          )
-          .toList();
-
-      final visibilityMode = parentSnapshot.selector.widgetPresence;
-
-      for (final WidgetTreeNode node in rootNodes) {
-        groups[node] ??= [];
-
-        final WidgetSelector root = switch (visibilityMode) {
-          WidgetPresence.onstage => spot(),
-          WidgetPresence.offstage => spotOffstage(),
-          WidgetPresence.combined => spotAllWidgets(),
-        };
-        final subtree = tree.scope(node);
-        final snapshot = WidgetSnapshot(
-          selector: root.withParent(spotElement(node.element)),
-          discovered: [
-            node,
-            ...subtree.allNodes,
-          ],
-          scope: subtree,
-          debugCandidates: candidates.map((it) => it.element).toList(),
-        );
-        groups[node]!.add(snapshot);
-      }
-
-      discoveryByParent.add(groups);
     }
-
-    final List<WidgetSnapshot> discoveredSnapshots =
-        discoveryByParent.map((it) => it.values).flatten().flatten().toList();
-
-    final List<WidgetTreeNode> allDiscoveredNodes =
-        discoveredSnapshots.map((it) => it.discovered).flatten().toList();
-
-    final List<Element> distinctElements =
-        allDiscoveredNodes.map((e) => e.element).toSet().toList();
-
-    // find nodes that exist in all parents
-    final List<Element> elementsInAllParents =
-        distinctElements.where((element) {
-      return discoveryByParent.all((
-        Map<WidgetTreeNode, List<WidgetSnapshot>> discovered,
-      ) {
-        return discovered.values.any((List<WidgetSnapshot> list) {
-          return list.any((node) {
-            return node.discovered.map((e) => e.element).contains(element);
-          });
-        });
-      });
-    }).toList();
-
-    final remaining = elementsInAllParents.mapNotNull((e) {
-      return candidates.firstOrNullWhere((node) {
-        return node.element == e;
-      });
-    }).toList();
-
     return remaining;
   }
 
@@ -119,4 +58,23 @@ class ParentFilter implements ElementFilter {
   String toString() {
     return 'ParentFilter which keeps $description Widget';
   }
+}
+
+/// Returns true when, for every parent selector, [candidate] or one of its
+/// ancestors was discovered by that selector ([parentSets]).
+///
+/// Different parent selectors may be satisfied by different ancestors.
+bool _isWithinAllParents(
+  WidgetTreeNode candidate,
+  List<Set<Element>> parentSets,
+) {
+  final List<Set<Element>> unsatisfied = parentSets.toList();
+  WidgetTreeNode? node = candidate;
+  while (node != null && unsatisfied.isNotEmpty) {
+    final element = node.element;
+    QueryStats.relationChecks += unsatisfied.length;
+    unsatisfied.removeWhere((parentSet) => parentSet.contains(element));
+    node = node.parent;
+  }
+  return unsatisfied.isEmpty;
 }

--- a/lib/src/spot/filters/parent_filter.dart
+++ b/lib/src/spot/filters/parent_filter.dart
@@ -12,6 +12,19 @@ class ParentFilter implements ElementFilter {
   final List<WidgetSelector> parents;
 
   @override
+  Object? get cacheKey {
+    final parentKeys = <Object>[];
+    for (final parent in parents) {
+      final key = parent.cacheKey;
+      if (key == null) {
+        return null;
+      }
+      parentKeys.add(key);
+    }
+    return SpotCacheKey(ParentFilter, parentKeys);
+  }
+
+  @override
   String get description {
     if (parents.length == 1) {
       return parents.first.toStringBreadcrumb();

--- a/lib/src/spot/filters/parent_filter.dart
+++ b/lib/src/spot/filters/parent_filter.dart
@@ -72,7 +72,7 @@ bool _isWithinAllParents(
   WidgetTreeNode? node = candidate;
   while (node != null && unsatisfied.isNotEmpty) {
     final element = node.element;
-    QueryStats.relationChecks += unsatisfied.length;
+    QueryStatsCounter.relationChecks += unsatisfied.length;
     unsatisfied.removeWhere((parentSet) => parentSet.contains(element));
     node = node.parent;
   }

--- a/lib/src/spot/filters/position_filter.dart
+++ b/lib/src/spot/filters/position_filter.dart
@@ -12,6 +12,9 @@ class PositionFilter implements ElementFilter {
   final Offset position;
 
   @override
+  Object? get cacheKey => null;
+
+  @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     final HitTestResult result = HitTestResult();
     // Flutter 3.10 does not expose the view-aware hitTestInView API yet.

--- a/lib/src/spot/filters/predicate_filter.dart
+++ b/lib/src/spot/filters/predicate_filter.dart
@@ -15,7 +15,7 @@ class PredicateFilter implements ElementFilter {
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     return candidates.where((node) {
-      QueryStats.candidateChecks++;
+      QueryStatsCounter.candidateChecks++;
       return predicate(node.element);
     });
   }

--- a/lib/src/spot/filters/predicate_filter.dart
+++ b/lib/src/spot/filters/predicate_filter.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:spot/src/spot/query_stats.dart';
 import 'package:spot/src/spot/widget_selector.dart';
 
 /// Filters widget tree nodes based on a predicate
@@ -14,6 +15,7 @@ class PredicateFilter implements ElementFilter {
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     return candidates.where((node) {
+      QueryStats.candidateChecks++;
       return predicate(node.element);
     });
   }

--- a/lib/src/spot/filters/predicate_filter.dart
+++ b/lib/src/spot/filters/predicate_filter.dart
@@ -10,7 +10,14 @@ class PredicateFilter implements ElementFilter {
   /// Creates a super generic filter that filters based on a predicate.
   ///
   /// The [description] is used to describe the filter in error messages.
-  PredicateFilter({required this.predicate, required this.description});
+  PredicateFilter({
+    required this.predicate,
+    required this.description,
+    this.cacheKey,
+  });
+
+  @override
+  final Object? cacheKey;
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {

--- a/lib/src/spot/filters/widget_type_filter.dart
+++ b/lib/src/spot/filters/widget_type_filter.dart
@@ -8,6 +8,9 @@ import 'package:spot/src/spot/widget_selector.dart';
 /// does not accidentally match a [Center] Widget, that extends [Align].
 class WidgetTypeFilter<W extends Widget> implements ElementFilter {
   @override
+  Object get cacheKey => SpotCacheKey(WidgetTypeFilter, [W]);
+
+  @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     if (W == Widget) {
       // [W] is the broadest possible type, this filter is a no-op that keeps

--- a/lib/src/spot/filters/widget_type_filter.dart
+++ b/lib/src/spot/filters/widget_type_filter.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:spot/src/spot/query_stats.dart';
 import 'package:spot/src/spot/widget_selector.dart';
 
 /// Filters candidates by widget type [W] comparing the runtime type.
@@ -14,9 +15,10 @@ class WidgetTypeFilter<W extends Widget> implements ElementFilter {
       return candidates;
     }
     final type = _typeOf<W>();
-    return candidates
-        .where((WidgetTreeNode node) => node.element.widget.runtimeType == type)
-        .toList();
+    return candidates.where((WidgetTreeNode node) {
+      QueryStats.candidateChecks++;
+      return node.element.widget.runtimeType == type;
+    }).toList();
   }
 
   @override

--- a/lib/src/spot/filters/widget_type_filter.dart
+++ b/lib/src/spot/filters/widget_type_filter.dart
@@ -16,7 +16,7 @@ class WidgetTypeFilter<W extends Widget> implements ElementFilter {
     }
     final type = _typeOf<W>();
     return candidates.where((WidgetTreeNode node) {
-      QueryStats.candidateChecks++;
+      QueryStatsCounter.candidateChecks++;
       return node.element.widget.runtimeType == type;
     }).toList();
   }

--- a/lib/src/spot/query_stats.dart
+++ b/lib/src/spot/query_stats.dart
@@ -44,7 +44,7 @@ class QueryStats {
   /// parent and child selectors.
   final int snapshotCalls;
 
-  /// Sum of all checks, the total work done by the query engine.
+  /// Sum of [nodesTraversed], [candidateChecks] and [relationChecks].
   int get totalChecks {
     return nodesTraversed + candidateChecks + relationChecks;
   }

--- a/lib/src/spot/query_stats.dart
+++ b/lib/src/spot/query_stats.dart
@@ -18,6 +18,8 @@ class QueryStats {
     required this.candidateChecks,
     required this.relationChecks,
     required this.snapshotCalls,
+    required this.cacheHits,
+    required this.cacheHitChecks,
   });
 
   /// Stats of a query that did no work at all.
@@ -26,6 +28,8 @@ class QueryStats {
     candidateChecks: 0,
     relationChecks: 0,
     snapshotCalls: 0,
+    cacheHits: 0,
+    cacheHitChecks: 0,
   );
 
   /// Number of `WidgetTreeNode`s materialized while traversing the widget
@@ -44,9 +48,24 @@ class QueryStats {
   /// parent and child selectors.
   final int snapshotCalls;
 
+  /// Number of stage-prefix results reused from cache.
+  final int cacheHits;
+
+  /// [totalChecks] avoided by cache hits.
+  final int cacheHitChecks;
+
   /// Sum of [nodesTraversed], [candidateChecks] and [relationChecks].
   int get totalChecks {
     return nodesTraversed + candidateChecks + relationChecks;
+  }
+
+  /// Ratio of avoided checks to the uncached checks.
+  double get cacheRatio {
+    final uncachedChecks = totalChecks + cacheHitChecks;
+    if (uncachedChecks == 0) {
+      return 0;
+    }
+    return cacheHitChecks / uncachedChecks;
   }
 
   /// Returns the difference between two measurements.
@@ -56,6 +75,8 @@ class QueryStats {
       candidateChecks: candidateChecks - other.candidateChecks,
       relationChecks: relationChecks - other.relationChecks,
       snapshotCalls: snapshotCalls - other.snapshotCalls,
+      cacheHits: cacheHits - other.cacheHits,
+      cacheHitChecks: cacheHitChecks - other.cacheHitChecks,
     );
   }
 
@@ -67,7 +88,9 @@ class QueryStats {
             nodesTraversed == other.nodesTraversed &&
             candidateChecks == other.candidateChecks &&
             relationChecks == other.relationChecks &&
-            snapshotCalls == other.snapshotCalls;
+            snapshotCalls == other.snapshotCalls &&
+            cacheHits == other.cacheHits &&
+            cacheHitChecks == other.cacheHitChecks;
   }
 
   @override
@@ -77,6 +100,8 @@ class QueryStats {
       candidateChecks,
       relationChecks,
       snapshotCalls,
+      cacheHits,
+      cacheHitChecks,
     );
   }
 
@@ -87,6 +112,9 @@ class QueryStats {
         'candidateChecks: $candidateChecks, '
         'relationChecks: $relationChecks, '
         'snapshotCalls: $snapshotCalls, '
+        'cacheHits: $cacheHits, '
+        'cacheHitChecks: $cacheHitChecks, '
+        'cacheRatio: ${(cacheRatio * 100).toStringAsFixed(0)}%, '
         'total: $totalChecks)';
   }
 }
@@ -111,6 +139,12 @@ class QueryStatsCounter {
   /// See [QueryStats.snapshotCalls]
   static int snapshotCalls = 0;
 
+  /// See [QueryStats.cacheHits]
+  static int cacheHits = 0;
+
+  /// See [QueryStats.cacheHitChecks]
+  static int cacheHitChecks = 0;
+
   /// The current totals since process start.
   static QueryStats get total {
     return QueryStats(
@@ -118,6 +152,8 @@ class QueryStatsCounter {
       candidateChecks: candidateChecks,
       relationChecks: relationChecks,
       snapshotCalls: snapshotCalls,
+      cacheHits: cacheHits,
+      cacheHitChecks: cacheHitChecks,
     );
   }
 }

--- a/lib/src/spot/query_stats.dart
+++ b/lib/src/spot/query_stats.dart
@@ -1,0 +1,47 @@
+/// Counters tracking how much work the spot query engine performs.
+///
+/// Only ever use this for debugging and performance regression tests.
+/// The exact numbers are an implementation detail of the query engine and
+/// may change between spot versions.
+class QueryStats {
+  QueryStats._();
+
+  /// Number of `WidgetTreeNode`s materialized while traversing the widget
+  /// tree (full tree walks and subtree walks).
+  static int nodesTraversed = 0;
+
+  /// Number of candidates evaluated by primitive filters
+  /// (type checks, predicates, text matches, onstage checks).
+  static int candidateChecks = 0;
+
+  /// Number of node/element comparisons performed while resolving
+  /// parent/child relationships between selectors.
+  static int relationChecks = 0;
+
+  /// Number of `snapshot()` invocations, including recursive invocations for
+  /// parent and child selectors.
+  static int snapshotCalls = 0;
+
+  /// Resets all counters to zero.
+  static void reset() {
+    nodesTraversed = 0;
+    candidateChecks = 0;
+    relationChecks = 0;
+    snapshotCalls = 0;
+  }
+
+  /// Sum of all counters, the total work done by the query engine.
+  static int get totalChecks {
+    return nodesTraversed + candidateChecks + relationChecks;
+  }
+
+  /// A human readable summary of all counters.
+  static String summary() {
+    return 'QueryStats('
+        'nodesTraversed: $nodesTraversed, '
+        'candidateChecks: $candidateChecks, '
+        'relationChecks: $relationChecks, '
+        'snapshotCalls: $snapshotCalls, '
+        'total: $totalChecks)';
+  }
+}

--- a/lib/src/spot/query_stats.dart
+++ b/lib/src/spot/query_stats.dart
@@ -1,47 +1,123 @@
-/// Counters tracking how much work the spot query engine performs.
+/// The amount of work the query engine performed to evaluate a selector,
+/// available via `WidgetSnapshot.queryStats`.
 ///
-/// Only ever use this for debugging and performance regression tests.
+/// Useful to detect and debug slow queries:
+///
+/// ```dart
+/// final snapshot = spot<AppBar>().spotText('Home').snapshot();
+/// print(snapshot.queryStats); // QueryStats(..., total: 15637)
+/// ```
+///
 /// The exact numbers are an implementation detail of the query engine and
-/// may change between spot versions.
+/// may change between spot versions. Only ever use them for debugging and
+/// relative comparisons, like guarding against performance regressions.
 class QueryStats {
-  QueryStats._();
+  /// Creates immutable [QueryStats].
+  const QueryStats({
+    required this.nodesTraversed,
+    required this.candidateChecks,
+    required this.relationChecks,
+    required this.snapshotCalls,
+  });
+
+  /// Stats of a query that did no work at all.
+  static const QueryStats zero = QueryStats(
+    nodesTraversed: 0,
+    candidateChecks: 0,
+    relationChecks: 0,
+    snapshotCalls: 0,
+  );
 
   /// Number of `WidgetTreeNode`s materialized while traversing the widget
-  /// tree (full tree walks and subtree walks).
-  static int nodesTraversed = 0;
+  /// tree.
+  final int nodesTraversed;
 
   /// Number of candidates evaluated by primitive filters
   /// (type checks, predicates, text matches, onstage checks).
-  static int candidateChecks = 0;
+  final int candidateChecks;
 
   /// Number of node/element comparisons performed while resolving
   /// parent/child relationships between selectors.
-  static int relationChecks = 0;
+  final int relationChecks;
 
-  /// Number of `snapshot()` invocations, including recursive invocations for
+  /// Number of selector evaluations, including the recursive evaluations of
   /// parent and child selectors.
-  static int snapshotCalls = 0;
+  final int snapshotCalls;
 
-  /// Resets all counters to zero.
-  static void reset() {
-    nodesTraversed = 0;
-    candidateChecks = 0;
-    relationChecks = 0;
-    snapshotCalls = 0;
-  }
-
-  /// Sum of all counters, the total work done by the query engine.
-  static int get totalChecks {
+  /// Sum of all checks, the total work done by the query engine.
+  int get totalChecks {
     return nodesTraversed + candidateChecks + relationChecks;
   }
 
-  /// A human readable summary of all counters.
-  static String summary() {
+  /// Returns the difference between two measurements.
+  QueryStats operator -(QueryStats other) {
+    return QueryStats(
+      nodesTraversed: nodesTraversed - other.nodesTraversed,
+      candidateChecks: candidateChecks - other.candidateChecks,
+      relationChecks: relationChecks - other.relationChecks,
+      snapshotCalls: snapshotCalls - other.snapshotCalls,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is QueryStats &&
+            runtimeType == other.runtimeType &&
+            nodesTraversed == other.nodesTraversed &&
+            candidateChecks == other.candidateChecks &&
+            relationChecks == other.relationChecks &&
+            snapshotCalls == other.snapshotCalls;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      nodesTraversed,
+      candidateChecks,
+      relationChecks,
+      snapshotCalls,
+    );
+  }
+
+  @override
+  String toString() {
     return 'QueryStats('
         'nodesTraversed: $nodesTraversed, '
         'candidateChecks: $candidateChecks, '
         'relationChecks: $relationChecks, '
         'snapshotCalls: $snapshotCalls, '
         'total: $totalChecks)';
+  }
+}
+
+/// Internal counters the query engine increments while evaluating selectors.
+///
+/// `snapshot()` reads [total] before and after evaluating a selector and
+/// attaches the difference to the created `WidgetSnapshot` as [QueryStats].
+/// The absolute values are meaningless, only differences are reported.
+class QueryStatsCounter {
+  QueryStatsCounter._();
+
+  /// See [QueryStats.nodesTraversed]
+  static int nodesTraversed = 0;
+
+  /// See [QueryStats.candidateChecks]
+  static int candidateChecks = 0;
+
+  /// See [QueryStats.relationChecks]
+  static int relationChecks = 0;
+
+  /// See [QueryStats.snapshotCalls]
+  static int snapshotCalls = 0;
+
+  /// The current totals since process start.
+  static QueryStats get total {
+    return QueryStats(
+      nodesTraversed: nodesTraversed,
+      candidateChecks: candidateChecks,
+      relationChecks: relationChecks,
+      snapshotCalls: snapshotCalls,
+    );
   }
 }

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -266,22 +266,32 @@ mixin ChainableSelectors<T extends Widget> {
           'Patterns are not supported when matching the whole text',
         );
       }
-      return spotTextWhere(
+      return _spotTextWhere(
         (it) => it.equals(needle),
         raw: raw,
         description: 'with text "$needle"',
         parents: parents,
         children: children,
+        cacheKey: _spotTextCacheKey(
+          matchType: _SpotTextMatchType.whole,
+          needle: needle,
+          raw: raw,
+        ),
       );
     }
 
     // default with contains
-    return spotTextWhere(
+    return _spotTextWhere(
       (it) => it.contains(needle),
       raw: raw,
       description: 'contains text "$needle"',
       parents: parents,
       children: children,
+      cacheKey: _spotTextCacheKey(
+        matchType: _SpotTextMatchType.contains,
+        needle: needle,
+        raw: raw,
+      ),
     );
   }
 
@@ -309,6 +319,23 @@ mixin ChainableSelectors<T extends Widget> {
     bool raw = false,
     String? description,
   }) {
+    return _spotTextWhere(
+      match,
+      parents: parents,
+      children: children,
+      raw: raw,
+      description: description,
+    );
+  }
+
+  WidgetSelector<AnyText> _spotTextWhere(
+    void Function(Subject<String>) match, {
+    required List<WidgetSelector> parents,
+    required List<WidgetSelector> children,
+    required bool raw,
+    required String? description,
+    Object? cacheKey,
+  }) {
     final String name = description ??
         () {
           return describe(match).map((it) => it.trim()).toList().join(' ');
@@ -319,6 +346,7 @@ mixin ChainableSelectors<T extends Widget> {
           match: (it) => match(it),
           description: 'Widget with text $name',
           normalizeText: !raw,
+          cacheKey: cacheKey,
         ),
         ..._childAndParentFilters(children, parents),
       ],
@@ -547,6 +575,9 @@ class _FirstElement extends ElementFilter {
   _FirstElement();
 
   @override
+  Object get cacheKey => _FirstElement;
+
+  @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     final first = candidates.firstOrNull;
     if (first == null) {
@@ -561,6 +592,9 @@ class _FirstElement extends ElementFilter {
 
 class _LastElement extends ElementFilter {
   _LastElement();
+
+  @override
+  Object get cacheKey => _LastElement;
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
@@ -579,6 +613,9 @@ class _ElementAtIndex extends ElementFilter {
   _ElementAtIndex(this.index);
 
   final int index;
+
+  @override
+  Object get cacheKey => SpotCacheKey(_ElementAtIndex, [index]);
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
@@ -693,6 +730,47 @@ extension SelectorToSnapshot<W extends Widget> on WidgetSelector<W> {
     return atMost(1);
   }
 }
+
+enum _SpotTextMatchType {
+  contains,
+  whole,
+}
+
+Object _spotTextCacheKey({
+  required _SpotTextMatchType matchType,
+  required Pattern needle,
+  required bool raw,
+}) {
+  return SpotCacheKey(
+    _SpotTextCacheKey,
+    [
+      matchType,
+      _patternCacheKey(needle),
+      raw,
+    ],
+  );
+}
+
+Object _patternCacheKey(Pattern pattern) {
+  if (pattern is String) {
+    return SpotCacheKey(String, [pattern]);
+  }
+  if (pattern is RegExp) {
+    return SpotCacheKey(
+      RegExp,
+      [
+        pattern.pattern,
+        pattern.isCaseSensitive,
+        pattern.isDotAll,
+        pattern.isMultiLine,
+        pattern.isUnicode,
+      ],
+    );
+  }
+  return SpotCacheKey(Pattern, [pattern]);
+}
+
+class _SpotTextCacheKey {}
 
 /// Extension on [WidgetSelector<W>] to provide easy access to the single
 /// widget, element, or render object in the current selection.

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -62,10 +62,9 @@ class WidgetSnapshot<W extends Widget> {
   /// The amount of work the query engine performed to discover [discovered],
   /// including the evaluation of all parent and child selectors.
   ///
-  /// Snapshot results are memoized per frame. When a selector instance was
-  /// already evaluated in the current frame, the memoized snapshot is
-  /// returned and [queryStats] reports the work of the original evaluation,
-  /// while the reuse itself costs almost nothing.
+  /// Stage-prefix results are memoized per frame. When cached stage results
+  /// are reused, [queryStats] reports the cheap lookup work and cache hit count
+  /// for the current call.
   final QueryStats queryStats;
 
   @override
@@ -197,15 +196,6 @@ void _snapshotDebugPrint(String text) {
 
 int _depth = -1;
 
-/// Memoized snapshot results per [WidgetTreeSnapshot].
-///
-/// A [WidgetSelector] always discovers the same widgets within one frame.
-/// Results are cached per selector instance, so that selectors which are
-/// reused in multiple chains (or as parent of multiple selectors) are only
-/// evaluated once per frame. The cache dies together with the
-/// [WidgetTreeSnapshot] when the next frame is pumped.
-final Expando<Map<WidgetSelector, WidgetSnapshot>> _snapshotCache = Expando();
-
 /// Creates a snapshot of widgets that match the specified [selector].
 ///
 /// This function captures the current state of widgets that match the criteria
@@ -224,15 +214,7 @@ WidgetSnapshot<W> snapshot<W extends Widget>(
   QueryStatsCounter.snapshotCalls++;
 
   final treeSnapshot = currentWidgetTreeSnapshot();
-  final cache = _snapshotCache[treeSnapshot] ??= Map.identity();
-  final WidgetSnapshot? cachedSnapshot = cache[selector];
-  if (cachedSnapshot != null) {
-    if (validateQuantity) {
-      cachedSnapshot.validateQuantity();
-    }
-    return cachedSnapshot as WidgetSnapshot<W>;
-  }
-
+  final cache = treeSnapshot.queryCache;
   final List<WidgetTreeNode> candidates = treeSnapshot.allNodes;
 
   final isAnyOffstage = selector.isAnyOffstage();
@@ -260,21 +242,42 @@ WidgetSnapshot<W> snapshot<W extends Widget>(
     ...selector.stages,
   ];
 
+  Object? prefixCacheKey = _initialStageCacheKey;
   for (int i = 0; i < stages.length; i++) {
     final stage = stages[i];
     // using unmodifiable copies to prevent accidental modification during filtering
     final remainingCandidatesFromPreviousStage =
         stageResults.last.candidates.toUnmodifiable();
+    final stageCacheKey = _stageCacheKey(prefixCacheKey, stage.cacheKey);
+    final cachedStageResult = stageCacheKey == null
+        ? null
+        : cache.stageResultsByPrefix[stageCacheKey];
 
     _snapshotDebugPrint(
       "+ Stage $i: $stage, "
       "input-candidates: ${remainingCandidatesFromPreviousStage.length}",
     );
 
-    final after = stage
-        .filter(remainingCandidatesFromPreviousStage)
-        .toList()
-        .toUnmodifiable();
+    final List<WidgetTreeNode> after;
+    if (cachedStageResult != null) {
+      QueryStatsCounter.cacheHits++;
+      QueryStatsCounter.cacheHitChecks += cachedStageResult.savedChecks;
+      after = cachedStageResult.candidates;
+    } else {
+      final statsBeforeStage = QueryStatsCounter.total;
+      after = stage
+          .filter(remainingCandidatesFromPreviousStage)
+          .toList()
+          .toUnmodifiable();
+      if (stageCacheKey != null) {
+        final stageStats = QueryStatsCounter.total - statsBeforeStage;
+        cache.stageResultsByPrefix[stageCacheKey] = CachedQueryStageResult(
+          candidates: after,
+          savedChecks: _savedChecks(stageStats),
+        );
+      }
+    }
+    prefixCacheKey = stageCacheKey;
     _snapshotDebugPrint("- Stage $i: $stage, "
         "output-candidates: ${after.length}");
     stageResults.add(_StageResult(index: i, filter: stage, candidates: after));
@@ -290,7 +293,6 @@ WidgetSnapshot<W> snapshot<W extends Widget>(
     debugCandidates: candidates.map((element) => element.element).toList(),
     queryStats: QueryStatsCounter.total - statsBefore,
   );
-  cache[selector] = snapshot;
   _depth--;
 
   if (validateQuantity) {
@@ -298,6 +300,24 @@ WidgetSnapshot<W> snapshot<W extends Widget>(
   }
 
   return snapshot;
+}
+
+final Object _initialStageCacheKey = Object();
+
+Object? _stageCacheKey(Object? prefixCacheKey, Object? filterCacheKey) {
+  if (prefixCacheKey == null || filterCacheKey == null) {
+    return null;
+  }
+  return SpotCacheKey(
+    _StageCacheKey,
+    [prefixCacheKey, filterCacheKey],
+  );
+}
+
+class _StageCacheKey {}
+
+int _savedChecks(QueryStats stats) {
+  return stats.totalChecks + stats.cacheHitChecks;
 }
 
 class _StageResult {

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -6,6 +6,7 @@ import 'package:spot/spot.dart';
 import 'package:spot/src/screenshot/screenshot_annotator.dart';
 import 'package:spot/src/spot/element_extensions.dart';
 import 'package:spot/src/spot/filters/onstage_filter.dart';
+import 'package:spot/src/spot/query_stats.dart';
 import 'package:spot/src/spot/widget_selector.dart';
 
 /// A type alias for a snapshot that can contain multiple widgets.
@@ -185,6 +186,15 @@ void _snapshotDebugPrint(String text) {
 
 int _depth = -1;
 
+/// Memoized snapshot results per [WidgetTreeSnapshot].
+///
+/// A [WidgetSelector] always discovers the same widgets within one frame.
+/// Results are cached per selector instance, so that selectors which are
+/// reused in multiple chains (or as parent of multiple selectors) are only
+/// evaluated once per frame. The cache dies together with the
+/// [WidgetTreeSnapshot] when the next frame is pumped.
+final Expando<Map<WidgetSelector, WidgetSnapshot>> _snapshotCache = Expando();
+
 /// Creates a snapshot of widgets that match the specified [selector].
 ///
 /// This function captures the current state of widgets that match the criteria
@@ -199,8 +209,18 @@ WidgetSnapshot<W> snapshot<W extends Widget>(
   // Make sure that any previous asynchronous operations are completed.
   // This check makes sure that a missing `await` in the line before throws here
   TestAsyncUtils.guardSync();
+  QueryStats.snapshotCalls++;
 
   final treeSnapshot = currentWidgetTreeSnapshot();
+  final cache = _snapshotCache[treeSnapshot] ??= Map.identity();
+  final WidgetSnapshot? cachedSnapshot = cache[selector];
+  if (cachedSnapshot != null) {
+    if (validateQuantity) {
+      cachedSnapshot.validateQuantity();
+    }
+    return cachedSnapshot as WidgetSnapshot<W>;
+  }
+
   final List<WidgetTreeNode> candidates = treeSnapshot.allNodes;
 
   final isAnyOffstage = selector.isAnyOffstage();
@@ -257,6 +277,7 @@ WidgetSnapshot<W> snapshot<W extends Widget>(
     scope: treeSnapshot,
     debugCandidates: candidates.map((element) => element.element).toList(),
   );
+  cache[selector] = snapshot;
   _depth--;
 
   if (validateQuantity) {

--- a/lib/src/spot/snapshot.dart
+++ b/lib/src/spot/snapshot.dart
@@ -29,7 +29,9 @@ class WidgetSnapshot<W extends Widget> {
     required this.discovered,
     required this.debugCandidates,
     required this.scope,
-  }) : _widgets = Map.fromEntries(
+    QueryStats? queryStats,
+  })  : queryStats = queryStats ?? QueryStats.zero,
+        _widgets = Map.fromEntries(
           discovered
               .map((e) => MapEntry(e, selector.mapElementToWidget(e.element))),
         );
@@ -56,6 +58,15 @@ class WidgetSnapshot<W extends Widget> {
 
   /// All elements in [scope] that match [selector]
   final List<WidgetTreeNode> discovered;
+
+  /// The amount of work the query engine performed to discover [discovered],
+  /// including the evaluation of all parent and child selectors.
+  ///
+  /// Snapshot results are memoized per frame. When a selector instance was
+  /// already evaluated in the current frame, the memoized snapshot is
+  /// returned and [queryStats] reports the work of the original evaluation,
+  /// while the reuse itself costs almost nothing.
+  final QueryStats queryStats;
 
   @override
   String toString() {
@@ -209,7 +220,8 @@ WidgetSnapshot<W> snapshot<W extends Widget>(
   // Make sure that any previous asynchronous operations are completed.
   // This check makes sure that a missing `await` in the line before throws here
   TestAsyncUtils.guardSync();
-  QueryStats.snapshotCalls++;
+  final QueryStats statsBefore = QueryStatsCounter.total;
+  QueryStatsCounter.snapshotCalls++;
 
   final treeSnapshot = currentWidgetTreeSnapshot();
   final cache = _snapshotCache[treeSnapshot] ??= Map.identity();
@@ -276,6 +288,7 @@ WidgetSnapshot<W> snapshot<W extends Widget>(
     discovered: stageResults.last.candidates,
     scope: treeSnapshot,
     debugCandidates: candidates.map((element) => element.element).toList(),
+    queryStats: QueryStatsCounter.total - statsBefore,
   );
   cache[selector] = snapshot;
   _depth--;

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -405,6 +405,7 @@ class MatchTextFilter implements ElementFilter {
     required this.match,
     required this.description,
     this.normalizeText = true,
+    this.cacheKey,
   });
 
   /// The function that asserts the text content.
@@ -419,6 +420,9 @@ class MatchTextFilter implements ElementFilter {
   /// text, ignoring invisible and special whitespace. When `false` it receives
   /// the [AnyTextContent.raw] text, matching the exact characters.
   final bool normalizeText;
+
+  @override
+  final Object? cacheKey;
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -423,7 +423,7 @@ class MatchTextFilter implements ElementFilter {
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
     return candidates.where((it) {
-      QueryStats.candidateChecks++;
+      QueryStatsCounter.candidateChecks++;
       return _match(it.element);
     });
   }

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:spot/spot.dart';
 import 'package:spot/src/checks/checks_nullability.dart';
+import 'package:spot/src/spot/query_stats.dart';
 
 /// A union type for any text widget that can be found in the widget tree.
 /// Specifically this includes:
@@ -421,7 +422,10 @@ class MatchTextFilter implements ElementFilter {
 
   @override
   Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
-    return candidates.where((it) => _match(it.element));
+    return candidates.where((it) {
+      QueryStats.candidateChecks++;
+      return _match(it.element);
+    });
   }
 
   bool _match(Element element) {

--- a/lib/src/spot/tree_snapshot.dart
+++ b/lib/src/spot/tree_snapshot.dart
@@ -125,6 +125,9 @@ class WidgetTreeSnapshot extends ScopedWidgetTreeSnapshot {
   /// the widget tree was recorded.
   final DateTime timestamp;
 
+  /// Query results cached for the lifetime of this tree snapshot.
+  final WidgetTreeQueryCache queryCache = WidgetTreeQueryCache();
+
   bool _isNextFrame = false;
 
   /// Creates a snapshot of the widget tree at the given [timestamp].
@@ -162,6 +165,27 @@ class WidgetTreeSnapshot extends ScopedWidgetTreeSnapshot {
   String toString() {
     return 'WidgetTreeSnapshot{timestamp: $timestamp, origin: $origin}';
   }
+}
+
+/// Selector query results cached for one [WidgetTreeSnapshot].
+class WidgetTreeQueryCache {
+  /// Intermediate stage-prefix results by structural stage-prefix cache key.
+  final Map<Object, CachedQueryStageResult> stageResultsByPrefix = {};
+}
+
+/// Cached result of applying one selector stage.
+class CachedQueryStageResult {
+  /// Creates a cached stage result.
+  const CachedQueryStageResult({
+    required this.candidates,
+    required this.savedChecks,
+  });
+
+  /// Candidates after this stage was applied.
+  final List<WidgetTreeNode> candidates;
+
+  /// [QueryStats.totalChecks] avoided when this result is reused.
+  final int savedChecks;
 }
 
 /// A snapshot representing a specific subtree within a [WidgetTreeSnapshot].

--- a/lib/src/spot/tree_snapshot.dart
+++ b/lib/src/spot/tree_snapshot.dart
@@ -233,7 +233,7 @@ class ScopedWidgetTreeSnapshot {
       depthFirstElements.add(next);
       fill(next);
     }
-    QueryStats.nodesTraversed += depthFirstElements.length;
+    QueryStatsCounter.nodesTraversed += depthFirstElements.length;
     final nodes = List<WidgetTreeNode>.unmodifiable(depthFirstElements);
     _allNodesCache = nodes;
     return nodes;

--- a/lib/src/spot/tree_snapshot.dart
+++ b/lib/src/spot/tree_snapshot.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/src/spot/element_extensions.dart';
+import 'package:spot/src/spot/query_stats.dart';
 
 /// caching the tree for the current frame
 WidgetTreeSnapshot? _cachedTree;
@@ -201,9 +202,18 @@ class ScopedWidgetTreeSnapshot {
         'It is only valid until the next frame is pumped.');
   }
 
+  List<WidgetTreeNode>? _allNodesCache;
+
   /// Returns all [WidgetTreeNode] in tree in depth-first order
+  ///
+  /// The tree is immutable for the lifetime of this snapshot (one frame),
+  /// the traversal happens only once and is cached afterwards.
   List<WidgetTreeNode> get allNodes {
     _ensureSnapshotIsFromThisFrame();
+    final cached = _allNodesCache;
+    if (cached != null) {
+      return cached;
+    }
     final List<WidgetTreeNode> depthFirstElements = [];
     final List<WidgetTreeNode> stack = [];
 
@@ -223,7 +233,10 @@ class ScopedWidgetTreeSnapshot {
       depthFirstElements.add(next);
       fill(next);
     }
-    return depthFirstElements.toList();
+    QueryStats.nodesTraversed += depthFirstElements.length;
+    final nodes = List<WidgetTreeNode>.unmodifiable(depthFirstElements);
+    _allNodesCache = nodes;
+    return nodes;
   }
 
   /// Returns the Elements in depth-first order

--- a/lib/src/spot/widget_selector.dart
+++ b/lib/src/spot/widget_selector.dart
@@ -99,6 +99,32 @@ class WidgetSelector<W extends Widget> with ChainableSelectors<W> {
   /// Whether to include offstage widgets in the selection
   final WidgetPresence widgetPresence;
 
+  /// A structural cache key used when this selector is nested in relation filters.
+  ///
+  /// [ParentFilter] and [ChildFilter] include this key in their own cache key so
+  /// equivalent nested selectors can reuse stage results.
+  ///
+  /// Returns `null` when any stage depends on data that must be read live.
+  Object? get cacheKey {
+    final stageKeys = <Object>[];
+    for (final stage in stages) {
+      final key = stage.cacheKey;
+      if (key == null) {
+        return null;
+      }
+      stageKeys.add(key);
+    }
+    return SpotCacheKey(
+      WidgetSelector,
+      [
+        type,
+        quantityConstraint,
+        widgetPresence,
+        SpotCacheKey(_SelectorStagesCacheKey, stageKeys),
+      ],
+    );
+  }
+
   /// All parent selectors of all stages this widget selector depends on
   List<WidgetSelector> get parents {
     return stages.whereType<ParentFilter>().flatMap((e) => e.parents).toList();
@@ -397,7 +423,66 @@ abstract class ElementFilter {
 
   /// A description to describe the filter
   String get description;
+
+  /// A structural key used to cache this filter's result within one frame.
+  ///
+  /// Return `null` when the filter reads mutable state that may change before
+  /// the next frame.
+  Object? get cacheKey => null;
 }
+
+/// Immutable structural cache key for cacheable selector/filter stages.
+class SpotCacheKey {
+  /// Creates a structural cache key.
+  SpotCacheKey(this.type, List<Object> values)
+      : values = List.unmodifiable(values) {
+    _throwIfCacheKeyPartIsCollection(type);
+    for (final value in values) {
+      _throwIfCacheKeyPartIsCollection(value);
+    }
+  }
+
+  /// The type of selector/filter represented by this key.
+  final Object type;
+
+  /// Immutable value parts that define the selector/filter semantics.
+  final List<Object> values;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other is! SpotCacheKey) {
+      return false;
+    }
+    if (type != other.type || values.length != other.values.length) {
+      return false;
+    }
+    for (int i = 0; i < values.length; i++) {
+      if (values[i] != other.values[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(type, Object.hashAll(values));
+  }
+}
+
+void _throwIfCacheKeyPartIsCollection(Object key) {
+  if (key is List || key is Set || key is Map) {
+    throw StateError(
+      'ElementFilter.cacheKey must not return List, Set or Map. '
+      'Use SpotCacheKey or records with value-equality fields.',
+    );
+  }
+}
+
+class _SelectorStagesCacheKey {}
 
 /// Defines the quantity constraints for the number of widgets
 /// expected to be found.

--- a/test/spot/query_check_count_test.dart
+++ b/test/spot/query_check_count_test.dart
@@ -105,6 +105,9 @@ void main() {
       filters: snapshot.queryStats.candidateChecks,
       relations: snapshot.queryStats.relationChecks,
       snapshots: snapshot.queryStats.snapshotCalls.toString(),
+      cacheHits: snapshot.queryStats.cacheHits.toString(),
+      cacheHitChecks: snapshot.queryStats.cacheHitChecks.toString(),
+      cacheRatio: _formatPercent(snapshot.queryStats.cacheRatio),
       matched: snapshot.discovered.length,
     );
     _printMeasurement(label, measurement);
@@ -140,6 +143,9 @@ void main() {
       filters: _simPredicateChecks,
       relations: _simComparisons,
       snapshots: '-',
+      cacheHits: '-',
+      cacheHitChecks: '-',
+      cacheRatio: '-',
       matched: matches.length,
     );
     _printMeasurement(label, measurement);
@@ -539,6 +545,9 @@ class _Measurement {
     required this.filters,
     required this.relations,
     required this.snapshots,
+    required this.cacheHits,
+    required this.cacheHitChecks,
+    required this.cacheRatio,
     required this.matched,
   });
 
@@ -548,6 +557,9 @@ class _Measurement {
   final int filters;
   final int relations;
   final String snapshots;
+  final String cacheHits;
+  final String cacheHitChecks;
+  final String cacheRatio;
   final int matched;
 }
 
@@ -571,6 +583,9 @@ void _printMeasurement(String label, _Measurement measurement) {
     filters: 'filter',
     relations: 'relation',
     snapshots: 'snapshots',
+    cacheHits: 'cache',
+    cacheHitChecks: 'saved',
+    cacheRatio: 'cached',
     matched: 'matched',
   );
   final values = _formatMeasurementRow(
@@ -580,6 +595,9 @@ void _printMeasurement(String label, _Measurement measurement) {
     filters: measurement.filters.toString(),
     relations: measurement.relations.toString(),
     snapshots: measurement.snapshots,
+    cacheHits: measurement.cacheHits,
+    cacheHitChecks: measurement.cacheHitChecks,
+    cacheRatio: measurement.cacheRatio,
     matched: measurement.matched.toString(),
   );
   print('$label\n  $header\n  $values');
@@ -593,6 +611,8 @@ void _printSummary(String label, List<_Comparison> comparisons) {
     fewer: 'fewer checks',
     spot: 'spot',
     finder: 'finder',
+    cacheHitChecks: 'saved',
+    cacheRatio: 'cached',
   );
   final rows = comparisons.map(_formatSummaryComparison).join('\n  ');
   print('Summary: $label\n  $header\n  $rows');
@@ -609,6 +629,8 @@ String _formatSummaryComparison(_Comparison comparison) {
     fewer: _formatInt(fewerChecks),
     spot: _formatInt(comparison.spot.total),
     finder: _formatInt(comparison.finder.total),
+    cacheHitChecks: comparison.spot.cacheHitChecks,
+    cacheRatio: comparison.spot.cacheRatio,
   );
 }
 
@@ -656,6 +678,8 @@ String _formatSummaryRow({
   required String fewer,
   required String spot,
   required String finder,
+  required String cacheHitChecks,
+  required String cacheRatio,
 }) {
   return [
     query.padRight(5),
@@ -664,6 +688,8 @@ String _formatSummaryRow({
     fewer.padLeft(13),
     spot.padLeft(10),
     finder.padLeft(10),
+    cacheHitChecks.padLeft(8),
+    cacheRatio.padLeft(6),
   ].join('  ');
 }
 
@@ -751,6 +777,9 @@ String _formatMeasurementRow({
   required String filters,
   required String relations,
   required String snapshots,
+  required String cacheHits,
+  required String cacheHitChecks,
+  required String cacheRatio,
   required String matched,
 }) {
   return [
@@ -760,8 +789,15 @@ String _formatMeasurementRow({
     filters.padLeft(8),
     relations.padLeft(9),
     snapshots.padLeft(9),
+    cacheHits.padLeft(5),
+    cacheHitChecks.padLeft(8),
+    cacheRatio.padLeft(6),
     matched.padLeft(7),
   ].join('  ');
+}
+
+String _formatPercent(double value) {
+  return '${(value * 100).toStringAsFixed(0)}%';
 }
 
 /// A grid tile of the multi-result query test

--- a/test/spot/query_check_count_test.dart
+++ b/test/spot/query_check_count_test.dart
@@ -18,13 +18,96 @@ import 'package:spot/src/spot/tree_snapshot.dart';
 /// comparisons of the linear `Iterable.contains` calls. Each simulation
 /// asserts that it discovers exactly the same elements as the real finder.
 void main() {
-  void measureSpot(
+  testWidgets('measure wall clock time for simple type queries with timeline',
+      (tester) async {
+    const warmups = 3;
+    const runs = 20;
+    timeline.mode = TimelineMode.reportOnError;
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Column(
+          children: [
+            _BenchWidgetA(),
+            _BenchWidgetB(),
+            _BenchWidgetC(),
+            _BenchWidgetD(),
+            _BenchWidgetE(),
+          ],
+        ),
+      ),
+    );
+
+    print('timeline mode: ${timeline.mode}');
+
+    final spotWithScreenshotsElapsed = await _measureWallClockAverage(
+      tester: tester,
+      warmups: warmups,
+      runs: runs,
+      measure: _runFiveSpotTypeQueries,
+    );
+
+    final finderElapsed = await _measureWallClockAverage(
+      tester: tester,
+      warmups: warmups,
+      runs: runs,
+      measure: _runFiveFinderTypeQueries,
+    );
+
+    _printWallClockSummary(
+      label: '5 simple type queries with timeline screenshots',
+      warmups: warmups,
+      runs: runs,
+      spot: spotWithScreenshotsElapsed,
+      finder: finderElapsed,
+    );
+
+    timeline.mode = TimelineMode.off;
+    print('timeline mode: ${timeline.mode}');
+
+    final spotWithoutScreenshotsElapsed = await _measureWallClockAverage(
+      tester: tester,
+      warmups: warmups,
+      runs: runs,
+      measure: _runFiveSpotTypeQueries,
+    );
+
+    final finderWithoutScreenshotsElapsed = await _measureWallClockAverage(
+      tester: tester,
+      warmups: warmups,
+      runs: runs,
+      measure: _runFiveFinderTypeQueries,
+    );
+
+    _printWallClockSummary(
+      label: '5 simple type queries without timeline screenshots',
+      warmups: warmups,
+      runs: runs,
+      spot: spotWithoutScreenshotsElapsed,
+      finder: finderWithoutScreenshotsElapsed,
+    );
+
+    _printWallClockScreenshotOverhead(
+      withScreenshots: spotWithScreenshotsElapsed,
+      withoutScreenshots: spotWithoutScreenshotsElapsed,
+    );
+  });
+
+  _Measurement measureSpot(
     String label,
     int maxChecks,
     WidgetSnapshot<Widget> Function() query,
   ) {
     final snapshot = query();
-    print('$label\n  ${snapshot.queryStats}');
+    final measurement = _Measurement(
+      engine: 'spot',
+      total: snapshot.queryStats.totalChecks,
+      treeWalks: snapshot.queryStats.nodesTraversed,
+      filters: snapshot.queryStats.candidateChecks,
+      relations: snapshot.queryStats.relationChecks,
+      snapshots: snapshot.queryStats.snapshotCalls.toString(),
+      matched: snapshot.discovered.length,
+    );
+    _printMeasurement(label, measurement);
     // Guards against performance regressions of the query engine. The
     // bounds have ~3x headroom over the currently measured numbers.
     expect(
@@ -32,9 +115,10 @@ void main() {
       lessThan(maxChecks),
       reason: 'Query engine did more checks than expected for: $label',
     );
+    return measurement;
   }
 
-  void measureFinder(
+  _Measurement measureFinder(
     String label,
     _SimResult Function() build,
     Finder realEquivalent,
@@ -49,11 +133,17 @@ void main() {
           'as the real finder for: $label',
     );
     final total = _simNodesVisited + _simPredicateChecks + _simComparisons;
-    print('$label\n  finderChecks: $total '
-        '(nodesVisited: $_simNodesVisited, '
-        'predicateChecks: $_simPredicateChecks, '
-        'comparisons: $_simComparisons, '
-        'matched: ${matches.length})');
+    final measurement = _Measurement(
+      engine: 'finder',
+      total: total,
+      treeWalks: _simNodesVisited,
+      filters: _simPredicateChecks,
+      relations: _simComparisons,
+      snapshots: '-',
+      matched: matches.length,
+    );
+    _printMeasurement(label, measurement);
+    return measurement;
   }
 
   testWidgets('count checks for common query shapes', (tester) async {
@@ -89,18 +179,22 @@ void main() {
     final treeSize = currentWidgetTreeSnapshot().allNodes.length;
     print('tree size: $treeSize nodes');
 
-    measureSpot('Q1 spot: spotText("Item 99") [no relationship]', 12000, () {
-      return spotText('Item 99').snapshot()..existsOnce();
-    });
-    measureFinder(
+    final q1Spot = measureSpot(
+      'Q1 spot: spotText("Item 99") [no relationship]',
+      treeSize * 6,
+      () {
+        return spotText('Item 99').snapshot()..existsOnce();
+      },
+    );
+    final q1Finder = measureFinder(
       'Q1 finder: find.text("Item 99")',
       () => _simLeaf(_textPredicate('Item 99')),
       find.byElementPredicate(_textPredicate('Item 99')),
     );
 
-    measureSpot(
+    final q2Spot = measureSpot(
         'Q2 spot: spot<MaterialApp>().spot<Scaffold>().spot<AppBar>().spotText("Home")',
-        50000, () {
+        treeSize * 10, () {
       return spot<MaterialApp>()
           .spot<Scaffold>()
           .spot<AppBar>()
@@ -108,7 +202,7 @@ void main() {
           .snapshot()
         ..existsOnce();
     });
-    measureFinder(
+    final q2Finder = measureFinder(
       'Q2 finder: find.descendant(MaterialApp > Scaffold > AppBar > "Home")',
       () {
         return _simDescendant(
@@ -134,15 +228,15 @@ void main() {
       ),
     );
 
-    measureSpot(
+    final q3Spot = measureSpot(
         'Q3 spot: spotText("Item 99").withParent(spot<Row>().withParent(spot<Container>()))',
-        40000, () {
+        treeSize * 10, () {
       return spotText('Item 99')
           .withParent(spot<Row>().withParent(spot<Container>()))
           .snapshot()
         ..existsOnce();
     });
-    measureFinder(
+    final q3aFinder = measureFinder(
       'Q3a finder: find.descendant(of: find.descendant(of: Container, matching: Row), matching: "Item 99")',
       () {
         return _simDescendant(
@@ -161,7 +255,7 @@ void main() {
         matching: find.byElementPredicate(_textPredicate('Item 99')),
       ),
     );
-    measureFinder(
+    final q3bFinder = measureFinder(
       'Q3b finder: find.descendant(of: Container, matching: find.descendant(of: Row, matching: "Item 99"))',
       () {
         return _simDescendant(
@@ -181,13 +275,13 @@ void main() {
       ),
     );
 
-    measureSpot(
-        'Q4 spot: spot<Container>().withChild(spotIcon(Icons.star))', 80000,
-        () {
+    final q4Spot = measureSpot(
+        'Q4 spot: spot<Container>().withChild(spotIcon(Icons.star))',
+        treeSize * 20, () {
       return spot<Container>().withChild(spotIcon(Icons.star)).snapshot()
         ..existsExactlyNTimes(100);
     });
-    measureFinder(
+    final q4Finder = measureFinder(
       'Q4 finder: find.ancestor(of: icon, matching: Container)',
       () {
         return _simAncestor(
@@ -201,13 +295,13 @@ void main() {
       ),
     );
 
-    measureSpot(
+    final q5Spot = measureSpot(
         'Q5 spot: spot<Row>().withParent(spot<MaterialApp>()) [wide parent]',
-        75000, () {
+        treeSize * 20, () {
       return spot<Row>().withParent(spot<MaterialApp>()).snapshot()
         ..existsAtLeastNTimes(100);
     });
-    measureFinder(
+    final q5Finder = measureFinder(
       'Q5 finder: find.descendant(of: MaterialApp, matching: Row)',
       () {
         return _simDescendant(
@@ -220,6 +314,15 @@ void main() {
         matching: find.byElementPredicate(_typePredicate(Row)),
       ),
     );
+
+    _printSummary('common query shapes', [
+      _Comparison(query: 'Q1', spot: q1Spot, finder: q1Finder),
+      _Comparison(query: 'Q2', spot: q2Spot, finder: q2Finder),
+      _Comparison(query: 'Q3a', spot: q3Spot, finder: q3aFinder),
+      _Comparison(query: 'Q3b', spot: q3Spot, finder: q3bFinder),
+      _Comparison(query: 'Q4', spot: q4Spot, finder: q4Finder),
+      _Comparison(query: 'Q5', spot: q5Spot, finder: q5Finder),
+    ]);
   });
 
   testWidgets('count checks for multi-result queries (4 of 100 grid tiles)',
@@ -252,13 +355,13 @@ void main() {
     final treeSize = currentWidgetTreeSnapshot().allNodes.length;
     print('tree size: $treeSize nodes');
 
-    measureSpot(
+    final m1Spot = measureSpot(
         'M1 spot: spot<_GridTile>().withChild(spotIcon(Icons.star)) -> 4 of 100',
-        60000, () {
+        treeSize * 8, () {
       return spot<_GridTile>().withChild(spotIcon(Icons.star)).snapshot()
         ..existsExactlyNTimes(4);
     });
-    measureFinder(
+    final m1Finder = measureFinder(
       'M1 finder: find.ancestor(of: star icon, matching: _GridTile)',
       () {
         return _simAncestor(
@@ -272,13 +375,13 @@ void main() {
       ),
     );
 
-    measureSpot(
+    final m2Spot = measureSpot(
         'M2 spot: spotIcon(Icons.star).withParent(spot<_GridTile>()) -> 4 of 100',
-        60000, () {
+        treeSize * 8, () {
       return spotIcon(Icons.star).withParent(spot<_GridTile>()).snapshot()
         ..existsExactlyNTimes(4);
     });
-    measureFinder(
+    final m2Finder = measureFinder(
       'M2 finder: find.descendant(of: _GridTile, matching: star icon)',
       () {
         return _simDescendant(
@@ -291,6 +394,11 @@ void main() {
         matching: find.byElementPredicate(_iconPredicate(Icons.star)),
       ),
     );
+
+    _printSummary('multi-result queries', [
+      _Comparison(query: 'M1', spot: m1Spot, finder: m1Finder),
+      _Comparison(query: 'M2', spot: m2Spot, finder: m2Finder),
+    ]);
   });
 
   testWidgets('count checks in deeply nested same-type tree', (tester) async {
@@ -307,12 +415,15 @@ void main() {
     final treeSize = currentWidgetTreeSnapshot().allNodes.length;
     print('tree size: $treeSize nodes');
 
-    measureSpot('N1 spot: spotText("leaf").withParent(spot<SizedBox>())', 10000,
-        () {
-      return spotText('leaf').withParent(spot<SizedBox>()).snapshot()
-        ..existsOnce();
-    });
-    measureFinder(
+    final n1Spot = measureSpot(
+      'N1 spot: spotText("leaf").withParent(spot<SizedBox>())',
+      treeSize * 10,
+      () {
+        return spotText('leaf').withParent(spot<SizedBox>()).snapshot()
+          ..existsOnce();
+      },
+    );
+    final n1Finder = measureFinder(
       'N1 finder: find.descendant(of: SizedBox, matching: "leaf")',
       () {
         return _simDescendant(
@@ -326,15 +437,15 @@ void main() {
       ),
     );
 
-    measureSpot(
+    final n2Spot = measureSpot(
         'N2 spot: spotText("leaf").withParent(spot<SizedBox>().withParent(spot<SizedBox>()))',
-        10000, () {
+        treeSize * 10, () {
       return spotText('leaf')
           .withParent(spot<SizedBox>().withParent(spot<SizedBox>()))
           .snapshot()
         ..existsOnce();
     });
-    measureFinder(
+    final n2aFinder = measureFinder(
       'N2a finder: find.descendant(of: find.descendant(of: SizedBox, matching: SizedBox), matching: "leaf")',
       () {
         return _simDescendant(
@@ -353,7 +464,7 @@ void main() {
         matching: find.byElementPredicate(_textPredicate('leaf')),
       ),
     );
-    measureFinder(
+    final n2bFinder = measureFinder(
       'N2b finder: find.descendant(of: SizedBox, matching: find.descendant(of: SizedBox, matching: "leaf"))',
       () {
         return _simDescendant(
@@ -372,7 +483,285 @@ void main() {
         ),
       ),
     );
+
+    _printSummary('deeply nested same-type tree', [
+      _Comparison(query: 'N1', spot: n1Spot, finder: n1Finder),
+      _Comparison(query: 'N2a', spot: n2Spot, finder: n2aFinder),
+      _Comparison(query: 'N2b', spot: n2Spot, finder: n2bFinder),
+    ]);
   });
+}
+
+Future<Duration> _measureWallClockAverage({
+  required WidgetTester tester,
+  required int warmups,
+  required int runs,
+  required void Function() measure,
+}) async {
+  for (int i = 0; i < warmups; i++) {
+    await tester.pump();
+    measure();
+  }
+
+  int totalMicros = 0;
+  for (int i = 0; i < runs; i++) {
+    await tester.pump();
+    final stopwatch = Stopwatch()..start();
+    measure();
+    stopwatch.stop();
+    totalMicros += stopwatch.elapsedMicroseconds;
+  }
+
+  return Duration(microseconds: totalMicros ~/ runs);
+}
+
+void _runFiveSpotTypeQueries() {
+  spot<_BenchWidgetA>().existsOnce();
+  spot<_BenchWidgetB>().existsOnce();
+  spot<_BenchWidgetC>().existsOnce();
+  spot<_BenchWidgetD>().existsOnce();
+  spot<_BenchWidgetE>().existsOnce();
+}
+
+void _runFiveFinderTypeQueries() {
+  expect(find.byType(_BenchWidgetA), findsOneWidget);
+  expect(find.byType(_BenchWidgetB), findsOneWidget);
+  expect(find.byType(_BenchWidgetC), findsOneWidget);
+  expect(find.byType(_BenchWidgetD), findsOneWidget);
+  expect(find.byType(_BenchWidgetE), findsOneWidget);
+}
+
+class _Measurement {
+  const _Measurement({
+    required this.engine,
+    required this.total,
+    required this.treeWalks,
+    required this.filters,
+    required this.relations,
+    required this.snapshots,
+    required this.matched,
+  });
+
+  final String engine;
+  final int total;
+  final int treeWalks;
+  final int filters;
+  final int relations;
+  final String snapshots;
+  final int matched;
+}
+
+class _Comparison {
+  const _Comparison({
+    required this.query,
+    required this.spot,
+    required this.finder,
+  });
+
+  final String query;
+  final _Measurement spot;
+  final _Measurement finder;
+}
+
+void _printMeasurement(String label, _Measurement measurement) {
+  final header = _formatMeasurementRow(
+    engine: 'engine',
+    total: 'total',
+    treeWalks: 'tree',
+    filters: 'filter',
+    relations: 'relation',
+    snapshots: 'snapshots',
+    matched: 'matched',
+  );
+  final values = _formatMeasurementRow(
+    engine: measurement.engine,
+    total: measurement.total.toString(),
+    treeWalks: measurement.treeWalks.toString(),
+    filters: measurement.filters.toString(),
+    relations: measurement.relations.toString(),
+    snapshots: measurement.snapshots,
+    matched: measurement.matched.toString(),
+  );
+  print('$label\n  $header\n  $values');
+}
+
+void _printSummary(String label, List<_Comparison> comparisons) {
+  final header = _formatSummaryRow(
+    query: 'query',
+    winner: 'winner',
+    factor: 'better by',
+    fewer: 'fewer checks',
+    spot: 'spot',
+    finder: 'finder',
+  );
+  final rows = comparisons.map(_formatSummaryComparison).join('\n  ');
+  print('Summary: $label\n  $header\n  $rows');
+}
+
+String _formatSummaryComparison(_Comparison comparison) {
+  final winner = _winner(comparison);
+  final fewerChecks = _fewerChecks(comparison);
+  final factor = _factor(comparison);
+  return _formatSummaryRow(
+    query: comparison.query,
+    winner: winner,
+    factor: factor,
+    fewer: _formatInt(fewerChecks),
+    spot: _formatInt(comparison.spot.total),
+    finder: _formatInt(comparison.finder.total),
+  );
+}
+
+String _winner(_Comparison comparison) {
+  if (comparison.spot.total < comparison.finder.total) {
+    return 'spot';
+  }
+  if (comparison.finder.total < comparison.spot.total) {
+    return 'finder';
+  }
+  return 'tie';
+}
+
+int _fewerChecks(_Comparison comparison) {
+  return (comparison.spot.total - comparison.finder.total).abs();
+}
+
+String _factor(_Comparison comparison) {
+  final lower = _lowerTotal(comparison);
+  final higher = _higherTotal(comparison);
+  if (lower == higher) {
+    return '1.0x';
+  }
+  return '${(higher / lower).toStringAsFixed(1)}x';
+}
+
+int _lowerTotal(_Comparison comparison) {
+  if (comparison.spot.total < comparison.finder.total) {
+    return comparison.spot.total;
+  }
+  return comparison.finder.total;
+}
+
+int _higherTotal(_Comparison comparison) {
+  if (comparison.spot.total > comparison.finder.total) {
+    return comparison.spot.total;
+  }
+  return comparison.finder.total;
+}
+
+String _formatSummaryRow({
+  required String query,
+  required String winner,
+  required String factor,
+  required String fewer,
+  required String spot,
+  required String finder,
+}) {
+  return [
+    query.padRight(5),
+    winner.padRight(6),
+    factor.padLeft(9),
+    fewer.padLeft(13),
+    spot.padLeft(10),
+    finder.padLeft(10),
+  ].join('  ');
+}
+
+String _formatInt(int value) {
+  final text = value.toString();
+  final chars = text.split('').reversed.toList();
+  final buffer = StringBuffer();
+  for (int i = 0; i < chars.length; i++) {
+    if (i > 0 && i % 3 == 0) {
+      buffer.write(',');
+    }
+    buffer.write(chars[i]);
+  }
+  return buffer.toString().split('').reversed.join();
+}
+
+void _printWallClockSummary({
+  required String label,
+  required int warmups,
+  required int runs,
+  required Duration spot,
+  required Duration finder,
+}) {
+  final spotMicros = spot.inMicroseconds;
+  final finderMicros = finder.inMicroseconds;
+  final winner = _wallClockWinner(spotMicros, finderMicros);
+  final factor = _wallClockFactor(spotMicros, finderMicros);
+  final difference = (spotMicros - finderMicros).abs();
+  print('Wall clock summary: $label ($warmups warmups, $runs runs, avg/run)\n'
+      '  winner  better by  difference       spot     finder\n'
+      '  ${winner.padRight(6)}  ${factor.padLeft(9)}  '
+      '${_formatDurationMicros(difference).padLeft(10)}  '
+      '${_formatDurationMicros(spotMicros).padLeft(9)}  '
+      '${_formatDurationMicros(finderMicros).padLeft(9)}');
+}
+
+void _printWallClockScreenshotOverhead({
+  required Duration withScreenshots,
+  required Duration withoutScreenshots,
+}) {
+  final withScreenshotMicros = withScreenshots.inMicroseconds;
+  final withoutScreenshotMicros = withoutScreenshots.inMicroseconds;
+  final overhead = withScreenshotMicros - withoutScreenshotMicros;
+  final factor =
+      _wallClockFactor(withScreenshotMicros, withoutScreenshotMicros);
+  print('Spot screenshot overhead\n'
+      '  extra time  slower by  with screenshots  without screenshots\n'
+      '  ${_formatDurationMicros(overhead).padLeft(10)}  '
+      '${factor.padLeft(9)}  '
+      '${_formatDurationMicros(withScreenshotMicros).padLeft(16)}  '
+      '${_formatDurationMicros(withoutScreenshotMicros).padLeft(19)}');
+}
+
+String _wallClockWinner(int spotMicros, int finderMicros) {
+  if (spotMicros < finderMicros) {
+    return 'spot';
+  }
+  if (finderMicros < spotMicros) {
+    return 'finder';
+  }
+  return 'tie';
+}
+
+String _wallClockFactor(int spotMicros, int finderMicros) {
+  final lower = spotMicros < finderMicros ? spotMicros : finderMicros;
+  final higher = spotMicros > finderMicros ? spotMicros : finderMicros;
+  if (lower == higher) {
+    return '1.0x';
+  }
+  return '${(higher / lower).toStringAsFixed(1)}x';
+}
+
+String _formatDurationMicros(int micros) {
+  if (micros < 1000) {
+    return '${micros}us';
+  }
+  final millis = micros / 1000;
+  return '${millis.toStringAsFixed(1)}ms';
+}
+
+String _formatMeasurementRow({
+  required String engine,
+  required String total,
+  required String treeWalks,
+  required String filters,
+  required String relations,
+  required String snapshots,
+  required String matched,
+}) {
+  return [
+    engine.padRight(6),
+    total.padLeft(8),
+    treeWalks.padLeft(8),
+    filters.padLeft(8),
+    relations.padLeft(9),
+    snapshots.padLeft(9),
+    matched.padLeft(7),
+  ].join('  ');
 }
 
 /// A grid tile of the multi-result query test
@@ -384,6 +773,51 @@ class _GridTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return child;
+  }
+}
+
+class _BenchWidgetA extends StatelessWidget {
+  const _BenchWidgetA();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}
+
+class _BenchWidgetB extends StatelessWidget {
+  const _BenchWidgetB();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}
+
+class _BenchWidgetC extends StatelessWidget {
+  const _BenchWidgetC();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}
+
+class _BenchWidgetD extends StatelessWidget {
+  const _BenchWidgetD();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}
+
+class _BenchWidgetE extends StatelessWidget {
+  const _BenchWidgetE();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
   }
 }
 

--- a/test/spot/query_check_count_test.dart
+++ b/test/spot/query_check_count_test.dart
@@ -1,0 +1,552 @@
+// ignore_for_file: avoid_unnecessary_containers, avoid_print
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+import 'package:spot/src/spot/query_stats.dart';
+import 'package:spot/src/spot/tree_snapshot.dart';
+
+/// Measures the number of checks the spot query engine performs for typical
+/// and pathological queries, and compares them with the number of checks the
+/// flutter_test finder API needs for equivalent queries.
+///
+/// Spot checks = nodesTraversed + candidateChecks + relationChecks
+/// (see QueryStats).
+///
+/// Finder checks are measured with a 1:1 simulation of the finder evaluation
+/// in flutter_test (finders.dart, _DescendantFinderMixin/_AncestorFinderMixin)
+/// that counts element tree walks, predicate evaluations and the element
+/// comparisons of the linear `Iterable.contains` calls. Each simulation
+/// asserts that it discovers exactly the same elements as the real finder.
+void main() {
+  void measureSpot(String label, int maxChecks, void Function() query) {
+    QueryStats.reset();
+    query();
+    print('$label\n  ${QueryStats.summary()}');
+    // Guards against performance regressions of the query engine. The
+    // bounds have ~3x headroom over the currently measured numbers.
+    expect(
+      QueryStats.totalChecks,
+      lessThan(maxChecks),
+      reason: 'Query engine did more checks than expected for: $label',
+    );
+  }
+
+  void measureFinder(
+    String label,
+    _SimResult Function() build,
+    Finder realEquivalent,
+  ) {
+    _resetSimStats();
+    final simulation = build();
+    final matches = simulation.matches;
+    expect(
+      matches,
+      realEquivalent.evaluate().toList(),
+      reason: 'Finder simulation must discover the same elements '
+          'as the real finder for: $label',
+    );
+    final total = _simNodesVisited + _simPredicateChecks + _simComparisons;
+    print('$label\n  finderChecks: $total '
+        '(nodesVisited: $_simNodesVisited, '
+        'predicateChecks: $_simPredicateChecks, '
+        'comparisons: $_simComparisons, '
+        'matched: ${matches.length})');
+  }
+
+  testWidgets('count checks for common query shapes', (tester) async {
+    // No timeline events/screenshots, only measure the pure query work
+    timeline.mode = TimelineMode.off;
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(title: const Text('Home')),
+          body: ListView(
+            itemExtent: 6,
+            children: [
+              for (int i = 0; i < 100; i++)
+                Container(
+                  child: Row(
+                    children: [
+                      const Icon(Icons.star, size: 4),
+                      Text('Item $i', style: const TextStyle(fontSize: 4)),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    // Walks the tree once, so that all queries below operate on the
+    // cached per-frame tree snapshot (like consecutive assertions in a test)
+    final treeSize = currentWidgetTreeSnapshot().allNodes.length;
+    print('tree size: $treeSize nodes');
+
+    measureSpot('Q1 spot: spotText("Item 99") [no relationship]', 12000, () {
+      spotText('Item 99').existsOnce();
+    });
+    measureFinder(
+      'Q1 finder: find.text("Item 99")',
+      () => _simLeaf(_textPredicate('Item 99')),
+      find.byElementPredicate(_textPredicate('Item 99')),
+    );
+
+    measureSpot(
+        'Q2 spot: spot<MaterialApp>().spot<Scaffold>().spot<AppBar>().spotText("Home")',
+        50000, () {
+      spot<MaterialApp>()
+          .spot<Scaffold>()
+          .spot<AppBar>()
+          .spotText('Home')
+          .existsOnce();
+    });
+    measureFinder(
+      'Q2 finder: find.descendant(MaterialApp > Scaffold > AppBar > "Home")',
+      () {
+        return _simDescendant(
+          of: _simDescendant(
+            of: _simDescendant(
+              of: _simLeaf(_typePredicate(MaterialApp)),
+              matching: _simLeaf(_typePredicate(Scaffold)),
+            ),
+            matching: _simLeaf(_typePredicate(AppBar)),
+          ),
+          matching: _simLeaf(_textPredicate('Home')),
+        );
+      },
+      find.descendant(
+        of: find.descendant(
+          of: find.descendant(
+            of: find.byElementPredicate(_typePredicate(MaterialApp)),
+            matching: find.byElementPredicate(_typePredicate(Scaffold)),
+          ),
+          matching: find.byElementPredicate(_typePredicate(AppBar)),
+        ),
+        matching: find.byElementPredicate(_textPredicate('Home')),
+      ),
+    );
+
+    measureSpot(
+        'Q3 spot: spotText("Item 99").withParent(spot<Row>().withParent(spot<Container>()))',
+        40000, () {
+      spotText('Item 99')
+          .withParent(spot<Row>().withParent(spot<Container>()))
+          .existsOnce();
+    });
+    measureFinder(
+      'Q3a finder: find.descendant(of: find.descendant(of: Container, matching: Row), matching: "Item 99")',
+      () {
+        return _simDescendant(
+          of: _simDescendant(
+            of: _simLeaf(_typePredicate(Container)),
+            matching: _simLeaf(_typePredicate(Row)),
+          ),
+          matching: _simLeaf(_textPredicate('Item 99')),
+        );
+      },
+      find.descendant(
+        of: find.descendant(
+          of: find.byElementPredicate(_typePredicate(Container)),
+          matching: find.byElementPredicate(_typePredicate(Row)),
+        ),
+        matching: find.byElementPredicate(_textPredicate('Item 99')),
+      ),
+    );
+    measureFinder(
+      'Q3b finder: find.descendant(of: Container, matching: find.descendant(of: Row, matching: "Item 99"))',
+      () {
+        return _simDescendant(
+          of: _simLeaf(_typePredicate(Container)),
+          matching: _simDescendant(
+            of: _simLeaf(_typePredicate(Row)),
+            matching: _simLeaf(_textPredicate('Item 99')),
+          ),
+        );
+      },
+      find.descendant(
+        of: find.byElementPredicate(_typePredicate(Container)),
+        matching: find.descendant(
+          of: find.byElementPredicate(_typePredicate(Row)),
+          matching: find.byElementPredicate(_textPredicate('Item 99')),
+        ),
+      ),
+    );
+
+    measureSpot(
+        'Q4 spot: spot<Container>().withChild(spotIcon(Icons.star))', 80000,
+        () {
+      spot<Container>()
+          .withChild(spotIcon(Icons.star))
+          .existsExactlyNTimes(100);
+    });
+    measureFinder(
+      'Q4 finder: find.ancestor(of: icon, matching: Container)',
+      () {
+        return _simAncestor(
+          of: _simLeaf(_iconPredicate(Icons.star)),
+          matching: _simLeaf(_typePredicate(Container)),
+        );
+      },
+      find.ancestor(
+        of: find.byElementPredicate(_iconPredicate(Icons.star)),
+        matching: find.byElementPredicate(_typePredicate(Container)),
+      ),
+    );
+
+    measureSpot(
+        'Q5 spot: spot<Row>().withParent(spot<MaterialApp>()) [wide parent]',
+        75000, () {
+      spot<Row>().withParent(spot<MaterialApp>()).existsAtLeastNTimes(100);
+    });
+    measureFinder(
+      'Q5 finder: find.descendant(of: MaterialApp, matching: Row)',
+      () {
+        return _simDescendant(
+          of: _simLeaf(_typePredicate(MaterialApp)),
+          matching: _simLeaf(_typePredicate(Row)),
+        );
+      },
+      find.descendant(
+        of: find.byElementPredicate(_typePredicate(MaterialApp)),
+        matching: find.byElementPredicate(_typePredicate(Row)),
+      ),
+    );
+  });
+
+  testWidgets('count checks for multi-result queries (4 of 100 grid tiles)',
+      (tester) async {
+    // No timeline events/screenshots, only measure the pure query work
+    timeline.mode = TimelineMode.off;
+    tester.view.physicalSize = const Size(800, 1200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: GridView.count(
+          crossAxisCount: 10,
+          children: [
+            for (int i = 0; i < 100; i++)
+              _GridTile(
+                child: Column(
+                  children: [
+                    // 4 tiles are highlighted with a star
+                    Icon(i % 25 == 0 ? Icons.star : Icons.circle, size: 8),
+                    Text('Tile $i', style: const TextStyle(fontSize: 8)),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+
+    final treeSize = currentWidgetTreeSnapshot().allNodes.length;
+    print('tree size: $treeSize nodes');
+
+    measureSpot(
+        'M1 spot: spot<_GridTile>().withChild(spotIcon(Icons.star)) -> 4 of 100',
+        60000, () {
+      spot<_GridTile>().withChild(spotIcon(Icons.star)).existsExactlyNTimes(4);
+    });
+    measureFinder(
+      'M1 finder: find.ancestor(of: star icon, matching: _GridTile)',
+      () {
+        return _simAncestor(
+          of: _simLeaf(_iconPredicate(Icons.star)),
+          matching: _simLeaf(_typePredicate(_GridTile)),
+        );
+      },
+      find.ancestor(
+        of: find.byElementPredicate(_iconPredicate(Icons.star)),
+        matching: find.byElementPredicate(_typePredicate(_GridTile)),
+      ),
+    );
+
+    measureSpot(
+        'M2 spot: spotIcon(Icons.star).withParent(spot<_GridTile>()) -> 4 of 100',
+        60000, () {
+      spotIcon(Icons.star).withParent(spot<_GridTile>()).existsExactlyNTimes(4);
+    });
+    measureFinder(
+      'M2 finder: find.descendant(of: _GridTile, matching: star icon)',
+      () {
+        return _simDescendant(
+          of: _simLeaf(_typePredicate(_GridTile)),
+          matching: _simLeaf(_iconPredicate(Icons.star)),
+        );
+      },
+      find.descendant(
+        of: find.byElementPredicate(_typePredicate(_GridTile)),
+        matching: find.byElementPredicate(_iconPredicate(Icons.star)),
+      ),
+    );
+  });
+
+  testWidgets('count checks in deeply nested same-type tree', (tester) async {
+    // No timeline events/screenshots, only measure the pure query work
+    timeline.mode = TimelineMode.off;
+    // 50 nested SizedBox widgets, the worst case for find.descendant:
+    // every nesting level matches and its whole subtree is enumerated again
+    Widget tree = const Text('leaf');
+    for (int i = 0; i < 50; i++) {
+      tree = SizedBox(child: tree);
+    }
+    await tester.pumpWidget(MaterialApp(home: tree));
+
+    final treeSize = currentWidgetTreeSnapshot().allNodes.length;
+    print('tree size: $treeSize nodes');
+
+    measureSpot('N1 spot: spotText("leaf").withParent(spot<SizedBox>())', 10000,
+        () {
+      spotText('leaf').withParent(spot<SizedBox>()).existsOnce();
+    });
+    measureFinder(
+      'N1 finder: find.descendant(of: SizedBox, matching: "leaf")',
+      () {
+        return _simDescendant(
+          of: _simLeaf(_typePredicate(SizedBox)),
+          matching: _simLeaf(_textPredicate('leaf')),
+        );
+      },
+      find.descendant(
+        of: find.byElementPredicate(_typePredicate(SizedBox)),
+        matching: find.byElementPredicate(_textPredicate('leaf')),
+      ),
+    );
+
+    measureSpot(
+        'N2 spot: spotText("leaf").withParent(spot<SizedBox>().withParent(spot<SizedBox>()))',
+        10000, () {
+      spotText('leaf')
+          .withParent(spot<SizedBox>().withParent(spot<SizedBox>()))
+          .existsOnce();
+    });
+    measureFinder(
+      'N2a finder: find.descendant(of: find.descendant(of: SizedBox, matching: SizedBox), matching: "leaf")',
+      () {
+        return _simDescendant(
+          of: _simDescendant(
+            of: _simLeaf(_typePredicate(SizedBox)),
+            matching: _simLeaf(_typePredicate(SizedBox)),
+          ),
+          matching: _simLeaf(_textPredicate('leaf')),
+        );
+      },
+      find.descendant(
+        of: find.descendant(
+          of: find.byElementPredicate(_typePredicate(SizedBox)),
+          matching: find.byElementPredicate(_typePredicate(SizedBox)),
+        ),
+        matching: find.byElementPredicate(_textPredicate('leaf')),
+      ),
+    );
+    measureFinder(
+      'N2b finder: find.descendant(of: SizedBox, matching: find.descendant(of: SizedBox, matching: "leaf"))',
+      () {
+        return _simDescendant(
+          of: _simLeaf(_typePredicate(SizedBox)),
+          matching: _simDescendant(
+            of: _simLeaf(_typePredicate(SizedBox)),
+            matching: _simLeaf(_textPredicate('leaf')),
+          ),
+        );
+      },
+      find.descendant(
+        of: find.byElementPredicate(_typePredicate(SizedBox)),
+        matching: find.descendant(
+          of: find.byElementPredicate(_typePredicate(SizedBox)),
+          matching: find.byElementPredicate(_textPredicate('leaf')),
+        ),
+      ),
+    );
+  });
+}
+
+/// A grid tile of the multi-result query test
+class _GridTile extends StatelessWidget {
+  const _GridTile({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+}
+
+bool Function(Element) _typePredicate(Type type) {
+  return (el) => el.widget.runtimeType == type;
+}
+
+bool Function(Element) _textPredicate(String text) {
+  return (el) {
+    final widget = el.widget;
+    if (widget is Text) {
+      return widget.data?.contains(text) ?? false;
+    }
+    return false;
+  };
+}
+
+bool Function(Element) _iconPredicate(IconData icon) {
+  return (el) {
+    final widget = el.widget;
+    return widget is Icon && widget.icon == icon;
+  };
+}
+
+int _simNodesVisited = 0;
+int _simPredicateChecks = 0;
+int _simComparisons = 0;
+
+void _resetSimStats() {
+  _simNodesVisited = 0;
+  _simPredicateChecks = 0;
+  _simComparisons = 0;
+}
+
+List<Element> _collectCounted(Element root) {
+  final elements = collectAllElementsFrom(root, skipOffstage: true).toList();
+  _simNodesVisited += elements.length;
+  return elements;
+}
+
+/// The (lazy) result of a simulated finder, mirroring `FinderResult` of
+/// flutter_test.
+abstract class _SimResult {
+  List<Element>? _matchesCache;
+
+  /// The matched elements, computed once on first access like the
+  /// `CachingIterable` based evaluation of flutter_test finders.
+  List<Element> get matches => _matchesCache ??= computeMatches();
+
+  List<Element> computeMatches();
+
+  /// Simulates `Iterable.contains(target)` on this finder result, the way
+  /// `_DescendantFinderMixin.findInCandidates` and
+  /// `_AncestorFinderMixin.findInCandidates` use it.
+  bool scanContains(Element target);
+}
+
+/// Result of a leaf finder like `find.byType` or `find.text`.
+///
+/// The element tree walk and the predicate evaluations are cached by
+/// `CachingIterable`, repeated `contains` calls only scan the already
+/// computed matches.
+class _SimLeafResult extends _SimResult {
+  _SimLeafResult(this.predicate);
+
+  final bool Function(Element) predicate;
+
+  @override
+  List<Element> computeMatches() {
+    final all = _collectCounted(WidgetsBinding.instance.rootElement!);
+    final found = <Element>[];
+    for (final element in all) {
+      _simPredicateChecks++;
+      if (predicate(element)) {
+        found.add(element);
+      }
+    }
+    return found;
+  }
+
+  @override
+  bool scanContains(Element target) {
+    // `this.` because flutter_test exports a top-level `matches()` Matcher
+    // that shadows the inherited getter
+    for (final match in this.matches) {
+      _simComparisons++;
+      if (identical(match, target)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+/// Result of `find.descendant`/`find.ancestor`.
+///
+/// flutter_test wraps `candidates.where((c) => matching.contains(c))` in a
+/// plain lazy `WhereIterable`. It is NOT cached, every `contains` call
+/// re-runs the filter chain over all candidates.
+class _SimRelationResult extends _SimResult {
+  _SimRelationResult({required this.candidates, required this.matching});
+
+  final List<Element> candidates;
+  final _SimResult matching;
+
+  @override
+  List<Element> computeMatches() {
+    final found = <Element>[];
+    for (final candidate in candidates) {
+      if (matching.scanContains(candidate)) {
+        found.add(candidate);
+      }
+    }
+    return found;
+  }
+
+  @override
+  bool scanContains(Element target) {
+    for (final candidate in candidates) {
+      if (matching.scanContains(candidate)) {
+        _simComparisons++;
+        if (identical(candidate, target)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}
+
+/// Simulates evaluating `find.byElementPredicate(predicate)`.
+_SimResult _simLeaf(bool Function(Element) predicate) {
+  return _SimLeafResult(predicate);
+}
+
+/// Simulates evaluating `find.descendant(of: of, matching: matching)`,
+/// mirroring `_DescendantFinderMixin` (flutter_test finders.dart).
+///
+/// The `of` finder is evaluated eagerly and the subtree of every match is
+/// enumerated (`allCandidates`).
+_SimResult _simDescendant({
+  required _SimResult of,
+  required _SimResult matching,
+}) {
+  final seen = <Element>{};
+  final candidates = <Element>[];
+  for (final ancestor in of.matches) {
+    for (final element in _collectCounted(ancestor)) {
+      if (seen.add(element)) {
+        candidates.add(element);
+      }
+    }
+  }
+  return _SimRelationResult(candidates: candidates, matching: matching);
+}
+
+/// Simulates evaluating `find.ancestor(of: of, matching: matching)`,
+/// mirroring `_AncestorFinderMixin` (flutter_test finders.dart).
+///
+/// The candidates are the ancestor chains of all `of` matches (not deduped).
+_SimResult _simAncestor({
+  required _SimResult of,
+  required _SimResult matching,
+}) {
+  final candidates = <Element>[];
+  for (final leaf in of.matches) {
+    leaf.visitAncestorElements((element) {
+      _simNodesVisited++;
+      candidates.add(element);
+      return true;
+    });
+  }
+  return _SimRelationResult(candidates: candidates, matching: matching);
+}

--- a/test/spot/query_check_count_test.dart
+++ b/test/spot/query_check_count_test.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
-import 'package:spot/src/spot/query_stats.dart';
 import 'package:spot/src/spot/tree_snapshot.dart';
 
 /// Measures the number of checks the spot query engine performs for typical
@@ -19,14 +18,17 @@ import 'package:spot/src/spot/tree_snapshot.dart';
 /// comparisons of the linear `Iterable.contains` calls. Each simulation
 /// asserts that it discovers exactly the same elements as the real finder.
 void main() {
-  void measureSpot(String label, int maxChecks, void Function() query) {
-    QueryStats.reset();
-    query();
-    print('$label\n  ${QueryStats.summary()}');
+  void measureSpot(
+    String label,
+    int maxChecks,
+    WidgetSnapshot<Widget> Function() query,
+  ) {
+    final snapshot = query();
+    print('$label\n  ${snapshot.queryStats}');
     // Guards against performance regressions of the query engine. The
     // bounds have ~3x headroom over the currently measured numbers.
     expect(
-      QueryStats.totalChecks,
+      snapshot.queryStats.totalChecks,
       lessThan(maxChecks),
       reason: 'Query engine did more checks than expected for: $label',
     );
@@ -88,7 +90,7 @@ void main() {
     print('tree size: $treeSize nodes');
 
     measureSpot('Q1 spot: spotText("Item 99") [no relationship]', 12000, () {
-      spotText('Item 99').existsOnce();
+      return spotText('Item 99').snapshot()..existsOnce();
     });
     measureFinder(
       'Q1 finder: find.text("Item 99")',
@@ -99,11 +101,12 @@ void main() {
     measureSpot(
         'Q2 spot: spot<MaterialApp>().spot<Scaffold>().spot<AppBar>().spotText("Home")',
         50000, () {
-      spot<MaterialApp>()
+      return spot<MaterialApp>()
           .spot<Scaffold>()
           .spot<AppBar>()
           .spotText('Home')
-          .existsOnce();
+          .snapshot()
+        ..existsOnce();
     });
     measureFinder(
       'Q2 finder: find.descendant(MaterialApp > Scaffold > AppBar > "Home")',
@@ -134,9 +137,10 @@ void main() {
     measureSpot(
         'Q3 spot: spotText("Item 99").withParent(spot<Row>().withParent(spot<Container>()))',
         40000, () {
-      spotText('Item 99')
+      return spotText('Item 99')
           .withParent(spot<Row>().withParent(spot<Container>()))
-          .existsOnce();
+          .snapshot()
+        ..existsOnce();
     });
     measureFinder(
       'Q3a finder: find.descendant(of: find.descendant(of: Container, matching: Row), matching: "Item 99")',
@@ -180,9 +184,8 @@ void main() {
     measureSpot(
         'Q4 spot: spot<Container>().withChild(spotIcon(Icons.star))', 80000,
         () {
-      spot<Container>()
-          .withChild(spotIcon(Icons.star))
-          .existsExactlyNTimes(100);
+      return spot<Container>().withChild(spotIcon(Icons.star)).snapshot()
+        ..existsExactlyNTimes(100);
     });
     measureFinder(
       'Q4 finder: find.ancestor(of: icon, matching: Container)',
@@ -201,7 +204,8 @@ void main() {
     measureSpot(
         'Q5 spot: spot<Row>().withParent(spot<MaterialApp>()) [wide parent]',
         75000, () {
-      spot<Row>().withParent(spot<MaterialApp>()).existsAtLeastNTimes(100);
+      return spot<Row>().withParent(spot<MaterialApp>()).snapshot()
+        ..existsAtLeastNTimes(100);
     });
     measureFinder(
       'Q5 finder: find.descendant(of: MaterialApp, matching: Row)',
@@ -251,7 +255,8 @@ void main() {
     measureSpot(
         'M1 spot: spot<_GridTile>().withChild(spotIcon(Icons.star)) -> 4 of 100',
         60000, () {
-      spot<_GridTile>().withChild(spotIcon(Icons.star)).existsExactlyNTimes(4);
+      return spot<_GridTile>().withChild(spotIcon(Icons.star)).snapshot()
+        ..existsExactlyNTimes(4);
     });
     measureFinder(
       'M1 finder: find.ancestor(of: star icon, matching: _GridTile)',
@@ -270,7 +275,8 @@ void main() {
     measureSpot(
         'M2 spot: spotIcon(Icons.star).withParent(spot<_GridTile>()) -> 4 of 100',
         60000, () {
-      spotIcon(Icons.star).withParent(spot<_GridTile>()).existsExactlyNTimes(4);
+      return spotIcon(Icons.star).withParent(spot<_GridTile>()).snapshot()
+        ..existsExactlyNTimes(4);
     });
     measureFinder(
       'M2 finder: find.descendant(of: _GridTile, matching: star icon)',
@@ -303,7 +309,8 @@ void main() {
 
     measureSpot('N1 spot: spotText("leaf").withParent(spot<SizedBox>())', 10000,
         () {
-      spotText('leaf').withParent(spot<SizedBox>()).existsOnce();
+      return spotText('leaf').withParent(spot<SizedBox>()).snapshot()
+        ..existsOnce();
     });
     measureFinder(
       'N1 finder: find.descendant(of: SizedBox, matching: "leaf")',
@@ -322,9 +329,10 @@ void main() {
     measureSpot(
         'N2 spot: spotText("leaf").withParent(spot<SizedBox>().withParent(spot<SizedBox>()))',
         10000, () {
-      spotText('leaf')
+      return spotText('leaf')
           .withParent(spot<SizedBox>().withParent(spot<SizedBox>()))
-          .existsOnce();
+          .snapshot()
+        ..existsOnce();
     });
     measureFinder(
       'N2a finder: find.descendant(of: find.descendant(of: SizedBox, matching: SizedBox), matching: "leaf")',

--- a/test/spot/snapshot_test.dart
+++ b/test/spot/snapshot_test.dart
@@ -24,4 +24,264 @@ void main() {
     expect(oldTree.discoveredWidget!.height, 200);
     expect(newTree.discoveredWidget!.height, 100);
   });
+
+  testWidgets('cacheable selector stages are reused across equivalent chains',
+      (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Column(
+            children: [
+              Row(children: [Text('a')]),
+              Row(children: [Text('b')]),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final first = spot<Text>()
+        .withParent(spot<Row>().withParent(spot<Column>()))
+        .snapshot();
+    final second = spot<Text>()
+        .withParent(spot<Row>().withParent(spot<Column>()))
+        .snapshot();
+
+    expect(first.queryStats.totalChecks, greaterThan(0));
+    expect(second.queryStats.totalChecks, 0);
+    expect(second.queryStats.cacheHits, greaterThan(0));
+    expect(second.queryStats.cacheHitChecks, greaterThan(0));
+    expect(second.queryStats.cacheRatio, 1);
+    expect(second.discoveredWidgets.map((it) => it.data), ['a', 'b']);
+  });
+
+  testWidgets('uncacheable whereElement suffix reruns in the same frame',
+      (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Column(
+            children: const [
+              Text('a'),
+              Text('b'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    var selectedText = 'a';
+    var predicateCalls = 0;
+    final selector = spot<Text>().whereElement(
+      (element) {
+        predicateCalls++;
+        final widget = element.widget;
+        return widget is Text && widget.data == selectedText;
+      },
+      description: 'matches selected text',
+    );
+
+    final first = selector.snapshot();
+    final firstPredicateCalls = predicateCalls;
+    selectedText = 'b';
+    final second = selector.snapshot();
+    final secondPredicateCalls = predicateCalls - firstPredicateCalls;
+    final expectedSecondCacheRatio =
+        second.queryStats.cacheHitChecks / first.queryStats.candidateChecks;
+
+    expect(first.discoveredWidgets.map((it) => it.data), ['a']);
+    expect(second.discoveredWidgets.map((it) => it.data), ['b']);
+    expect(firstPredicateCalls, 2);
+    expect(secondPredicateCalls, 2);
+    expect(first.queryStats.cacheHits, 0);
+    expect(first.queryStats.cacheHitChecks, 0);
+    expect(first.queryStats.cacheRatio, 0);
+    expect(
+      first.queryStats.candidateChecks,
+      second.queryStats.cacheHitChecks + firstPredicateCalls,
+    );
+    expect(second.queryStats.candidateChecks, secondPredicateCalls);
+    expect(second.queryStats.totalChecks, secondPredicateCalls);
+    expect(second.queryStats.cacheHits, 2);
+    expect(
+      second.queryStats.cacheRatio,
+      closeTo(expectedSecondCacheRatio, 0.0000001),
+    );
+  });
+
+  testWidgets('spotText reuses equivalent text selector cache', (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Column(
+            children: const [
+              Text('hello'),
+              Text('world'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final first = spotText('hello').snapshot();
+    final second = spotText('hello').snapshot();
+
+    expect(first.queryStats.totalChecks, greaterThan(0));
+    expect(second.queryStats.totalChecks, 0);
+    expect(second.queryStats.cacheHits, greaterThan(0));
+    expect(second.queryStats.cacheRatio, 1);
+    expect(second.discoveredWidget!.text, 'hello');
+  });
+
+  testWidgets('spotTextWhere reruns in the same frame', (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Column(
+            children: const [
+              Text('a'),
+              Text('b'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    var selectedText = 'a';
+    final selector = spot().spotTextWhere(
+      (it) {
+        it.equals(selectedText);
+      },
+      description: 'matches selected text',
+    );
+
+    final first = selector.snapshot();
+    selectedText = 'b';
+    final second = selector.snapshot();
+
+    expect(first.discoveredWidget!.text, 'a');
+    expect(second.discoveredWidget!.text, 'b');
+    expect(second.queryStats.totalChecks, greaterThan(0));
+    expect(second.queryStats.cacheHits, greaterThan(0));
+  });
+
+  testWidgets('PredicateFilter can opt into cacheKey reuse', (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Column(
+            children: const [
+              Text('a'),
+              Text('b'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    WidgetSelector<Text> selector() {
+      return WidgetSelector<Text>(
+        stages: [
+          PredicateFilter(
+            predicate: (element) {
+              final widget = element.widget;
+              return widget is Text && widget.data == 'a';
+            },
+            description: 'Text data is a',
+            cacheKey: SpotCacheKey(
+              PredicateFilter,
+              ['Text data is a'],
+            ),
+          ),
+        ],
+      );
+    }
+
+    final first = selector().snapshot();
+    final second = selector().snapshot();
+
+    expect(first.queryStats.totalChecks, greaterThan(0));
+    expect(second.queryStats.totalChecks, 0);
+    expect(second.queryStats.cacheHits, greaterThan(0));
+    expect(second.queryStats.cacheRatio, 1);
+    expect(second.discoveredWidget!.data, 'a');
+  });
+
+  testWidgets('PredicateFilter defaults to live evaluation', (tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: Column(
+            children: const [
+              Text('a'),
+              Text('b'),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    var selectedText = 'a';
+    final selector = WidgetSelector<Text>(
+      stages: [
+        PredicateFilter(
+          predicate: (element) {
+            final widget = element.widget;
+            return widget is Text && widget.data == selectedText;
+          },
+          description: 'Text data is selectedText',
+        ),
+      ],
+    );
+
+    final first = selector.snapshot();
+    selectedText = 'b';
+    final second = selector.snapshot();
+
+    expect(first.discoveredWidget!.data, 'a');
+    expect(second.discoveredWidget!.data, 'b');
+    expect(second.queryStats.totalChecks, greaterThan(0));
+  });
+
+  testWidgets('cache keys reject collection values', (tester) async {
+    await tester.pumpWidget(Center());
+
+    void expectInvalidCacheKey(Object key) {
+      final selector = WidgetSelector<Widget>(
+        stages: [_CollectionCacheKeyFilter(key)],
+      );
+
+      expect(
+        () => snapshot(selector),
+        throwsA(isA<StateError>()),
+      );
+    }
+
+    expectInvalidCacheKey(<Object>[]);
+    expectInvalidCacheKey(<Object>{});
+    expectInvalidCacheKey(<Object, Object>{});
+  });
+}
+
+class _CollectionCacheKeyFilter extends ElementFilter {
+  _CollectionCacheKeyFilter(this.key);
+
+  final Object key;
+
+  @override
+  Object get cacheKey => key;
+
+  @override
+  String get description => 'invalid cache key';
+
+  @override
+  Iterable<WidgetTreeNode> filter(Iterable<WidgetTreeNode> candidates) {
+    return candidates;
+  }
 }


### PR DESCRIPTION
Relative selectors (`withParent`, `withChild`, chained `spot()`) used to resolve relationships by searching downwards through whole subtrees.
That made relationship checks grow with subtree size and caused `ChildFilter` to re-run `snapshot(childSelector)` once per candidate.

Relationships now resolve from the candidate side: walk from each candidate up to the root and check ancestors against hash sets of the parent matches.
`ChildFilter` counts child matches below each ancestor once, then reuses those counts for the candidate pass.

Selector stages are also cached per frame by structural cache keys.
Equivalent selector chains can now reuse cacheable prefixes across fresh selector instances, while live predicates such as `whereElement`, `spotTextWhere`, and `atPosition` still rerun their uncached suffix.

Same query shapes, checks counted on the benchmark fixtures:

```text
Query                                                     before    upward walk  with cache
MaterialApp > Scaffold > AppBar > Home                  3,471,219       15,637       7,905
Item 99 with Row > Container parent                     1,040,997       11,801       4,069
Container with child star icon, 100 matches               685,899       26,432      20,633
Row with MaterialApp parent                             2,046,750       24,932      17,200
```

The cache helps most when a later query reuses cacheable subqueries from earlier stages:

```text
Query                                                     before cache  with cache  reduction
star icon with _GridTile parent                                  7,592         112        99%
leaf text with two nested SizedBox parents                       1,253          53        96%
```

Wall-clock without screenshots is now roughly tied with equivalent finders on the simple-query benchmark.
With screenshots enabled, the timeline screenshot work dominates the timing and is not a useful query-engine signal.

`query_check_count_test.dart` prints per-query winner summaries, cache hits, saved checks, and cache ratio so regressions are easy to spot from CI output.
