### PR TITLE
Preserve tree order for atPosition

### DIFF
--- a/lib/src/spot/filters/position_filter.dart
+++ b/lib/src/spot/filters/position_filter.dart
@@ -27,26 +27,12 @@ class PositionFilter implements ElementFilter {
         .map((entry) => _elementFromHitTarget(entry.target))
         .whereType<Element>()
         .toList();
-    final hitElements = <Element>[];
     final hitElementSet = <Element>{};
     for (final element in hits) {
-      if (!hitElementSet.add(element)) {
-        continue;
-      }
-      hitElements.add(element);
+      hitElementSet.add(element);
     }
 
-    final matchedByElement = <Element, WidgetTreeNode>{};
-    for (final node in candidates) {
-      if (!hitElementSet.contains(node.element)) {
-        continue;
-      }
-      matchedByElement[node.element] = node;
-    }
-
-    return hitElements
-        .map((element) => matchedByElement[element])
-        .whereType<WidgetTreeNode>();
+    return candidates.where((node) => hitElementSet.contains(node.element));
   }
 
   @override

--- a/lib/src/spot/selectors.dart
+++ b/lib/src/spot/selectors.dart
@@ -1144,6 +1144,7 @@ extension PositionFilterSelector<W extends Widget> on WidgetSelector<W> {
   /// [position] is a global screen coordinate.
   /// Flutter hit testing decides which widgets match, so widgets that overlap
   /// the coordinate but do not receive hit-test events are not included.
+  /// Matching widgets keep the same tree order as the incoming selector.
   @useResult
   WidgetSelector<W> atPosition(Offset position) {
     return addStage(PositionFilter(position));

--- a/test/spot/widget_at_position_test.dart
+++ b/test/spot/widget_at_position_test.dart
@@ -87,6 +87,64 @@ void main() {
     expect(box.color, Colors.green);
   });
 
+  testWidgets('atPosition preserves tree order', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox(
+            key: ValueKey('outer'),
+            width: 100,
+            height: 100,
+            child: SizedBox(
+              key: ValueKey('inner'),
+              width: 100,
+              height: 100,
+              child: ColoredBox(color: Colors.green),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final boxes = spot<SizedBox>()
+        .atPosition(const Offset(400, 300))
+        .snapshot()
+        .discoveredWidgets;
+
+    expect(boxes.map((it) => it.key), [
+      const ValueKey('outer'),
+      const ValueKey('inner'),
+    ]);
+  });
+
+  testWidgets('withParent keeps the order from atPosition', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox(
+            key: ValueKey('outer'),
+            width: 100,
+            height: 100,
+            child: SizedBox(
+              key: ValueKey('inner'),
+              width: 100,
+              height: 100,
+              child: ColoredBox(color: Colors.green),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final firstBox = spot<SizedBox>()
+        .atPosition(const Offset(400, 300))
+        .withParent(spot<Center>())
+        .first()
+        .snapshotWidget();
+
+    expect(firstBox.key, const ValueKey('outer'));
+  });
+
   testWidgets('atPosition returns no widgets outside the view', (tester) async {
     await tester.pumpWidget(
       const MaterialApp(


### PR DESCRIPTION
Make `atPosition()` use Flutter hit testing as a membership check while preserving the incoming selector order.
This keeps `first()` and `atIndex()` consistent with Spot's usual tree-order semantics when users chain `atPosition()` with relation filters.