### PR TITLE
Cache a widget's diagnostic properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improve: `hasDiagnosticProp`, `getDiagnosticProp` and `withDiagnosticProp` share one cache of a widget's diagnostic properties instead of running `debugFillProperties` again on every call. Every matcher in a chain used to rebuild the properties of the same widget, and every `with*` selector rebuilt them for every widget in the tree. Measured over a tree of 200 `Text`s, one `with*` filter went from 523µs to 228µs for `spotText` and from 145µs to 135µs for `spot<Text>()`. `WidgetSelector.mapElementToWidget` now has to return a widget with the same properties every time it is called with the same element within one frame; it may still return a new instance per call, as the `AnyText` selectors behind `spotText` do.
 - New: `act.inspectTap()` reports whether a widget can be tapped and why not, as a value instead of a thrown error. It sends no pointer events and pumps no frame, so a test can assert that something is untappable *for a specific reason* rather than matching on message strings. #150
   ```dart
   final inspection = act.inspectTap(spot<ElevatedButton>());

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Improvement: `hasDiagnosticProp`, `getDiagnosticProp` and `withDiagnosticProp` share one cache of a widget's diagnostic properties instead of running `debugFillProperties` again on every call. Every matcher in a chain used to rebuild the properties of the same widget, and so did every query that inspected a widget an earlier query had already inspected. Over a tree of 200 `Text`s, repeated property queries in one frame are around 1.5x faster. #159
+- Improvement: `hasDiagnosticProp`, `getDiagnosticProp` and `withDiagnosticProp` share one cache of a widget's diagnostic properties instead of running `debugFillProperties` again on every call. Every matcher in a chain used to rebuild the properties of the same widget, and so did every query that inspected a widget an earlier query had already inspected. Over a tree of 200 `Text`s, repeated property queries are around 1.5x faster. #159
 - New: `act.inspectTap()` reports whether a widget can be tapped and why not, as a value instead of a thrown error. It sends no pointer events and pumps no frame, so a test can assert that something is untappable *for a specific reason* rather than matching on message strings. #150
   ```dart
   final inspection = act.inspectTap(spot<ElevatedButton>());

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: A `WidgetMatcher` reports the widget it matched, not whatever is in the tree when you read it. `getDiagnosticProp` used to re-read the live widget while `matcher.widget` returned the matched one, so a matcher held across a pump could answer with two different values. All of them now read the matched widget; take a new matcher to assert against the current tree. #159
+
 - Improvement: `hasDiagnosticProp`, `getDiagnosticProp` and `withDiagnosticProp` share one cache of a widget's diagnostic properties instead of running `debugFillProperties` again on every call. Every matcher in a chain used to rebuild the properties of the same widget, and so did every query that inspected a widget an earlier query had already inspected. Over a tree of 200 `Text`s, repeated property queries are around 1.5x faster. #159
 - New: `act.inspectTap()` reports whether a widget can be tapped and why not, as a value instead of a thrown error. It sends no pointer events and pumps no frame, so a test can assert that something is untappable *for a specific reason* rather than matching on message strings. #150
   ```dart

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Improve: `hasDiagnosticProp`, `getDiagnosticProp` and `withDiagnosticProp` share one cache of a widget's diagnostic properties instead of running `debugFillProperties` again on every call. Every matcher in a chain used to rebuild the properties of the same widget, and every `with*` selector rebuilt them for every widget in the tree. Measured over a tree of 200 `Text`s, one `with*` filter went from 523µs to 228µs for `spotText` and from 145µs to 135µs for `spot<Text>()`. `WidgetSelector.mapElementToWidget` now has to return a widget with the same properties every time it is called with the same element within one frame; it may still return a new instance per call, as the `AnyText` selectors behind `spotText` do.
+- Improvement: `hasDiagnosticProp`, `getDiagnosticProp` and `withDiagnosticProp` share one cache of a widget's diagnostic properties instead of running `debugFillProperties` again on every call. Every matcher in a chain used to rebuild the properties of the same widget, and so did every query that inspected a widget an earlier query had already inspected. Over a tree of 200 `Text`s, repeated property queries in one frame are around 1.5x faster. #159
 - New: `act.inspectTap()` reports whether a widget can be tapped and why not, as a value instead of a thrown error. It sends no pointer events and pumps no frame, so a test can assert that something is untappable *for a specific reason* rather than matching on message strings. #150
   ```dart
   final inspection = act.inspectTap(spot<ElevatedButton>());

--- a/lib/src/spot/diagnostic_props.dart
+++ b/lib/src/spot/diagnostic_props.dart
@@ -160,13 +160,13 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
 /// Keyed on the derived widget itself, which is the only thing the properties
 /// depend on. A [Widget] is immutable, so what it fills in cannot change while
 /// the instance lives; a rebuild creates a new instance and with it a new
-/// entry. Nothing has to notice a frame here.
+/// entry. Nothing here needs invalidating.
 ///
 /// A [WidgetSelector] that synthesizes a widget per call gets a new entry per
 /// call and never a hit — correct, just uncached. The [AnyText] selectors
 /// behind [spotText] are the ones that would pay for that, which is why
