### PR TITLE
Add bool quantity checks and WidgetSelector.getDiagnosticProp()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- New: `WidgetSelector.isPresent()` and `isAbsent()` return `bool` without failing the test, and `countWidgets()` returns the number of matching widgets. Use them to branch test logic on the presence, absence or quantity of a widget. #30
+  ```dart
+  if (spot<Tooltip>().withMessage('Open navigation menu').isPresent()) {
+    // ...
+  }
+  if (spot<Tooltip>().withMessage('Close menu').isAbsent()) {
+    // ...
+  }
+  final buttonCount = spot<ElevatedButton>().countWidgets();
+  final hasTwoButtons = spot<ElevatedButton>().countWidgets() == 2;
+  final hasAtLeastTwoButtons = spot<ElevatedButton>().countWidgets() >= 2;
+  ```
+- New: `getDiagnosticProp<T>('name')` is now also available on `WidgetSelector`, alongside the existing `getWidgetProp`, `getElementProp`, `getStateProp` and `getRenderObjectProp` readers. #30
+  ```dart
+  final message = spot<Tooltip>().getDiagnosticProp<String>('message');
+  ```
+
 - New: Text matching ignores invisible and special whitespace, so tests can use regular characters. `spotText`, `spotTextWhere`, `whereText`, `withText` and `hasText` strip invisible characters (zero width space, soft hyphen, word joiner, BOM) and fold every Unicode space separator (`Zs`, e.g. non-breaking space) to a regular space. Meaningful characters (zero width joiner, bidi controls, the `U+FFFC` WidgetSpan placeholder) and line breaks are kept. #138 (thx @MichaelTamm)
   ```dart
   spotText('foobar').existsOnce();  // matches Text('foo\u{200B}bar')

--- a/README.md
+++ b/README.md
@@ -16,23 +16,23 @@ visualizes the steps of a widget test as HTML report with automatic screenshots,
 
 - [Get started](#get-started)
 - [Timeline](#timeline)
-    - [Overview](#overview)
-    - [Add custom events to the Timeline](#add-custom-events-to-the-timeline)
-    - [Change Timeline mode](#change-timeline-mode)
-    - [Timeline in console on CI](#timeline-in-console-on-ci)
+  - [Overview](#overview)
+  - [Add custom events to the Timeline](#add-custom-events-to-the-timeline)
+  - [Change Timeline mode](#change-timeline-mode)
+  - [Timeline in console on CI](#timeline-in-console-on-ci)
 - [Screenshots](#screenshots)
-    - [Manual Screenshots](#manual-screenshots)
-    - [Load Fonts](#load-fonts)
+  - [Manual Screenshots](#manual-screenshots)
+  - [Load Fonts](#load-fonts)
 - [spot - Widget selectors](#widget-selectors-spot)
-    - [Chain selectors](#chain-selectors)
-    - [Selectors](#selectors)
-    - [Better errors](#better-errors)
-    - [Matchers](#matchers)
-    - [Selectors vs. Matchers](#selectors-vs-matchers)
-    - [Find offstage widgets](#find-offstage-widgets)
-- [act - tap, drag, type](#act-tap-drag-type-click)
+  - [Chain selectors](#chain-selectors)
+  - [Selectors](#selectors)
+  - [Better errors](#better-errors)
+  - [Matchers](#matchers)
+  - [Selectors vs. Matchers](#selectors-vs-matchers)
+  - [Find offstage widgets](#find-offstage-widgets)
+- [act - tap, drag, type](#act---tap-drag-type-click)
   - [tap](#tap)
-  - [tapAt](#tapAt)
+  - [tapAt](#tapat)
   - [enterText](#entertext)
   - [dragUntilVisible](#draguntilvisible)
   - [more act functions](#more-act-functions)
@@ -254,9 +254,13 @@ void main() {
 
 Additionally, `loadAppFonts()` loads the `Roboto` font, which is the default font in Flutter tests.
 
-| before | after |
-|--------|-------|
-| ![golden_testImage](https://github.com/user-attachments/assets/385e7760-c3ee-42d7-a3bd-6c5b906b7452) | ![golden_masterImage](https://github.com/user-attachments/assets/8261f27e-5a38-43c2-bff9-cfe01496215c) |
+Before:
+
+![golden_testImage](https://github.com/user-attachments/assets/385e7760-c3ee-42d7-a3bd-6c5b906b7452)
+
+After:
+
+![golden_masterImage](https://github.com/user-attachments/assets/8261f27e-5a38-43c2-bff9-cfe01496215c)
 
 ## Widget selectors `spot`
 
@@ -406,10 +410,29 @@ The easiest matchers are the quantity matchers. They allow checking how many wid
 final selector = spot<ElevatedButton>();
 
 // calls snapshot() internally
-final matchOne = selector.existsOnce(); 
+final matchOne = selector.existsOnce();
 final matchMultiple = selector.existsExactlyNTimes(5);
 
-selector.doesNotExist(); // end, nothing to match on 
+selector.doesNotExist(); // end, nothing to match on
+```
+
+To check the presence or absence of a widget without failing the test, use `isPresent()` or `isAbsent()`.
+They return a `bool` instead of throwing, allowing test logic to branch on the presence or absence of a widget.
+Quantity constraints are ignored because these methods only check whether at least one widget matches the selector.
+Use `countWidgets()` to read the exact number of matching widgets.
+
+```dart
+if (spot<Tooltip>().withMessage('Open navigation menu').isPresent()) {
+  // ...
+}
+
+if (spot<Tooltip>().withMessage('Close menu').isAbsent()) {
+  // ...
+}
+
+final buttonCount = spot<ElevatedButton>().countWidgets();
+final hasTwoButtons = spot<ElevatedButton>().countWidgets() == 2;
+final hasAtLeastTwoButtons = spot<ElevatedButton>().countWidgets() >= 2;
 ```
 
 #### Property matchers
