### PR TITLE
Enter text bypass hit test flag

### DIFF
--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -66,6 +66,19 @@ class Act {
       editableTextState = element.state as EditableTextState;
     }
 
+    // A read-only field (e.g. a disabled or readOnly TextField) can not receive
+    // input on any path: tapping it produces a generic hit-test failure, and
+    // bypassing the hit test only results in a silent no-op. Surface a clear
+    // reason instead.
+    if (editableTextState.widget.readOnly) {
+      throw TestFailure(
+        "Widget '${selector.toStringBreadcrumb()}' is read-only and can not "
+        'receive text input. This is usually caused by a disabled or '
+        'read-only TextField. To set its content, assign it through the '
+        "field's TextEditingController instead.",
+      );
+    }
+
     if (!bypassHitTest) {
       // Tap the field for real. This validates that the field is actually
       // hittable (not off-screen or covered) and focuses it, which in turn

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -26,6 +26,18 @@ class Act {
 
   /// Enters a text into the first [EditableText] child of [selector].
   ///
+  /// By default the field is tapped the way a real user would tap it before the
+  /// text is entered. The tap goes through the same hit-test validation as
+  /// [tap], so this throws if the field is outside the viewport or covered by
+  /// another widget (e.g. an overlay or an on-screen keyboard). This makes the
+  /// test fail when the field could not actually be reached by a user.
+  ///
+  /// Set [bypassHitTest] to `true` to skip the tap and force-focus the field by
+  /// reaching directly into the widget tree. This fills the field even when it
+  /// is not reachable, which is occasionally useful to seed state for a field
+  /// that is not the subject of the test. Prefer the default whenever the
+  /// field's reachability is part of what you are testing.
+  ///
   /// ```dart
   /// final emailTextField = spot<Form>()
   ///     .spot<TextField>()
@@ -35,30 +47,43 @@ class Act {
   ///     )..existsOnce();
   /// await act.enterText(emailTextField, 'alfred@phntm.xyz');
   /// ```
-  Future<void> enterText(WidgetSelector selector, String text) async {
+  Future<void> enterText(
+    WidgetSelector selector,
+    String text, {
+    bool bypassHitTest = false,
+  }) async {
     // Check if widget is in the widget tree. Throws if not.
     selector.snapshot().existsOnce();
+
+    final editableText = spot<EditableText>().withParent(selector);
+    final element = editableText.snapshot().discoveredElement;
+    final EditableTextState editableTextState;
+    if (element is! StatefulElement || element.state is! EditableTextState) {
+      throw TestFailure(
+        "Widget '${selector.toStringBreadcrumb()}' is not a descendant of EditableText.",
+      );
+    } else {
+      editableTextState = element.state as EditableTextState;
+    }
+
+    if (!bypassHitTest) {
+      // Tap the field for real. This validates that the field is actually
+      // hittable (not off-screen or covered) and focuses it, which in turn
+      // requests the keyboard and attaches the text input connection - exactly
+      // what happens when a user taps the field.
+      await tap(editableText);
+    }
 
     return await TestAsyncUtils.guard<void>(() async {
       final binding = TestWidgetsFlutterBinding.instance;
 
-      final editableText = spot<EditableText>().withParent(selector);
-      final element = editableText.snapshot().discoveredElement;
-      final EditableTextState editableTextState;
-
-      if (element is! StatefulElement || element.state is! EditableTextState) {
-        throw TestFailure(
-          "Widget '${selector.toStringBreadcrumb()}' is not a descendant of EditableText.",
-        );
-      } else {
-        editableTextState = element.state as EditableTextState;
+      if (bypassHitTest) {
+        // Setting focusedEditable causes the binding to call requestKeyboard()
+        // on the EditableTextState, which itself eventually calls
+        // TextInput.attach to establish the connection.
+        binding.focusedEditable = editableTextState;
+        await binding.pump();
       }
-
-      // Setting focusedEditable causes the binding to call requestKeyboard()
-      // on the EditableTextState, which itself eventually calls TextInput.attach
-      // to establish the connection.
-      binding.focusedEditable = editableTextState;
-      await binding.pump();
 
       if (!kIsWeb) {
         // Fix for enterText() not working in release mode on real iOS devices.
@@ -69,8 +94,7 @@ class Act {
         binding.testTextInput.register();
       }
 
-      final testTextInput = binding.testTextInput;
-      testTextInput.enterText(text);
+      binding.testTextInput.enterText(text);
       await binding.pump();
     });
   }

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -79,11 +79,12 @@ class Act {
       );
     }
 
-    if (!bypassHitTest) {
-      // Tap the field for real. This validates that the field is actually
-      // hittable (not off-screen or covered) and focuses it, which in turn
-      // requests the keyboard and attaches the text input connection - exactly
-      // what happens when a user taps the field.
+    if (!bypassHitTest && !editableTextState.widget.focusNode.hasFocus) {
+      // A real user does not always tap a field to focus it - it may already be
+      // focused via the keyboard or autofocus. Only when it isn't focused yet do
+      // we tap it the way a user would. The tap also validates that the field is
+      // actually hittable (not off-screen or covered) and focuses it, which in
+      // turn requests the keyboard and attaches the text input connection.
       await tap(editableText);
     }
 

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -585,6 +585,38 @@ void actTests() {
       );
     });
   });
+
+  group('enter text into an unreachable field', () {
+    // By default enterText taps the field first, which goes through hit testing
+    // and fails because the field is completely covered by the (fake) on-screen
+    // keyboard - exactly as it should in a real app.
+    testWidgets('enterText throws when the field is covered', (tester) async {
+      await tester.pumpWidget(const _KeyboardCoveredTextFieldApp());
+
+      await expectLater(
+        () => act.enterText(spot<TextField>(), 'hello'),
+        throwsSpotErrorContaining([
+          'can not be interacted with directly',
+          'ColoredBox', // the fake keyboard covering the field
+          'completely covering it',
+        ]),
+      );
+
+      // Nothing was entered because the tap never reached the field.
+      spotText('hello').doesNotExist();
+    });
+
+    // bypassHitTest: true reaches into the widget tree and force-focuses the
+    // field, filling it even though a real user could never reach it. This is
+    // the explicit escape hatch for seeding state.
+    testWidgets('enterText with bypassHitTest fills a covered field',
+        (tester) async {
+      await tester.pumpWidget(const _KeyboardCoveredTextFieldApp());
+
+      await act.enterText(spot<TextField>(), 'hello', bypassHitTest: true);
+      spotText('hello').existsOnce();
+    });
+  });
 }
 
 class ColorToggleApp extends StatefulWidget {
@@ -609,6 +641,39 @@ class _ColorToggleAppState extends State<ColorToggleApp> {
             });
           },
           child: null,
