### PR TITLE
Export ScreenshotAnnotator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: `ScreenshotAnnotator` is exported. `takeScreenshot(annotators: ...)` has always accepted them, but the type could not be named from `package:spot/spot.dart`, so writing one meant importing `package:spot/src/`.
+
 - Fix: A `WidgetMatcher` reports the widget it matched, not whatever is in the tree when you read it. `getDiagnosticProp` used to re-read the live widget while `matcher.widget` returned the matched one, so a matcher held across a pump could answer with two different values. All of them now read the matched widget; take a new matcher to assert against the current tree. #159
 
 - Improvement: `hasDiagnosticProp`, `getDiagnosticProp` and `withDiagnosticProp` share one cache of a widget's diagnostic properties instead of running `debugFillProperties` again on every call. Every matcher in a chain used to rebuild the properties of the same widget, and so did every query that inspected a widget an earlier query had already inspected. Over a tree of 200 `Text`s, repeated property queries are around 1.5x faster. #159

--- a/lib/spot.dart
+++ b/lib/spot.dart
@@ -49,6 +49,8 @@ export 'package:spot/src/screenshot/screenshot.dart'
         SnapshotScreenshotExtension,
         TimelineSyncScreenshot,
         takeScreenshot;
+export 'package:spot/src/screenshot/screenshot_annotator.dart'
+    show ScreenshotAnnotator;
 export 'package:spot/src/spot/default_selectors.dart'
     show DefaultWidgetMatchers, DefaultWidgetSelectors;
 export 'package:spot/src/spot/diagnostic_props.dart'

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -14,7 +14,6 @@ import 'package:spot/spot.dart';
 import 'package:spot/src/flutter/frame_clock.dart';
 import 'package:spot/src/screenshot/screenshot.dart' as self
     show takeScreenshot;
-import 'package:spot/src/screenshot/screenshot_annotator.dart';
 import 'package:spot/src/screenshot/screenshot_io.dart'
     if (dart.library.html) 'package:spot/src/screenshot/screenshot_web.dart';
 import 'package:stack_trace/stack_trace.dart';

--- a/test/screenshot/custom_annotator_test.dart
+++ b/test/screenshot/custom_annotator_test.dart
@@ -1,0 +1,42 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+
+/// Written against `package:spot/spot.dart` alone, which is the point of this
+/// file: `takeScreenshot` accepts annotators, so a package consumer has to be
+/// able to write one without reaching into `package:spot/src/`.
+class _BorderAnnotator implements ScreenshotAnnotator {
+  @override
+  String get name => 'Border Annotator';
+
+  @override
+  Future<ui.Image> annotate(ui.Image image) {
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    canvas.drawImage(image, Offset.zero, Paint());
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, image.width.toDouble(), image.height.toDouble()),
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2
+        ..color = const Color(0xff00ff00),
+    );
+    return recorder.endRecording().toImage(image.width, image.height);
+  }
+}
+
+void main() {
+  testWidgets('a custom annotator only needs the public API', (tester) async {
+    await tester.pumpWidget(const ColoredBox(color: Color(0xffff0000)));
+
+    final screenshot = await takeScreenshot(
+      print: false,
+      annotators: [_BorderAnnotator()],
+    );
+
+    expect(screenshot.annotations, hasLength(1));
+    expect(screenshot.annotations.single.name, 'Border Annotator');
+  });
+}


### PR DESCRIPTION
`takeScreenshot` and `takeScreenshotSync` accept a `List<ScreenshotAnnotator>`, but the type was not in the show list of `lib/spot.dart`. A consumer could be handed the parameter with no way to name a type to put in it:

```dart
import 'package:spot/spot.dart';

class BorderAnnotator implements ScreenshotAnnotator {
  // Error: 'ScreenshotAnnotator' isn't a type
}
```

Writing an annotator meant importing `package:spot/src/screenshot/screenshot_annotator.dart`.

The concrete annotators stay private. `HighlightAnnotator`, `CrosshairAnnotator` and `ArrowAnnotator` are spot's own and none of them appear in a public signature, so the interface is the only part an implementer needs.

The test is written against `package:spot/spot.dart` alone, so it stops compiling if the export goes away again.