-/// [AnyTextWidgetSelector] hands out the same instance for the same element
-/// within a frame.
+/// [AnyTextWidgetSelector] hands out the same instance for an element until
+/// something it was derived from changes.
 List<DiagnosticsNode> _diagnosticProps(
   Element element,
   Widget Function(Element element) mapElementToWidget,

--- a/lib/src/spot/diagnostic_props.dart
+++ b/lib/src/spot/diagnostic_props.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:spot/spot.dart';
 import 'package:spot/src/checks/checks_nullability.dart';
+import 'package:spot/src/flutter/frame_clock.dart';
 import 'package:spot/src/spot/selectors.dart';
 import 'package:spot/src/spot/widget_matcher.dart';
 
@@ -49,10 +50,9 @@ extension DiagnosticPropWidgetSelector<W extends Widget> on WidgetSelector<W> {
 
     return whereElement(
       (element) {
-        final diagnosticsNode = mapElementToWidget(element).toDiagnosticsNode();
-        final DiagnosticsNode? prop = diagnosticsNode
-            .getProperties()
-            .firstOrNullWhere((e) => e.name == propName);
+        final DiagnosticsNode? prop =
+            _diagnosticProps(element, mapElementToWidget)
+                .firstOrNullWhere((e) => e.name == propName);
 
         final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
 
@@ -101,11 +101,9 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
   /// final checked = spot<Checkbox>().existsOnce().getDiagnosticProp<bool>('value');
   /// ```
   T getDiagnosticProp<T>(String propName) {
-    final diagnosticsNode =
-        selector.mapElementToWidget(element).toDiagnosticsNode();
-    final DiagnosticsNode? prop = diagnosticsNode
-        .getProperties()
-        .firstOrNullWhere((e) => e.name == propName);
+    final DiagnosticsNode? prop =
+        _diagnosticProps(element, selector.mapElementToWidget)
+            .firstOrNullWhere((e) => e.name == propName);
     final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
     return actual as T;
   }
@@ -117,10 +115,9 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
     String propName,
     MatchProp<T> match,
   ) {
-    final diagnosticsNode = widget.toDiagnosticsNode();
-    final DiagnosticsNode? prop = diagnosticsNode
-        .getProperties()
-        .firstOrNullWhere((e) => e.name == propName);
+    final DiagnosticsNode? prop =
+        _diagnosticProps(element, selector.mapElementToWidget)
+            .firstOrNullWhere((e) => e.name == propName);
 
     final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
     void condition(Subject<T?> subject) {
@@ -149,6 +146,58 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
     final failure = softCheckHideNull(actual, condition);
     failure.throwPropertyCheckFailure(condition, element);
     return this;
+  }
+}
+
+/// The [DiagnosticsProperty]s of the widget [mapElementToWidget] derives from
+/// [element], cached for the duration of the current frame.
+///
+/// [Widget.toDiagnosticsNode] returns a fresh node on every call, and each node
+/// only caches [DiagnosticsNode.getProperties] for itself. Without this cache
+/// every matcher in a chain re-runs `debugFillProperties` for the same widget,
+/// and every `with*` selector re-runs it for every widget in the tree.
+///
+/// The cache is keyed on the [Element]'s own widget rather than the derived
+/// one, because [WidgetSelector.mapElementToWidget] may synthesize a widget per
+/// call, as the [AnyText] selectors do. [mapElementToWidget] is part of the key
+/// so that two selectors deriving different widgets from one element, such as
+/// `spot<RichText>()` and `spotText()`, don't read each other's properties.
+///
+/// A frame is the longest span over which a derived widget is guaranteed to
+/// keep reporting the same properties. Widgets themselves are immutable, but a
+/// derived widget can read live state: [AnyText.fromEditableText] takes the
+/// text from the controller, and an [EditableText] keeps its widget instance
+/// while its text changes. Holding entries past the frame that produced them
+/// would serve the text a test just replaced.
+List<DiagnosticsNode> _diagnosticProps(
+  Element element,
+  Widget Function(Element element) mapElementToWidget,
+) {
+  _dropCacheOnNewFrame();
+  final derived = _propsCache[element.widget] ??= {};
+  return derived[mapElementToWidget] ??=
+      mapElementToWidget(element).toDiagnosticsNode().getProperties();
+}
+
+/// Maps an [Element]'s widget to the properties of every widget derived from it
+/// in the current frame, keyed by the function that derived it.
+///
+/// An [Expando] because the keys are widgets of a tree the test may tear down
+/// at any point, and holding them here must not keep them alive.
+Expando<Map<Function, List<DiagnosticsNode>>> _propsCache = Expando();
+
+int _cachedFrame = -1;
+
+/// Drops everything cached in an earlier frame.
+///
+/// [FrameClock] counts frames for the whole process, so this only has to
+/// notice that the number moved. Nothing here registers a frame callback of
+/// its own.
+void _dropCacheOnNewFrame() {
+  final frame = FrameClock.frameNumberInProcess;
+  if (frame != _cachedFrame) {
+    _cachedFrame = frame;
+    _propsCache = Expando();
   }
 }
 

--- a/lib/src/spot/diagnostic_props.dart
+++ b/lib/src/spot/diagnostic_props.dart
@@ -49,9 +49,9 @@ extension DiagnosticPropWidgetSelector<W extends Widget> on WidgetSelector<W> {
 
     return whereElement(
       (element) {
+        final props = _diagnosticProps(mapElementToWidget(element));
         final DiagnosticsNode? prop =
-            _diagnosticProps(element, mapElementToWidget)
-                .firstOrNullWhere((e) => e.name == propName);
+            props.firstOrNullWhere((e) => e.name == propName);
 
         final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
 
@@ -100,9 +100,9 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
   /// final checked = spot<Checkbox>().existsOnce().getDiagnosticProp<bool>('value');
   /// ```
   T getDiagnosticProp<T>(String propName) {
+    final props = _diagnosticProps(widget);
     final DiagnosticsNode? prop =
-        _diagnosticProps(element, selector.mapElementToWidget)
-            .firstOrNullWhere((e) => e.name == propName);
+        props.firstOrNullWhere((e) => e.name == propName);
     final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
     return actual as T;
   }
@@ -114,9 +114,9 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
     String propName,
     MatchProp<T> match,
   ) {
+    final props = _diagnosticProps(widget);
     final DiagnosticsNode? prop =
-        _diagnosticProps(element, selector.mapElementToWidget)
-            .firstOrNullWhere((e) => e.name == propName);
+        props.firstOrNullWhere((e) => e.name == propName);
 
     final actual = prop?.value as T? ?? prop?.getDefaultValue<T>();
     void condition(Subject<T?> subject) {
@@ -148,8 +148,7 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
   }
 }
 
-/// The [DiagnosticsProperty]s of the widget [mapElementToWidget] derives from
-/// [element], cached on that widget.
+/// The [DiagnosticsProperty]s of [widget], cached on it.
 ///
 /// [Widget.toDiagnosticsNode] returns a fresh node on every call, and each node
 /// only caches [DiagnosticsNode.getProperties] for itself. Without this cache
@@ -167,11 +166,7 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
 /// behind [spotText] are the ones that would pay for that, which is why
 /// [AnyTextWidgetSelector] hands out the same instance for an element until
 /// something it was derived from changes.
-List<DiagnosticsNode> _diagnosticProps(
-  Element element,
-  Widget Function(Element element) mapElementToWidget,
-) {
-  final widget = mapElementToWidget(element);
+List<DiagnosticsNode> _diagnosticProps(Widget widget) {
   return _propsCache[widget] ??=
       List.unmodifiable(widget.toDiagnosticsNode().getProperties());
 }

--- a/lib/src/spot/diagnostic_props.dart
+++ b/lib/src/spot/diagnostic_props.dart
@@ -3,7 +3,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:spot/spot.dart';
 import 'package:spot/src/checks/checks_nullability.dart';
-import 'package:spot/src/flutter/frame_clock.dart';
 import 'package:spot/src/spot/selectors.dart';
 import 'package:spot/src/spot/widget_matcher.dart';
 
@@ -150,56 +149,41 @@ extension DiagnosticPropWidgetMatcher<W extends Widget> on WidgetMatcher<W> {
 }
 
 /// The [DiagnosticsProperty]s of the widget [mapElementToWidget] derives from
-/// [element], cached for the duration of the current frame.
+/// [element], cached on that widget.
 ///
 /// [Widget.toDiagnosticsNode] returns a fresh node on every call, and each node
 /// only caches [DiagnosticsNode.getProperties] for itself. Without this cache
 /// every matcher in a chain re-runs `debugFillProperties` for the same widget,
-/// and every `with*` selector re-runs it for every widget in the tree.
+/// and so does every query that inspects a widget an earlier query already
+/// inspected.
 ///
-/// The cache is keyed on the [Element]'s own widget rather than the derived
-/// one, because [WidgetSelector.mapElementToWidget] may synthesize a widget per
-/// call, as the [AnyText] selectors do. [mapElementToWidget] is part of the key
-/// so that two selectors deriving different widgets from one element, such as
-/// `spot<RichText>()` and `spotText()`, don't read each other's properties.
+/// Keyed on the derived widget itself, which is the only thing the properties
+/// depend on. A [Widget] is immutable, so what it fills in cannot change while
+/// the instance lives; a rebuild creates a new instance and with it a new
+/// entry. Nothing has to notice a frame here.
 ///
-/// A frame is the longest span over which a derived widget is guaranteed to
-/// keep reporting the same properties. Widgets themselves are immutable, but a
-/// derived widget can read live state: [AnyText.fromEditableText] takes the
-/// text from the controller, and an [EditableText] keeps its widget instance
-/// while its text changes. Holding entries past the frame that produced them
-/// would serve the text a test just replaced.
+/// A [WidgetSelector] that synthesizes a widget per call gets a new entry per
+/// call and never a hit — correct, just uncached. The [AnyText] selectors
+/// behind [spotText] are the ones that would pay for that, which is why
+/// [AnyTextWidgetSelector] hands out the same instance for the same element
+/// within a frame.
 List<DiagnosticsNode> _diagnosticProps(
   Element element,
   Widget Function(Element element) mapElementToWidget,
 ) {
-  _dropCacheOnNewFrame();
-  final derived = _propsCache[element.widget] ??= {};
-  return derived[mapElementToWidget] ??=
-      mapElementToWidget(element).toDiagnosticsNode().getProperties();
+  final widget = mapElementToWidget(element);
+  return _propsCache[widget] ??=
+      List.unmodifiable(widget.toDiagnosticsNode().getProperties());
 }
 
-/// Maps an [Element]'s widget to the properties of every widget derived from it
-/// in the current frame, keyed by the function that derived it.
+/// The [DiagnosticsProperty]s of a [Widget], for as long as that widget lives.
 ///
 /// An [Expando] because the keys are widgets of a tree the test may tear down
 /// at any point, and holding them here must not keep them alive.
-Expando<Map<Function, List<DiagnosticsNode>>> _propsCache = Expando();
-
-int _cachedFrame = -1;
-
-/// Drops everything cached in an earlier frame.
 ///
-/// [FrameClock] counts frames for the whole process, so this only has to
-/// notice that the number moved. Nothing here registers a frame callback of
-/// its own.
-void _dropCacheOnNewFrame() {
-  final frame = FrameClock.frameNumberInProcess;
-  if (frame != _cachedFrame) {
-    _cachedFrame = frame;
-    _propsCache = Expando();
-  }
-}
+/// The lists are unmodifiable because every caller in the process now reads the
+/// same instance.
+final Expando<List<DiagnosticsNode>> _propsCache = Expando();
 
 extension on DiagnosticsNode {
   T? getDefaultValue<T>() {

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:spot/spot.dart';
 import 'package:spot/src/checks/checks_nullability.dart';
-import 'package:spot/src/flutter/frame_clock.dart';
 import 'package:spot/src/spot/query_stats.dart';
 
 /// A union type for any text widget that can be found in the widget tree.
@@ -413,7 +412,8 @@ class AnyTextWidgetSelector extends WidgetSelector<AnyText> {
     required super.stages,
   }) : super(mapElementToWidget: _mapElementToAnyText);
 
-  /// The [AnyText] of [element], the same instance for the rest of the frame.
+  /// The [AnyText] of [element], the same instance until something it was
+  /// derived from changes.
   ///
   /// [AnyText] is synthesized, so without this every caller would get a fresh
   /// instance — [WidgetMatcher.widget], every `with*` filter and every property
@@ -421,17 +421,34 @@ class AnyTextWidgetSelector extends WidgetSelector<AnyText> {
   /// derive from it, which is what makes the diagnostic property cache in
   /// `diagnostic_props.dart` work for [spotText].
   ///
-  /// Only for the frame that produced it. An [AnyText] copies live state:
-  /// [AnyText.fromEditableText] takes the text off the controller, and an
-  /// [EditableText] keeps its widget instance while its text changes. Serving
-  /// it in a later frame would serve the text a test just replaced.
+  /// An [AnyText] copies live state, so it is only good while that state is
+  /// unchanged. [_anyTextVersion] is what changed-or-not is decided on, which
+  /// keeps this exact rather than merely timely: a new instance appears the
+  /// moment the text does, not at the next frame.
   static AnyText _mapElementToAnyText(Element element) {
-    final frame = FrameClock.frameNumberInProcess;
-    if (frame != _memoizedFrame) {
-      _memoizedFrame = frame;
-      _anyTextOfElement = Expando();
+    final version = _anyTextVersion(element);
+    final memoized = _anyTextOfElement[element];
+    if (memoized != null && memoized.version == version) {
+      return memoized.anyText;
     }
-    return _anyTextOfElement[element] ??= _deriveAnyText(element);
+    final anyText = _deriveAnyText(element);
+    _anyTextOfElement[element] = _MemoizedAnyText(version, anyText);
+    return anyText;
+  }
+
+  /// Everything [_deriveAnyText] reads, as a value that compares equal when
+  /// none of it changed.
+  ///
+  /// A [RichText] carries its text, so the widget instance is the whole of it.
+  /// An [EditableText] does not: it keeps its instance while the controller's
+  /// value changes underneath, so that value is part of the version.
+  static Object _anyTextVersion(Element element) {
+    final widget = element.widget;
+    if (widget is EditableText) {
+      final state = (element as StatefulElement).state as EditableTextState;
+      return (widget, state.textEditingValue);
+    }
+    return widget;
   }
 
   static AnyText _deriveAnyText(Element element) {
@@ -450,18 +467,19 @@ class AnyTextWidgetSelector extends WidgetSelector<AnyText> {
   }
 }
 
-/// The [AnyText] synthesized for an [Element] in frame [_memoizedFrame].
+/// The [AnyText] synthesized for an [Element], together with the inputs it was
+/// derived from.
 ///
 /// An [Expando] because the keys are elements of a tree the test may tear down
 /// at any point, and holding them here must not keep them alive.
-Expando<AnyText> _anyTextOfElement = Expando();
+final Expando<_MemoizedAnyText> _anyTextOfElement = Expando();
 
-/// The frame [_anyTextOfElement] holds instances of.
-///
-/// [FrameClock] counts frames for the whole process, so noticing that the
-/// number moved is all it takes to drop the previous frame's instances.
-/// Nothing here registers a frame callback of its own.
-int _memoizedFrame = -1;
+class _MemoizedAnyText {
+  _MemoizedAnyText(this.version, this.anyText);
+
+  final Object version;
+  final AnyText anyText;
+}
 
 /// Matches text widgets ([EditableText] and [RichText]) on screen.
 ///

--- a/lib/src/spot/text/any_text.dart
+++ b/lib/src/spot/text/any_text.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:spot/spot.dart';
 import 'package:spot/src/checks/checks_nullability.dart';
+import 'package:spot/src/flutter/frame_clock.dart';
 import 'package:spot/src/spot/query_stats.dart';
 
 /// A union type for any text widget that can be found in the widget tree.
@@ -412,7 +413,28 @@ class AnyTextWidgetSelector extends WidgetSelector<AnyText> {
     required super.stages,
   }) : super(mapElementToWidget: _mapElementToAnyText);
 
+  /// The [AnyText] of [element], the same instance for the rest of the frame.
+  ///
+  /// [AnyText] is synthesized, so without this every caller would get a fresh
+  /// instance — [WidgetMatcher.widget], every `with*` filter and every property
+  /// read. Handing out one instance per element lets callers cache what they
+  /// derive from it, which is what makes the diagnostic property cache in
+  /// `diagnostic_props.dart` work for [spotText].
+  ///
+  /// Only for the frame that produced it. An [AnyText] copies live state:
+  /// [AnyText.fromEditableText] takes the text off the controller, and an
+  /// [EditableText] keeps its widget instance while its text changes. Serving
+  /// it in a later frame would serve the text a test just replaced.
   static AnyText _mapElementToAnyText(Element element) {
+    final frame = FrameClock.frameNumberInProcess;
+    if (frame != _memoizedFrame) {
+      _memoizedFrame = frame;
+      _anyTextOfElement = Expando();
+    }
+    return _anyTextOfElement[element] ??= _deriveAnyText(element);
+  }
+
+  static AnyText _deriveAnyText(Element element) {
     if (element.widget is RichText) {
       // RichText is used by Text and SelectableText under the hood
       return AnyText.fromRichText(element.widget as RichText);
@@ -427,6 +449,19 @@ class AnyTextWidgetSelector extends WidgetSelector<AnyText> {
     );
   }
 }
+
+/// The [AnyText] synthesized for an [Element] in frame [_memoizedFrame].
+///
+/// An [Expando] because the keys are elements of a tree the test may tear down
+/// at any point, and holding them here must not keep them alive.
+Expando<AnyText> _anyTextOfElement = Expando();
+
+/// The frame [_anyTextOfElement] holds instances of.
+///
+/// [FrameClock] counts frames for the whole process, so noticing that the
+/// number moved is all it takes to drop the previous frame's instances.
+/// Nothing here registers a frame callback of its own.
+int _memoizedFrame = -1;
 
 /// Matches text widgets ([EditableText] and [RichText]) on screen.
 ///

--- a/lib/src/spot/widget_matcher.dart
+++ b/lib/src/spot/widget_matcher.dart
@@ -41,7 +41,7 @@ class _WidgetMatcherImpl<W extends Widget> implements WidgetMatcher<W> {
   _WidgetMatcherImpl({
     required this.element,
     required this.selector,
-  });
+  }) : widget = selector.mapElementToWidget(element);
 
   @override
   final Element element;
@@ -49,8 +49,11 @@ class _WidgetMatcherImpl<W extends Widget> implements WidgetMatcher<W> {
   @override
   final WidgetSelector<W> selector;
 
+  /// Captured when this matcher was created, like the widgets a
+  /// [WidgetSnapshot] holds, so everything the matcher reports describes one
+  /// point in time.
   @override
-  W get widget => selector.mapElementToWidget(element);
+  final W widget;
 }
 
 class _WidgetMatcherFromSnapshot<W extends Widget> implements WidgetMatcher<W> {

--- a/lib/src/spot/widget_selector.dart
+++ b/lib/src/spot/widget_selector.dart
@@ -92,10 +92,9 @@ class WidgetSelector<W extends Widget> with ChainableSelectors<W> {
   /// Overwrite this method when [W] is a synthetic widget like [AnyText] that
   /// combines multiple widgets of similar (but not exact) Type
   ///
-  /// Must return a widget with the same properties every time it is called with
-  /// the same [Element] within one frame. It may return a new instance each
-  /// call, and it may read state that changes between frames, but callers cache
-  /// what they derive from it for the length of a frame.
+  /// Called repeatedly for the same [Element], so returning the same instance
+  /// for the same element is worth it when synthesizing is expensive. Returning
+  /// a new instance each call is always correct.
   final W Function(Element element) mapElementToWidget;
 
   /// The runtime type of the widget this selector is intended for.

--- a/lib/src/spot/widget_selector.dart
+++ b/lib/src/spot/widget_selector.dart
@@ -91,6 +91,11 @@ class WidgetSelector<W extends Widget> with ChainableSelectors<W> {
 
   /// Overwrite this method when [W] is a synthetic widget like [AnyText] that
   /// combines multiple widgets of similar (but not exact) Type
+  ///
+  /// Must return a widget with the same properties every time it is called with
+  /// the same [Element] within one frame. It may return a new instance each
+  /// call, and it may read state that changes between frames, but callers cache
+  /// what they derive from it for the length of a frame.
   final W Function(Element element) mapElementToWidget;
 
   /// The runtime type of the widget this selector is intended for.

--- a/test/selectors/diagnostic_prop_test.dart
+++ b/test/selectors/diagnostic_prop_test.dart
@@ -95,8 +95,7 @@ void main() {
             )
             .existsOnce(),
         throwsSpotErrorContaining([
-          'Could not find Icon with prop "semanticLabel" equals \'remove\' '
-              'in widget tree',
+          notFoundMessage,
           'A less specific search (Icon) discovered 1 matches!',
           'Icon(IconData(U+0E047), semanticLabel: "add"',
         ]),
@@ -342,8 +341,7 @@ void main() {
       expect(
         () => spot<Icon>().withSemanticLabel('remove').existsOnce(),
         throwsSpotErrorContaining([
-          'Could not find Icon with prop "semanticLabel" equals \'remove\' '
-              'in widget tree',
+          notFoundMessage,
           'A less specific search (Icon) discovered 1 matches!',
           'Icon(IconData(U+0E047), semanticLabel: "add"',
         ]),
@@ -351,6 +349,14 @@ void main() {
     });
   });
 }
+
+/// The first line of the failure when no `Icon` has `semanticLabel: remove`.
+///
+/// A local so the two tests that assert it cannot drift apart, and because
+/// adjacent strings inside a list literal read as a forgotten comma.
+const notFoundMessage =
+    'Could not find Icon with prop "semanticLabel" equals \'remove\' '
+    'in widget tree';
 
 /// Reports how often it was asked for its diagnostic properties.
 class _CountingProps extends StatelessWidget {

--- a/test/selectors/diagnostic_prop_test.dart
+++ b/test/selectors/diagnostic_prop_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
@@ -189,6 +190,86 @@ void main() {
       );
     });
 
+    testWidgets('builds the props of a widget only once', (tester) async {
+      // Why the cache exists. All three entry points read through it, so a
+      // widget fills its properties once no matter how often it is inspected.
+      var fills = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _CountingProps(value: 4, onFillProperties: () => fills++),
+        ),
+      );
+
+      spot<_CountingProps>()
+          .existsOnce()
+          .hasDiagnosticProp<int>('value', (it) => it.equals(4));
+      expect(fills, 1);
+
+      spot<_CountingProps>().existsOnce().getDiagnosticProp<int>('value');
+      spot<_CountingProps>()
+          .withDiagnosticProp<int>('value', (it) => it.equals(4))
+          .existsOnce();
+      expect(fills, 1);
+
+      // A rebuild creates a new widget instance, which has its own properties.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _CountingProps(value: 7, onFillProperties: () => fills++),
+        ),
+      );
+      expect(
+        spot<_CountingProps>().existsOnce().getDiagnosticProp<int>('value'),
+        7,
+      );
+      expect(fills, 2);
+    });
+
+    testWidgets('does not share props between elements of one widget',
+        (tester) async {
+      // One widget instance can be mounted in several elements, and a selector
+      // deriving its widget from the element reports different props for each.
+      const shared = _Marker();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Column(
+            children: [
+              DefaultTextStyle(
+                style: TextStyle(fontSize: 10),
+                child: shared,
+              ),
+              DefaultTextStyle(
+                style: TextStyle(fontSize: 20),
+                child: shared,
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(
+        _spotFontSizeOfContext()
+            .atIndex(0)
+            .existsOnce()
+            .getDiagnosticProp<double>('contextValue'),
+        10,
+      );
+      expect(
+        _spotFontSizeOfContext()
+            .atIndex(1)
+            .existsOnce()
+            .getDiagnosticProp<double>('contextValue'),
+        20,
+      );
+      // Both directions: reading the first element's props for the second one
+      // makes the filter match twice for 10 and never for 20.
+      _spotFontSizeOfContext()
+          .withDiagnosticProp<double>('contextValue', (it) => it.equals(10))
+          .existsOnce();
+      _spotFontSizeOfContext()
+          .withDiagnosticProp<double>('contextValue', (it) => it.equals(20))
+          .existsOnce();
+    });
+
     testWidgets('generated withDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
@@ -212,4 +293,56 @@ void main() {
       );
     });
   });
+}
+
+/// Reports how often it was asked for its diagnostic properties.
+class _CountingProps extends StatelessWidget {
+  const _CountingProps({required this.value, required this.onFillProperties});
+
+  final int value;
+  final void Function() onFillProperties;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    onFillProperties();
+    super.debugFillProperties(properties);
+    properties.add(IntProperty('value', value));
+  }
+}
+
+/// A widget without properties of its own, to be mounted more than once.
+class _Marker extends StatelessWidget {
+  const _Marker();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}
+
+/// The properties of a [_Marker] element, taken from its context instead of
+/// from its widget, which is what makes two elements of one [_Marker] instance
+/// report different properties.
+class _FontSizeOfContext extends StatelessWidget {
+  const _FontSizeOfContext(this.contextValue);
+
+  final double contextValue;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DoubleProperty('contextValue', contextValue));
+  }
+}
+
+WidgetSelector<_FontSizeOfContext> _spotFontSizeOfContext() {
+  return WidgetSelector<_FontSizeOfContext>(
+    stages: [WidgetTypeFilter<_Marker>()],
+    mapElementToWidget: (element) =>
+        _FontSizeOfContext(DefaultTextStyle.of(element).style.fontSize!),
+  );
 }