@@ -436,6 +459,24 @@ spot<AppBar>().spot<Tooltip>().existsAtLeastOnce()
       .hasShowDurationWhere((it) => it.isGreaterOrEqual(Duration(seconds: 1000)))
       .hasTriggerMode(TooltipTriggerMode.longPress)
     );
+```
+
+#### Property readers
+
+Instead of asserting, read the raw property values to pass them into other functions.
+Each `has*` matcher has a `get*` counterpart on `WidgetMatcher`.
+
+```dart
+final message = spot<Tooltip>().existsOnce().getMessage();
+```
+
+Read any property with `getWidgetProp`, `getElementProp`, `getStateProp`, `getRenderObjectProp` or `getDiagnosticProp`, directly on the `WidgetSelector` or on a `WidgetMatcher`.
+
+```dart
+final size = spot<Tooltip>().getRenderObjectProp(
+  renderObjectProp<Size, RenderBox>('size', (r) => r.size),
+);
+final message = spot<Tooltip>().getDiagnosticProp<String>('message');
 ```
 
 ### Selectors vs. Matchers

--- a/lib/src/spot/props.dart
+++ b/lib/src/spot/props.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
 import 'package:spot/src/checks/checks_nullability.dart';
+import 'package:spot/src/spot/diagnostic_props.dart';
 import 'package:spot/src/spot/filters/predicate_filter.dart';
 import 'package:spot/src/spot/selectors.dart';
 import 'package:spot/src/spot/widget_selector.dart';
@@ -117,6 +118,18 @@ extension PropGetter<W extends Widget> on WidgetSelector<W> {
     final matcher = existsOnce();
     final renderObject = matcher.element.renderObject! as R;
     return prop.get(renderObject);
+  }
+
+  /// Retrieves the diagnostic property with [propName] of type [T] from
+  /// the matched widget (via `Widget.toDiagnosticsNode()`).
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// final message = spot<Tooltip>().getDiagnosticProp<String>('message');
+  /// ```
+  T getDiagnosticProp<T>(String propName) {
+    final matcher = existsOnce();
+    return matcher.getDiagnosticProp<T>(propName);
   }
 }
 

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -846,6 +846,72 @@ extension QuantityMatchers<W extends Widget> on WidgetSelector<W> {
     snapshot(none).doesNotExist();
   }
 
