### PR TITLE
Cache the resolved widget location per widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improvement: The source location of a widget is resolved once per widget instead of on every lookup, which speeds up `act.tapAt()` timeline events and the diagnostics behind failing `act.tap()` calls. #154
 - New: `WidgetSelector<AnyText>.whereIsEditable()` and `whereIsNotEditable()` filter text matches by whether they come from an editable text input.
   ```dart
   spotText('username').whereIsEditable().existsOnce();

--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -1157,10 +1157,40 @@ Future<T> _alwaysPropagateDevicePointerEvents<T>(
   }
 }
 
+/// Caches the [WidgetLocation] of a [Widget], including a `null` result
+///
+/// Keyed by [Widget], not by [Element], because an [Element] survives a
+/// rebuild that replaces its widget with one created at a different location,
+/// while a [Widget] instance always originates from a single constructor call.
+class _CachedWidgetLocation {
+  _CachedWidgetLocation(this.location);
+
+  final WidgetLocation? location;
+}
+
+final Expando<_CachedWidgetLocation> _widgetLocationCache =
+    Expando<_CachedWidgetLocation>('debugWidgetLocation');
+
 /// Grants access to the location of a Widget via [WidgetInspectorService]
 extension WidgetLocationExt on Element {
   /// Returns where the widget was created in code
+  ///
+  /// The result is cached per [Widget]. Resolving a location serializes a
+  /// diagnostics node to JSON, which is far too expensive to repeat for every
+  /// widget on every hit test.
   WidgetLocation? get debugWidgetLocation {
+    final widget = this.widget;
+    final cached = _widgetLocationCache[widget];
+    if (cached != null) {
+      return cached.location;
+    }
+
+    final location = _resolveDebugWidgetLocation();
+    _widgetLocationCache[widget] = _CachedWidgetLocation(location);
+    return location;
+  }
+
+  WidgetLocation? _resolveDebugWidgetLocation() {
     try {
       final delegate = InspectorSerializationDelegate(
         service: WidgetInspectorService.instance,

--- a/test/act/widget_location_test.dart
+++ b/test/act/widget_location_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+import 'package:spot/src/act/act.dart';
+
+void main() {
+  testWidgets('reports the location where the widget was created',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Text('hello'),
+      ),
+    );
+
+    final location = spot<Text>().snapshotElement().debugWidgetLocation;
+
+    expect(location, isNotNull);
+    expect(location!.file.path, contains('widget_location_test.dart'));
+    expect(location.isUserCode, isTrue);
+  });
+
+  testWidgets('follows the widget when a rebuild moves the constructor call',
+      (tester) async {
+    // Both branches build a Text into the same slot, so the Element is reused
+    // while its widget comes from a different line. A location cached per
+    // Element would keep reporting the first branch.
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: _SwitchingText(useFirst: true),
+      ),
+    );
+    final firstElement = spot<Text>().snapshotElement();
+    final first = firstElement.debugWidgetLocation;
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: _SwitchingText(useFirst: false),
+      ),
+    );
+    final secondElement = spot<Text>().snapshotElement();
+    final second = secondElement.debugWidgetLocation;
+
+    expect(
+      secondElement,
+      same(firstElement),
+      reason: 'the Element must be reused for this test to prove anything',
+    );
+    expect(first!.file.path, contains('widget_location_test.dart'));
+    expect(second!.file.path, contains('widget_location_test.dart'));
+    expect(second.file.path, isNot(first.file.path));
+  });
+}
+
+class _SwitchingText extends StatelessWidget {
+  const _SwitchingText({required this.useFirst});
+
+  final bool useFirst;
+
+  @override
+  Widget build(BuildContext context) {
+    if (useFirst) {
+      return const Text('hello');
+    }
+    return const Text('world');
+  }
+}


### PR DESCRIPTION
Resolving `debugWidgetLocation` serializes the element's whole diagnostics node to JSON via `InspectorSerializationDelegate`, just to read `file`, `line`, `column` and `createdByLocalProject`. Nothing cached the result, so every lookup paid for it again — around 0.08ms per call. That is cheap once and expensive in a loop, which makes the getter a trap for any caller that walks a hit-test path or a parent chain.

This caches it, so `debugWidgetLocation` is safe to call repeatedly.

Today the callers are `act.tapAt()`'s timeline events, which resolve the location of every widget on the hit-test path, and the tap failure diagnostics. Both are bounded, so the win is modest — this is mostly about removing the sharp edge before something does call it in a loop.

No tracking issue; found while profiling upcoming work on `act.inspectTap()`.

### Keyed by Widget, not Element

The interesting decision. An `Element` outlives its widget, and a rebuild can swap in a widget created at a different line:

```dart
Widget build(BuildContext context) {
  if (useFirst) {
    return const Text('hello'); // line 58
  }
  return const Text('world');   // line 60
}
```

Both branches build into the same slot, so the `Element` is reused. An Element-keyed cache would keep reporting line 58 forever and point error messages at the wrong branch. A `Widget` instance always originates from a single constructor call, which makes it the correct key.

`widget_location_test.dart` pins this — it fails if the key is changed to the element.

Identical `const` widgets on different lines are not a problem: with `--track-widget-creation` the location is part of the const expression, so they are distinct instances and resolve to their own lines.

### Why the `_CachedWidgetLocation` wrapper

`Expando` cannot distinguish "never computed" from "computed, result was null", and null is a normal outcome here — with `--track-widget-creation` off it is the outcome for *every* widget. Without the wrapper the cache would never hit in that mode, which is exactly when the repeated cost would otherwise be paid.