--- a/test/selectors/diagnostic_prop_test.dart
+++ b/test/selectors/diagnostic_prop_test.dart
@@ -125,10 +125,61 @@ void main() {
       expect(spot<Icon>().existsOnce().getDiagnosticProp<double>('size'), 7);
     });
 
+    testWidgets('a matcher keeps reporting the widget it matched',
+        (tester) async {
+      // A matcher describes the moment it was created, like the snapshot it
+      // came from. Reading a prop off it later must not answer for a widget
+      // it never matched.
+      final controller = TextEditingController(text: 'before');
+      final focusNode = FocusNode();
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: EditableText(
+              controller: controller,
+              focusNode: focusNode,
+              style: TextStyle(fontSize: 12),
+              cursorColor: Colors.red,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      );
+
+      final matcher = spotTextWhere((it) => it.isNotEmpty()).existsOnce();
+      // The other matcher implementation, built from an element instead of
+      // holding a snapshot.
+      final discovered = spotTextWhere((it) => it.isNotEmpty())
+          .existsExactlyNTimes(1)
+          .discovered
+          .single;
+
+      controller.text = 'after';
+      await tester.pump();
+
+      expect(matcher.widget.text, 'before');
+      expect(matcher.getDiagnosticProp<String>('text'), 'before');
+      matcher.hasDiagnosticProp<String>('text', (it) => it.equals('before'));
+
+      expect(discovered.widget.text, 'before');
+      expect(discovered.getDiagnosticProp<String>('text'), 'before');
+
+      // Only the matcher is frozen. A new query sees the current tree.
+      expect(
+        spotTextWhere((it) => it.isNotEmpty())
+            .existsOnce()
+            .getDiagnosticProp<String>('text'),
+        'after',
+      );
+    });
+
     testWidgets('reads fresh text after a controller change', (tester) async {
       // AnyText reads the text off the live controller, and a bare
-      // EditableText keeps its widget instance while its text changes. The
-      // props of one frame must not be served in the next.
+      // EditableText keeps its widget instance while its text changes. A
+      // matcher taken after the change must see it.
       final controller = TextEditingController(text: 'before');
       final focusNode = FocusNode();
       addTearDown(controller.dispose);

--- a/test/selectors/diagnostic_prop_test.dart
+++ b/test/selectors/diagnostic_prop_test.dart
@@ -12,43 +12,45 @@ void main() {
     testWidgets('getDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Icon(Icons.add, size: 4),
+          home: Icon(Icons.add, semanticLabel: 'add'),
         ),
       );
 
-      final size = spot<Icon>().existsOnce().getDiagnosticProp<double>('size');
-      expect(size, 4);
+      final label =
+          spot<Icon>().existsOnce().getDiagnosticProp<String>('semanticLabel');
+      expect(label, 'add');
     });
 
     testWidgets('generated getDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Icon(Icons.add, size: 4),
+          home: Icon(Icons.add, semanticLabel: 'add'),
         ),
       );
 