+  /// Returns whether at least one widget of type [W] matches this selector,
+  /// without failing the test when none is found.
+  ///
+  /// Use it to branch test logic based on the presence of a widget, where
+  /// the asserting matchers like [existsOnce] or [doesNotExist] would throw.
+  ///
+  /// Quantity constraints like [QuantitySelectors.atLeast] are ignored.
+  /// Use [countWidgets] to read the exact number of matching widgets.
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// if (spot<Tooltip>().withMessage('Open navigation menu').isPresent()) {
+  ///   // ...
+  /// }
+  /// ```
+  /// #### See also:
+  /// - [doesNotExist] asserts that no widgets of type [W] exist.
+  /// - [existsOnce] asserts that exactly one widget of type [W] exists.
+  /// - [existsAtLeastOnce] asserts that at least one widget of type [W] exists.
+  @useResult
+  bool isPresent() {
+    return countWidgets() > 0;
+  }
+
+  /// Returns whether no widget of type [W] matches this selector,
+  /// without failing the test when one is found.
+  ///
+  /// Use it to branch test logic based on the absence of a widget, where
+  /// the asserting matchers like [doesNotExist] or [existsOnce] would throw.
+  ///
+  /// Quantity constraints like [QuantitySelectors.atLeast] are ignored.
+  /// Use [countWidgets] to read the exact number of matching widgets.
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// if (spot<Tooltip>().withMessage('Close menu').isAbsent()) {
+  ///   // ...
+  /// }
+  /// ```
+  /// #### See also:
+  /// - [isPresent] returns whether at least one widget of type [W] exists.
+  /// - [doesNotExist] asserts that no widgets of type [W] exist.
+  /// - [existsOnce] asserts that exactly one widget of type [W] exists.
+  @useResult
+  bool isAbsent() {
+    return countWidgets() == 0;
+  }
+
+  /// Returns how many widgets of type [W] match this selector,
+  /// without failing the test when the quantity does not match.
+  ///
+  /// Quantity constraints like [QuantitySelectors.atLeast] are ignored.
+  /// Compare the returned number for boolean quantity checks.
+  ///
+  /// #### Example usage:
+  /// ```dart
+  /// final buttonCount = spot<ElevatedButton>().countWidgets();
+  /// final hasAtLeastTwoButtons = spot<ElevatedButton>().countWidgets() >= 2;
+  /// ```
+  @useResult
+  int countWidgets() {
+    final found =
+        snapshot(removeQuantityConstraints(), validateQuantity: false);
+    return found.discovered.length;
+  }
+
   /// Asserts that exactly one widget of type [W] exists.
   ///
   /// #### Example usage:

--- a/test/spot/existence_comparison_test.dart
+++ b/test/spot/existence_comparison_test.dart
@@ -15,6 +15,8 @@ void main() {
 
       final sizedBox = spot<SizedBox>();
 
+      expect(sizedBox.isPresent(), isFalse);
+      expect(sizedBox.isAbsent(), isTrue);
       expect(() => sizedBox.doesNotExist(), returnsNormally);
       expect(() => sizedBox.existsOnce(), throwsTestFailure);
       expect(() => sizedBox.existsAtLeastOnce(), throwsTestFailure);
@@ -36,6 +38,8 @@ void main() {
 
       final sizedBox = spot<SizedBox>();
 
+      expect(sizedBox.isPresent(), isTrue);
+      expect(sizedBox.isAbsent(), isFalse);
       expect(() => sizedBox.doesNotExist(), throwsTestFailure);
       expect(() => sizedBox.existsOnce(), returnsNormally);
       expect(() => sizedBox.existsAtLeastOnce(), returnsNormally);
@@ -56,6 +60,8 @@ void main() {
 
       final sizedBox = spot<SizedBox>();
 
+      expect(sizedBox.isPresent(), isTrue);
+      expect(sizedBox.isAbsent(), isFalse);
       expect(() => sizedBox.doesNotExist(), throwsTestFailure);
       expect(() => sizedBox.existsOnce(), throwsTestFailure);
       expect(() => sizedBox.existsAtLeastOnce(), returnsNormally);
@@ -66,6 +72,77 @@ void main() {
       expect(() => sizedBox.existsAtLeastNTimes(2), returnsNormally);
       expect(() => sizedBox.existsAtMostNTimes(1), throwsTestFailure);
       expect(() => sizedBox.existsAtMostNTimes(2), returnsNormally);
+    });
+  });
+
+  group('isPresent and isAbsent', () {
+    testWidgets('checks presence of widgets filtered by props', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Tooltip(
+            message: 'Open navigation menu',
+            child: SizedBox(),
+          ),
+        ),
+      );
+
+      bool isBurgerMenuPresent() {
+        return spot<Tooltip>().withMessage('Open navigation menu').isPresent();
+      }
+
+      expect(isBurgerMenuPresent(), isTrue);
+      expect(spot<Tooltip>().withMessage('Close menu').isPresent(), isFalse);
+      expect(spot<Tooltip>().withMessage('Close menu').isAbsent(), isTrue);
+    });
+
+    testWidgets('ignores quantity constraints', (tester) async {
+      await tester.pumpWidget(SizedBox());
+
+      expect(spot<SizedBox>().atLeast(5).countWidgets(), 1);
+      expect(spot<SizedBox>().amount(2).countWidgets(), 1);
+      expect(spot<SizedBox>().atMost(0).countWidgets(), 1);
+      expect(spot<SizedBox>().atLeast(1).isPresent(), isTrue);
+      expect(spot<SizedBox>().atLeast(5).isPresent(), isTrue);
+      expect(spot<SizedBox>().amount(1).isPresent(), isTrue);
+      expect(spot<SizedBox>().amount(2).isPresent(), isTrue);
+      expect(spot<SizedBox>().atMost(1).isPresent(), isTrue);
+      expect(spot<SizedBox>().atMost(0).isPresent(), isTrue);
+      expect(spot<SizedBox>().atMost(0).isAbsent(), isFalse);
+      expect(spot<Placeholder>().atLeast(0).isAbsent(), isTrue);
+    });
+
+    testWidgets('counts widgets without throwing', (tester) async {
+      await tester.pumpWidget(Column(children: [SizedBox(), SizedBox()]));
+
+      final sizedBox = spot<SizedBox>();
+
+      expect(sizedBox.countWidgets(), 2);
+      expect(sizedBox.countWidgets() == 1, isFalse);
+      expect(sizedBox.countWidgets() == 2, isTrue);
+      expect(sizedBox.countWidgets() >= 3, isFalse);
+      expect(sizedBox.countWidgets() >= 2, isTrue);
+      expect(sizedBox.countWidgets() <= 1, isFalse);
+      expect(sizedBox.countWidgets() <= 2, isTrue);
+    });
+
+    testWidgets('uses at least one match without quantity constraints',
+        (tester) async {
+      await tester.pumpWidget(Placeholder());
+
+      expect(spot<SizedBox>().countWidgets(), 0);
+      expect(spot<SizedBox>().isPresent(), isFalse);
+      expect(spot<SizedBox>().isAbsent(), isTrue);
+      expect(spot<SizedBox>().countWidgets() >= 0, isTrue);
+      expect(spot<SizedBox>().countWidgets() <= 0, isTrue);
+    });
+
+    testWidgets('does not add an event to the timeline', (tester) async {
+      await tester.pumpWidget(SizedBox());
+
+      final eventCount = timeline.events.length;
+      final isSizedBoxPresent = spot<SizedBox>().isPresent();
+      expect(timeline.events.length, eventCount);
+      expect(isSizedBoxPresent, isTrue);
     });
   });
 