+        ),
+      ),
+    );
+  }
+}
+
+/// A text field that is completely hidden behind a fake on-screen keyboard.
+///
+/// The [ColoredBox] fills the whole screen and consumes all pointer events, so
+/// the [TextField] underneath can never be tapped by a real user - but its
+/// controller can still be filled directly via [Act.enterText].
+class _KeyboardCoveredTextFieldApp extends StatelessWidget {
+  const _KeyboardCoveredTextFieldApp();
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Material(
+        child: Stack(
+          children: [
+            Align(
+              alignment: Alignment.topCenter,
+              child: Padding(
+                padding: EdgeInsets.all(20),
+                child: SizedBox(width: 200, child: TextField()),
+              ),
+            ),
+            // Fake on-screen keyboard covering the entire screen, including the
+            // text field above.
+            Positioned.fill(
+              child: ColoredBox(color: Color(0xFF00FF00)),
+            ),
+          ],
         ),
       ),
     );

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -616,6 +616,22 @@ void actTests() {
       await act.enterText(spot<TextField>(), 'hello', bypassHitTest: true);
       spotText('hello').existsOnce();
     });
+
+    // A real user does not always tap to focus a field - it can be focused via
+    // the keyboard or autofocus. When the field is already focused, enterText
+    // types into it without tapping, so it succeeds even though the field is
+    // covered and could not be tapped.
+    testWidgets('enters text into an already-focused field without tapping',
+        (tester) async {
+      await tester.pumpWidget(
+        const _KeyboardCoveredTextFieldApp(autofocus: true),
+      );
+      // Let autofocus take effect.
+      await tester.pump();
+
+      await act.enterText(spot<TextField>(), 'hello');
+      spotText('hello').existsOnce();
+    });
   });
 
   group('enter text into a disabled field', () {
@@ -689,24 +705,29 @@ class _ColorToggleAppState extends State<ColorToggleApp> {
 /// the [TextField] underneath can never be tapped by a real user - but its
 /// controller can still be filled directly via [Act.enterText].
 class _KeyboardCoveredTextFieldApp extends StatelessWidget {
-  const _KeyboardCoveredTextFieldApp();
+  const _KeyboardCoveredTextFieldApp({this.autofocus = false});
+
+  final bool autofocus;
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       home: Material(
         child: Stack(
           children: [
             Align(
               alignment: Alignment.topCenter,
               child: Padding(
-                padding: EdgeInsets.all(20),
-                child: SizedBox(width: 200, child: TextField()),
+                padding: const EdgeInsets.all(20),
+                child: SizedBox(
+                  width: 200,
+                  child: TextField(autofocus: autofocus),
+                ),
               ),
             ),
             // Fake on-screen keyboard covering the entire screen, including the
             // text field above.
-            Positioned.fill(
+            const Positioned.fill(
               child: ColoredBox(color: Color(0xFF00FF00)),
             ),
           ],

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -617,6 +617,42 @@ void actTests() {
       spotText('hello').existsOnce();
     });
   });
+
+  group('enter text into a disabled field', () {
+    // A disabled TextField builds a read-only EditableText, which can never
+    // receive input. Both paths throw a dedicated error rather than silently
+    // doing nothing.
+    for (final bypassHitTest in [false, true]) {
+      testWidgets(
+        'throws a dedicated error on a disabled field '
+        '(bypassHitTest: $bypassHitTest)',
+        (tester) async {
+          final controller = TextEditingController(text: 'original');
+          addTearDown(controller.dispose);
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Material(
+                child: TextField(controller: controller, enabled: false),
+              ),
+            ),
+          );
+
+          await expectLater(
+            () => act.enterText(
+              spot<TextField>(),
+              'new',
+              bypassHitTest: bypassHitTest,
+            ),
+            throwsSpotErrorContaining([
+              'is read-only and can not receive text input',
+              'TextEditingController',
+            ]),
+          );
+          expect(controller.text, 'original');
+        },
+      );
+    }
+  });
 }
 
 class ColorToggleApp extends StatefulWidget {

--- a/test/act/act_test.dart
+++ b/test/act/act_test.dart
@@ -549,10 +549,20 @@ void actTests() {
     });
 
     testWidgets('enter text in text field', (tester) async {
+      // Record events so we can assert the unfocused field is tapped. This also
+      // acts as the control for the "already-focused field is not tapped" test:
+      // it proves the timeline captures taps, so the absence of the event there
+      // is meaningful.
+      timeline.mode = TimelineMode.reportOnError;
       await tester
           .pumpWidget(const MaterialApp(home: Material(child: TextField())));
       await act.enterText(spot<TextField>(), 'hello');
       spotText('hello').existsOnce();
+
+      expect(
+        timeline.events.where((e) => e.eventType.label == 'Tap Event'),
+        isNotEmpty,
+      );
     });
 
     testWidgets('spot a non existing widget throws an error', (tester) async {
@@ -623,6 +633,9 @@ void actTests() {
     // covered and could not be tapped.
     testWidgets('enters text into an already-focused field without tapping',
         (tester) async {
+      // Record events so we can assert that no tap happened.
+      timeline.mode = TimelineMode.reportOnError;
+
       await tester.pumpWidget(
         const _KeyboardCoveredTextFieldApp(autofocus: true),
       );
@@ -631,6 +644,13 @@ void actTests() {
 
       await act.enterText(spot<TextField>(), 'hello');
       spotText('hello').existsOnce();
+
+      // The field was already focused, so enterText skipped the tap entirely -
+      // no 'Tap Event' was added to the timeline.
+      expect(
+        timeline.events.where((e) => e.eventType.label == 'Tap Event'),
+        isEmpty,
+      );
     });
   });
 


### PR DESCRIPTION
# Make `enterText` hit-test the field by default

`act.enterText` used to force-focus the `EditableText` directly — filling
fields that were off-screen or covered (overlay, dialog, on-screen keyboard).
Tests that should fail passed.

Now `enterText` taps the field via the real `act.tap` path first, so an
unreachable field throws. Old behavior stays behind an explicit flag:

```dart
Future<void> enterText(
  WidgetSelector selector,
  String text, {
  bool bypassHitTest = false, // true = old force-focus, for seeding state
})
```

Reuses `act.tap` (no duplicated hit-test logic), keeps the iOS
`testTextInput.register()` fix, no nested guard.

A real user doesn't always tap to focus a field — it may already be focused
via the keyboard or autofocus. So the tap is **skipped when the field already
has focus**, and the text is entered directly. Only an unfocused field is
tapped (and thus required to be reachable).

Read-only / disabled fields (which can never receive input) now throw a
dedicated error on *both* paths — pointing at the `TextEditingController` —
instead of a cryptic hit-test failure (default) or a silent no-op
(`bypassHitTest`).

**Breaking** — but well-targeted: reachable fields don't break (the vast
majority); breakage is almost always a real bug the test should've caught.
Keeping the cheat as default would never surface those.

Tests: new groups in `act_test.dart` cover a fully-covered field (throws by
default, fills with `bypassHitTest: true`; succeeds when the field is
autofocused, since no tap is needed) and a disabled field (dedicated error on
both paths).