-      final size = spot<Icon>().existsOnce().getSize();
-      expect(size, 4);
+      final label = spot<Icon>().existsOnce().getSemanticLabel();
+      expect(label, 'add');
     });
 
     testWidgets('hasDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Icon(Icons.add, size: 4),
+          home: Icon(Icons.add, semanticLabel: 'add'),
         ),
       );
 
       spot<Icon>()
           .existsOnce()
-          .hasDiagnosticProp<double>('size', (it) => it.equals(4));
+          .hasDiagnosticProp<String>('semanticLabel', (it) => it.equals('add'));
 
       expect(
-        () => spot<Icon>()
-            .existsOnce()
-            .hasDiagnosticProp<double>('size', (it) => it.equals(2)),
+        () => spot<Icon>().existsOnce().hasDiagnosticProp<String>(
+              'semanticLabel',
+              (it) => it.equals('remove'),
+            ),
         throwsSpotErrorContaining([
-          'Icon with property size',
-          'equals <2.0>, actual: <4.0>',
+          'Icon with property semanticLabel',
+          "equals 'remove', actual: 'add'",
         ]),
       );
     });
@@ -56,17 +58,20 @@ void main() {
     testWidgets('generated hasDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Icon(Icons.add, size: 4),
+          home: Icon(Icons.add, semanticLabel: 'add'),
         ),
       );
 
