### PR TITLE
Add editable text selector filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- New: `WidgetSelector<AnyText>.whereIsEditable()` and `whereIsNotEditable()` filter text matches by whether they come from an editable text input.
+  ```dart
+  spotText('username').whereIsEditable().existsOnce();
+  spotText('Username').whereIsNotEditable().existsOnce();
+  ```
 - New: `WidgetSelector.isPresent()` and `isAbsent()` return `bool` without failing the test, and `countWidgets()` returns the number of matching widgets. Use them to branch test logic on the presence, absence or quantity of a widget. #30
   ```dart
   if (spot<Tooltip>().withMessage('Open navigation menu').isPresent()) {

--- a/README.md
+++ b/README.md
@@ -368,6 +368,16 @@ spot<Text>().withText('Save').existsOnce();
 spotText('Save').existsOnce();
 ```
 
+Use `whereIsEditable()` and `whereIsNotEditable()` when the same text can appear as a label and as input content.
+
+```dart
+spotText('username').whereIsEditable().existsOnce();
+spotText('Username').whereIsNotEditable().existsOnce();
+```
+
+`whereIsEditable()` keeps text from enabled inputs that accept user edits.
+`whereIsNotEditable()` keeps regular display text and disabled or read-only inputs.
+
 Use `raw: true` when exact characters matter.
 Use `whereRawText`, `withRawText` and `hasRawText` for exact-character selector and matcher chains.
 

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -80,7 +80,8 @@ export 'package:spot/src/spot/snapshot.dart'
         ToWidgetMatcher,
         WidgetSnapshot,
         WidgetSnapshotShorthands;
-export 'package:spot/src/spot/text/any_text.dart' show AnyText, AnyTextContent;
+export 'package:spot/src/spot/text/any_text.dart'
+    show AnyText, AnyTextContent, AnyTextEditabilitySelector;
 export 'package:spot/src/spot/tree_snapshot.dart'
     show ScopedWidgetTreeSnapshot, WidgetTreeNode;
 export 'package:spot/src/spot/widget_matcher.dart'

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -308,6 +308,44 @@ class AnyTextContent {
   String toString() => 'AnyTextContent(raw: "$raw", normalized: "$normalized")';
 }
 
+/// Filters text selectors by whether the text can be edited by the user.
+extension AnyTextEditabilitySelector on WidgetSelector<AnyText> {
+  /// Keeps text backed by an [EditableText] that accepts user edits.
+  ///
+  /// Disabled and read-only text inputs are not editable.
+  @useResult
+  WidgetSelector<AnyText> whereIsEditable() {
+    return whereElement(
+      _isEditableTextElement,
+      description: 'is editable text',
+    );
+  }
+
+  /// Keeps text that is not editable by the user.
+  ///
+  /// This includes regular text widgets and disabled or read-only text inputs.
+  @useResult
+  WidgetSelector<AnyText> whereIsNotEditable() {
+    return whereElement(
+      (element) {
+        return !_isEditableTextElement(element);
+      },
+      description: 'is not editable text',
+    );
+  }
+}
+
+bool _isEditableTextElement(Element element) {
+  final widget = element.widget;
+  if (widget is! EditableText) {
+    return false;
+  }
+  if (widget.readOnly) {
+    return false;
+  }
+  return widget.focusNode.canRequestFocus;
+}
+
 /// Code units that have no visible glyph and no semantic effect on plain
 /// text. [AnyText.normalizeVisibleText] removes them entirely.
 ///

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -220,6 +220,91 @@ void main() {
     spotText('a').existsExactlyNTimes(2);
   });
 
+  group('text editability', () {
+    testWidgets('whereIsEditable keeps editable text inputs', (tester) async {
+      await tester.pumpWidget(
+        _stage(
+          children: [
+            TextFormField(initialValue: 'username'),
+            Text('username'),
+          ],
+        ),
+      );
+
+      spotText('username').existsExactlyNTimes(2);
+      spotText('username').whereIsEditable().existsOnce();
+      spotText('username').whereIsNotEditable().existsOnce();
+    });
+
+    testWidgets('whereIsEditable rejects read-only text inputs', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _stage(
+          children: [TextFormField(initialValue: 'username', readOnly: true)],
+        ),
+      );
+
+      spotText('username').whereIsEditable().doesNotExist();
+      spotText('username').whereIsNotEditable().existsOnce();
+    });
+
+    testWidgets('whereIsEditable rejects disabled text inputs', (tester) async {
+      await tester.pumpWidget(
+        _stage(
+          children: [TextFormField(initialValue: 'username', enabled: false)],
+        ),
+      );
+
+      spotText('username').whereIsEditable().doesNotExist();
+      spotText('username').whereIsNotEditable().existsOnce();
+    });
+
+    testWidgets('whereIsEditable rejects focus-blocked EditableText', (
+      tester,
+    ) async {
+      final focusNode = FocusNode(canRequestFocus: false);
+      addTearDown(focusNode.dispose);
+
+      final controller = TextEditingController(text: 'username');
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        _stage(
+          children: [
+            EditableText(
+              controller: controller,
+              focusNode: focusNode,
+              style: testTextStyle,
+              cursorColor: Colors.black,
+              backgroundCursorColor: Colors.black,
+            ),
+          ],
+        ),
+      );
+
+      spotText('username').whereIsEditable().doesNotExist();
+      spotText('username').whereIsNotEditable().existsOnce();
+    });
+
+    testWidgets('whereIsNotEditable keeps non-input text', (tester) async {
+      await tester.pumpWidget(
+        _stage(
+          children: [
+            Text('username'),
+            SelectableText('username'),
+            RichText(
+              text: TextSpan(text: 'username', style: testTextStyle),
+            ),
+          ],
+        ),
+      );
+
+      spotText('username').whereIsEditable().doesNotExist();
+      spotText('username').whereIsNotEditable().existsExactlyNTimes(3);
+    });
+  });
+
   group('spotTextWhere', () {
     for (final tree in trees.entries) {
       final widgetType = tree.key;


### PR DESCRIPTION
Adds `whereIsEditable()` and `whereIsNotEditable()` to refine `spotText()` matches by whether the text is backed by an enabled, focusable `EditableText`.

```dart
spotText('username').whereIsEditable().existsOnce();
spotText('Username').whereIsNotEditable().existsOnce();
```

Disabled and read-only inputs stay in `whereIsNotEditable()` alongside display text.