@@ -84,6 +161,8 @@ void main() {
 
       expect(sizedBox.snapshot().discovered, isNotNull);
 
+      expect(sizedBox.isPresent(), isTrue);
+      expect(sizedBox.isAbsent(), isFalse);
       expect(() => sizedBox.doesNotExist(), throwsTestFailure);
       expect(() => sizedBox.existsOnce(), returnsNormally);
       expect(() => sizedBox.existsAtLeastOnce(), returnsNormally);
@@ -113,6 +192,8 @@ void main() {
 
       expect(sizedBox.snapshot().discovered, isEmpty);
 
+      expect(sizedBox.isPresent(), isFalse);
+      expect(sizedBox.isAbsent(), isTrue);
       expect(() => sizedBox.doesNotExist(), returnsNormally);
       expect(() => sizedBox.existsOnce(), throwsTestFailure);
       expect(() => sizedBox.existsAtLeastOnce(), throwsTestFailure);

--- a/test/spot/read_prop_test.dart
+++ b/test/spot/read_prop_test.dart
@@ -50,6 +50,19 @@ void main() {
       );
       expect(size, const Size(800.0, 600.0));
     });
+
+    testWidgets('getDiagnosticProp', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Tooltip(
+            message: 'Open navigation menu',
+            child: SizedBox(),
+          ),
+        ),
+      );
+      final message = spot<Tooltip>().getDiagnosticProp<String>('message');
+      expect(message, 'Open navigation menu');
+    });
   });
 
   group('WidgetMatcher', () {


### PR DESCRIPTION
Fixes #30

Check whether a widget is present or absent without failing the test:

```dart
if (spot<Tooltip>().withMessage('Open navigation menu').isPresent()) {
  // ...
}

if (spot<Tooltip>().withMessage('Close menu').isAbsent()) {
  // ...
}
```

Read the number of matching widgets without failing the test:

```dart
final buttonCount = spot<ElevatedButton>().countWidgets();
final hasTwoButtons = spot<ElevatedButton>().countWidgets() == 2;
final hasAtLeastTwoButtons = spot<ElevatedButton>().countWidgets() >= 2;
```

The assertive API keeps the existing `exists*` names:

```dart
spot<ElevatedButton>().existsOnce();
spot<ElevatedButton>().existsAtLeastNTimes(2);
```

Read diagnostic properties directly from a selector that resolves to exactly one widget:

```dart
final message = spot<Tooltip>().getDiagnosticProp<String>('message');
```

Selector property readers keep the same names as snapshot readers and fail when the selector does not resolve to exactly one widget.