-      spot<Icon>().existsOnce().hasSize(4).hasSizeWhere((it) => it.equals(4));
+      spot<Icon>()
+          .existsOnce()
+          .hasSemanticLabel('add')
+          .hasSemanticLabelWhere((it) => it.equals('add'));
 
       expect(
-        () => spot<Icon>().existsOnce().hasSize(2),
+        () => spot<Icon>().existsOnce().hasSemanticLabel('remove'),
         throwsSpotErrorContaining([
-          'Icon with property size',
-          'equals <2.0>, actual: <4.0>',
+          'Icon with property semanticLabel',
+          "equals 'remove', actual: 'add'",
         ]),
       );
     });
@@ -74,22 +79,26 @@ void main() {
     testWidgets('withDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Icon(Icons.add, size: 4),
+          home: Icon(Icons.add, semanticLabel: 'add'),
         ),
       );
 
       spot<Icon>()
-          .withDiagnosticProp<double>('size', (it) => it.equals(4))
+          .withDiagnosticProp<String>('semanticLabel', (it) => it.equals('add'))
           .existsOnce();
 
       expect(
         () => spot<Icon>()
-            .withDiagnosticProp<double>('size', (it) => it.equals(2))
+            .withDiagnosticProp<String>(
+              'semanticLabel',
+              (it) => it.equals('remove'),
+            )
             .existsOnce(),
         throwsSpotErrorContaining([
-          'Could not find Icon with prop "size" equals <2.0> in widget tree',
+          'Could not find Icon with prop "semanticLabel" equals \'remove\' '
+              'in widget tree',
           'A less specific search (Icon) discovered 1 matches!',
-          'Icon(IconData(U+0E047), size: 4.0',
+          'Icon(IconData(U+0E047), semanticLabel: "add"',
         ]),
       );
     });
@@ -269,22 +278,23 @@ void main() {
     testWidgets('generated withDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Icon(Icons.add, size: 4),
+          home: Icon(Icons.add, semanticLabel: 'add'),
         ),
       );
 
-      spot<Icon>().withSize(4).existsOnce();
-      spot<Icon>().whereSize((it) => it.equals(4)).existsOnce();
+      spot<Icon>().withSemanticLabel('add').existsOnce();
+      spot<Icon>().whereSemanticLabel((it) => it.equals('add')).existsOnce();
 
-      spot<Icon>().withSize(3).doesNotExist();
-      spot<Icon>().whereSize((it) => it.equals(3)).doesNotExist();
+      spot<Icon>().withSemanticLabel('edit').doesNotExist();
+      spot<Icon>().whereSemanticLabel((it) => it.equals('edit')).doesNotExist();
 
       expect(
-        () => spot<Icon>().withSize(2).existsOnce(),
+        () => spot<Icon>().withSemanticLabel('remove').existsOnce(),
         throwsSpotErrorContaining([
-          'Could not find Icon with prop "size" equals <2.0> in widget tree',
+          'Could not find Icon with prop "semanticLabel" equals \'remove\' '
+              'in widget tree',
           'A less specific search (Icon) discovered 1 matches!',
-          'Icon(IconData(U+0E047), size: 4.0',
+          'Icon(IconData(U+0E047), semanticLabel: "add"',
         ]),
       );
     });

--- a/test/selectors/diagnostic_prop_test.dart
+++ b/test/selectors/diagnostic_prop_test.dart
@@ -12,44 +12,43 @@ void main() {
     testWidgets('getDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Text('a', maxLines: 4),
+          home: Icon(Icons.add, size: 4),
         ),
       );
 
-      final maxLines =
-          spot<Text>().existsOnce().getDiagnosticProp<int>('maxLines');
-      expect(maxLines, 4);
+      final size = spot<Icon>().existsOnce().getDiagnosticProp<double>('size');
+      expect(size, 4);
     });
 
     testWidgets('generated getDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Text('a', maxLines: 4),
+          home: Icon(Icons.add, size: 4),
         ),
       );
 
-      final maxLines2 = spot<Text>().existsOnce().getMaxLines();
-      expect(maxLines2, 4);
+      final size = spot<Icon>().existsOnce().getSize();
+      expect(size, 4);
     });
 
     testWidgets('hasDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Text('a', maxLines: 4),
+          home: Icon(Icons.add, size: 4),
         ),
       );
 
-      spot<Text>()
+      spot<Icon>()
           .existsOnce()
-          .hasDiagnosticProp<int>('maxLines', (it) => it.equals(4));
+          .hasDiagnosticProp<double>('size', (it) => it.equals(4));
 
       expect(
-        () => spot<Text>()
+        () => spot<Icon>()
             .existsOnce()
-            .hasDiagnosticProp<int>('maxLines', (it) => it.equals(2)),
+            .hasDiagnosticProp<double>('size', (it) => it.equals(2)),
         throwsSpotErrorContaining([
-          'Text with property maxLines',
-          'equals <2>, actual: <4>',
+          'Icon with property size',
+          'equals <2.0>, actual: <4.0>',
         ]),
       );
     });
@@ -57,20 +56,17 @@ void main() {
     testWidgets('generated hasDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Text('a', maxLines: 4),
+          home: Icon(Icons.add, size: 4),
         ),
       );
 
-      spot<Text>()
-          .existsOnce()
-          .hasMaxLines(4)
-          .hasMaxLinesWhere((it) => it.equals(4));
+      spot<Icon>().existsOnce().hasSize(4).hasSizeWhere((it) => it.equals(4));
 
       expect(
-        () => spot<Text>().existsOnce().hasMaxLines(2),
+        () => spot<Icon>().existsOnce().hasSize(2),
         throwsSpotErrorContaining([
-          'Text with property maxLines',
-          'equals <2>, actual: <4>',
+          'Icon with property size',
+          'equals <2.0>, actual: <4.0>',
         ]),
       );
     });
@@ -78,22 +74,22 @@ void main() {
     testWidgets('withDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Text('a', maxLines: 4),
+          home: Icon(Icons.add, size: 4),
         ),
       );
 
-      spot<Text>()
-          .withDiagnosticProp<int>('maxLines', (it) => it.equals(4))
+      spot<Icon>()
+          .withDiagnosticProp<double>('size', (it) => it.equals(4))
           .existsOnce();
 
       expect(
-        () => spot<Text>()
-            .withDiagnosticProp<int>('maxLines', (it) => it.equals(2))
+        () => spot<Icon>()
+            .withDiagnosticProp<double>('size', (it) => it.equals(2))
             .existsOnce(),
         throwsSpotErrorContaining([
-          'Could not find Text with prop "maxLines" equals <2> in widget tree',
-          'A less specific search (Text) discovered 1 matches!',
-          'Text("a", maxLines: 4,',
+          'Could not find Icon with prop "size" equals <2.0> in widget tree',
+          'A less specific search (Icon) discovered 1 matches!',
+          'Icon(IconData(U+0E047), size: 4.0',
         ]),
       );
     });
@@ -103,21 +99,21 @@ void main() {
       // which must not read the previous instance's props.
       await tester.pumpWidget(
         MaterialApp(
-          home: Text('a', maxLines: 4),
+          home: Icon(Icons.add, size: 4),
         ),
       );
-      spot<Text>().existsOnce().hasMaxLines(4);
-      spot<Text>().withMaxLines(4).existsOnce();
+      spot<Icon>().existsOnce().hasSize(4);
+      spot<Icon>().withSize(4).existsOnce();
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Text('a', maxLines: 7),
+          home: Icon(Icons.add, size: 7),
         ),
       );
-      spot<Text>().existsOnce().hasMaxLines(7);
-      spot<Text>().withMaxLines(7).existsOnce();
-      spot<Text>().withMaxLines(4).doesNotExist();
-      expect(spot<Text>().existsOnce().getDiagnosticProp<int>('maxLines'), 7);
+      spot<Icon>().existsOnce().hasSize(7);
+      spot<Icon>().withSize(7).existsOnce();
+      spot<Icon>().withSize(4).doesNotExist();
+      expect(spot<Icon>().existsOnce().getDiagnosticProp<double>('size'), 7);
     });
 
     testWidgets('reads fresh text after a controller change', (tester) async {
@@ -273,22 +269,22 @@ void main() {
     testWidgets('generated withDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Text('a', maxLines: 4),
+          home: Icon(Icons.add, size: 4),
         ),
       );
 
-      spot<Text>().withMaxLines(4).existsOnce();
-      spot<Text>().whereMaxLines((it) => it.equals(4)).existsOnce();
+      spot<Icon>().withSize(4).existsOnce();
+      spot<Icon>().whereSize((it) => it.equals(4)).existsOnce();
 
-      spot<Text>().withMaxLines(3).doesNotExist();
-      spot<Text>().whereMaxLines((it) => it.equals(3)).doesNotExist();
+      spot<Icon>().withSize(3).doesNotExist();
+      spot<Icon>().whereSize((it) => it.equals(3)).doesNotExist();
 
       expect(
-        () => spot<Text>().withMaxLines(2).existsOnce(),
+        () => spot<Icon>().withSize(2).existsOnce(),
         throwsSpotErrorContaining([
-          'Could not find Text with prop "maxLines" equals <2> in widget tree',
-          'A less specific search (Text) discovered 1 matches!',
-          'Text("a", maxLines: 4,',
+          'Could not find Icon with prop "size" equals <2.0> in widget tree',
+          'A less specific search (Icon) discovered 1 matches!',
+          'Icon(IconData(U+0E047), size: 4.0',
         ]),
       );
     });

--- a/test/selectors/diagnostic_prop_test.dart
+++ b/test/selectors/diagnostic_prop_test.dart
@@ -97,6 +97,98 @@ void main() {
       );
     });
 
+    testWidgets('reads fresh props after a rebuild', (tester) async {
+      // Props are cached per widget instance. A rebuild creates a new instance,
+      // which must not read the previous instance's props.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 4),
+        ),
+      );
+      spot<Text>().existsOnce().hasMaxLines(4);
+      spot<Text>().withMaxLines(4).existsOnce();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 7),
+        ),
+      );
+      spot<Text>().existsOnce().hasMaxLines(7);
+      spot<Text>().withMaxLines(7).existsOnce();
+      spot<Text>().withMaxLines(4).doesNotExist();
+      expect(spot<Text>().existsOnce().getDiagnosticProp<int>('maxLines'), 7);
+    });
+
+    testWidgets('reads fresh text after a controller change', (tester) async {
+      // AnyText reads the text off the live controller, and a bare
+      // EditableText keeps its widget instance while its text changes. The
+      // props of one frame must not be served in the next.
+      final controller = TextEditingController(text: 'before');
+      final focusNode = FocusNode();
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: EditableText(
+              controller: controller,
+              focusNode: focusNode,
+              style: TextStyle(fontSize: 12),
+              cursorColor: Colors.red,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ),
+        ),
+      );
+      // Read the prop, not the text filter, so this goes through the cache.
+      expect(
+        spotTextWhere((it) => it.isNotEmpty())
+            .existsOnce()
+            .getDiagnosticProp<String>('text'),
+        'before',
+      );
+
+      final widgetBefore = find.byType(EditableText).evaluate().first.widget;
+      controller.text = 'after';
+      await tester.pump();
+      final widgetAfter = find.byType(EditableText).evaluate().first.widget;
+      // The premise of the test: the same instance now reports a new text.
+      expect(identical(widgetBefore, widgetAfter), isTrue);
+
+      expect(
+        spotTextWhere((it) => it.isNotEmpty())
+            .existsOnce()
+            .getDiagnosticProp<String>('text'),
+        'after',
+      );
+    });
+
+    testWidgets('selectors deriving different widgets do not collide',
+        (tester) async {
+      // spot<RichText>() and spotText() resolve to the same element but derive
+      // different widgets from it, so they must not read each other's props.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Text('a', maxLines: 4, style: TextStyle(fontSize: 12)),
+        ),
+      );
+
+      // Each has props the other lacks: AnyText flattens the TextStyle into
+      // font_*, RichText reports a textWidthBasis. Reading the other one's
+      // props finds neither.
+      expect(
+        spot<RichText>()
+            .existsOnce()
+            .getDiagnosticProp<TextWidthBasis>('textWidthBasis'),
+        TextWidthBasis.parent,
+      );
+      expect(
+        spotText('a').existsOnce().getDiagnosticProp<double>('font_size'),
+        12,
+      );
+    });
+
     testWidgets('generated withDiagnosticProp', (tester) async {
       await tester.pumpWidget(
         MaterialApp(

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -325,6 +325,30 @@ void main() {
     }
   });
 
+  group('AnyText instances', () {
+    testWidgets('are reused for an element within a frame', (tester) async {
+      // AnyText is synthesized per call, which makes it useless as a cache key
+      // for anything derived from it. Handing out one instance per element and
+      // frame is what lets callers cache, e.g. the diagnostic properties.
+      await tester.pumpWidget(_stage(children: [Text('foo')]));
+      final selector = spotText('foo');
+      final element = find.byType(RichText).evaluate().first;
+
+      final first = selector.mapElementToWidget(element);
+      expect(identical(selector.mapElementToWidget(element), first), isTrue);
+
+      await tester.pumpWidget(_stage(children: [Text('foo')]));
+      final elementAfterFrame = find.byType(RichText).evaluate().first;
+      // The premise: the frame is the only thing that changed, the element is
+      // still the same one.
+      expect(identical(elementAfterFrame, element), isTrue);
+      expect(
+        identical(selector.mapElementToWidget(elementAfterFrame), first),
+        isFalse,
+      );
+    });
+  });
+
   group('deprecated', () {
     group('Text', () {
       testWidgets('spotTexts finds Text', (tester) async {

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -326,10 +326,10 @@ void main() {
   });
 
   group('AnyText instances', () {
-    testWidgets('are reused for an element within a frame', (tester) async {
+    testWidgets('are reused while nothing they read changed', (tester) async {
       // AnyText is synthesized per call, which makes it useless as a cache key
-      // for anything derived from it. Handing out one instance per element and
-      // frame is what lets callers cache, e.g. the diagnostic properties.
+      // for anything derived from it. Handing out one instance per element is
+      // what lets callers cache, e.g. the diagnostic properties.
       await tester.pumpWidget(_stage(children: [Text('foo')]));
       final selector = spotText('foo');
       final element = find.byType(RichText).evaluate().first;
@@ -337,15 +337,42 @@ void main() {
       final first = selector.mapElementToWidget(element);
       expect(identical(selector.mapElementToWidget(element), first), isTrue);
 
-      await tester.pumpWidget(_stage(children: [Text('foo')]));
-      final elementAfterFrame = find.byType(RichText).evaluate().first;
-      // The premise: the frame is the only thing that changed, the element is
-      // still the same one.
-      expect(identical(elementAfterFrame, element), isTrue);
-      expect(
-        identical(selector.mapElementToWidget(elementAfterFrame), first),
-        isFalse,
+      // A frame that rebuilds nothing changes nothing, so the instance stands.
+      tester.binding.scheduleFrame();
+      await tester.pump();
+      expect(identical(selector.mapElementToWidget(element), first), isTrue);
+    });
+
+    testWidgets('are replaced when the text changes without a rebuild',
+        (tester) async {
+      // An EditableText keeps its widget instance while its controller's text
+      // changes, and does not need a frame to do it.
+      final controller = TextEditingController(text: 'before');
+      final focusNode = FocusNode();
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+      await tester.pumpWidget(
+        _stage(
+          children: [
+            EditableText(
+              controller: controller,
+              focusNode: focusNode,
+              style: testTextStyle,
+              cursorColor: Colors.red,
+              backgroundCursorColor: Colors.grey,
+            ),
+          ],
+        ),
       );
+
+      String readText() => spotTextWhere((it) => it.isNotEmpty())
+          .existsOnce()
+          .getDiagnosticProp<String>('text');
+      expect(readText(), 'before');
+
+      controller.text = 'after';
+      // No pump. The widget instance is untouched, only the controller moved.
+      expect(readText(), 'after');
     });
 
     testWidgets('do not outlive the widget they were derived from',

--- a/test/widgets/text_test.dart
+++ b/test/widgets/text_test.dart
@@ -347,6 +347,22 @@ void main() {
         isFalse,
       );
     });
+
+    testWidgets('do not outlive the widget they were derived from',
+        (tester) async {
+      await tester.pumpWidget(_stage(children: [Text('foo')]));
+      expect(
+        spotText('foo').existsOnce().getDiagnosticProp<String>('text'),
+        'foo',
+      );
+
+      // The element is reused, only its RichText is replaced.
+      await tester.pumpWidget(_stage(children: [Text('bar')]));
+      expect(
+        spotText('bar').existsOnce().getDiagnosticProp<String>('text'),
+        'bar',
+      );
+    });
   });
 
   group('deprecated', () {


### PR DESCRIPTION
`toDiagnosticsNode()` returns a fresh node every call and each node only caches `getProperties()` for itself, so nothing was reused between calls.
Every matcher in a chain rebuilt the properties of the same widget, and so did every query that inspected a widget an earlier query had already inspected.

`hasDiagnosticProp`, `getDiagnosticProp` and `withDiagnosticProp` now read through one cache, keyed on the widget instance the properties were built from.

The entries never expire.
A `Widget` is immutable, so what `debugFillProperties` writes cannot change while the instance lives, and a rebuild produces a new instance with a new entry.
Nothing has to notice a frame, and a widget that survives a pump keeps its properties across it.

### Synthesized widgets

A selector that synthesizes its widget per call gets a new entry per call and never a hit.
That is correct, just uncached, and it is what `AnyText` does — which is why `spotText` needed one more piece.
`AnyTextWidgetSelector` hands out the same `AnyText` for an element until something it was derived from changes:

```dart
static Object _anyTextVersion(Element element) {
  final widget = element.widget;
  if (widget is EditableText) {
    final state = (element as StatefulElement).state as EditableTextState;
    return (widget, state.textEditingValue);
  }
  return widget;
}
```

A `RichText` carries its own text, so the widget instance is the whole version.
An `EditableText` does not — it keeps its instance while the controller's value changes underneath — so that value is part of it.
Comparing what it was derived from rather than counting frames keeps this exact: a write to a controller is visible on the next read, with no pump in between.

Nothing is asked of `WidgetSelector.mapElementToWidget`.
An implementation that reads live state and returns a fresh widget on every call stays correct, it only misses the cache.

### A matcher reports the widget it matched

`getDiagnosticProp` re-derived its widget from the live element on every call, while `matcher.widget` returned the one the matcher was built from.
A matcher held across a pump answered both ways at once:

```dart
final matcher = spotText('before').existsOnce();
controller.text = 'after';
await tester.pump();

matcher.widget.text                       // 'before'
matcher.getDiagnosticProp<String>('text') // 'after', now 'before'
```

Both accessors now read the matched widget, and both `WidgetMatcher` implementations capture it when they are built, the way `WidgetSnapshot` already captures the widgets it discovered.
A snapshot freezes the tree on purpose; a matcher built from one should not quietly step outside it.
To assert against the current tree, take a new matcher.

### Numbers

Over a tree of 200 `Text`s, µs per query:

| | before | after |
| --- | --- | --- |
| the same `with*` query again in one frame | 891 | 524 |
| the first `with*` query of a frame, tree unchanged since the last | 810 | 340 |

The second row is what never expiring buys: widgets that did not rebuild keep both their `AnyText` and its properties across the pump.
