### PR TITLE
Use a fresh pointer id for act.tap and act.tapAt

### DIFF
--- a/lib/src/act/act.dart
+++ b/lib/src/act/act.dart
@@ -134,12 +134,12 @@ class Act {
           );
         }
 
-        // Finally, tap the widget by sending a down and up event.
-        final downEvent = PointerDownEvent(position: positionToTap);
-        binding.handlePointerEvent(downEvent);
-
-        final upEvent = PointerUpEvent(position: positionToTap);
-        binding.handlePointerEvent(upEvent);
+        // Finally, tap the widget by sending a down and up event. Use a fresh
+        // pointer id, because reusing an id (like the default 0) joins the
+        // gesture arena of a previous gesture with the same id, where the tap
+        // can lose against a stale winner and get silently swallowed.
+        final gesture = await gestures.startGesture(positionToTap);
+        await gesture.up();
 
         await binding.pump();
       });
@@ -239,10 +239,10 @@ class Act {
             color: Colors.blue,
           );
         }
-        final downEvent = PointerDownEvent(position: position);
-        binding.handlePointerEvent(downEvent);
-        final upEvent = PointerUpEvent(position: position);
-        binding.handlePointerEvent(upEvent);
+        // Use a fresh pointer id, see Act.tap for why pointer 0 must not be
+        // reused.
+        final gesture = await gestures.startGesture(position);
+        await gesture.up();
         await binding.pump();
       });
     });

--- a/lib/src/act/gestures.dart
+++ b/lib/src/act/gestures.dart
@@ -14,7 +14,12 @@ class Gestures {
   /// [startGesture] method is called without an explicit pointer identifier.
   int get nextPointer => _nextPointer;
 
-  static int _nextPointer = 1;
+  // Seeded far above flutter_test's own pointer counter (WidgetController,
+  // starting at 1) and the small ids multi-touch tests hardcode, so a stale
+  // gesture arena leaked by either can never sit on an id spot is about to
+  // use. See https://github.com/passsy/spot/issues/164 for how a reused id
+  // silently swallows a tap.
+  static int _nextPointer = 1 << 20;
 
   static int _getNextPointer() {
     final int result = _nextPointer;

--- a/test/act/act_tap_pointer_id_test.dart
+++ b/test/act/act_tap_pointer_id_test.dart
@@ -4,30 +4,47 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
 
 // Regression for https://github.com/passsy/spot/issues/164
+//
+// Pointer id 0 is the default of raw PointerDownEvent, which act.tap used to
+// dispatch. Ids 1-10 are what other allocators produce: flutter_test's
+// WidgetController counter (1, 2, 3, ...) and the small ids multi-touch tests
+// hardcode. Spot allocates from an offset range (1 << 20 and up), so a stale
+// gesture arena on any of these ids must never capture a spot tap.
+var _arenasPoisoned = false;
+
 void main() {
-  testWidgets('poison gesture arena 0 with an unresolved eager winner', (
+  testWidgets('poison gesture arenas 0-10 with unresolved eager winners', (
     tester,
   ) async {
-    final recognizer = _EagerRecognizer();
+    for (var pointer = 0; pointer <= 10; pointer++) {
+      final recognizer = _EagerRecognizer();
 
-    recognizer.addPointer(
-      const PointerDownEvent(
-        // ignore: avoid_redundant_argument_values
-        pointer: 0,
-        position: Offset(10, 10),
-      ),
-    );
+      recognizer.addPointer(
+        PointerDownEvent(
+          pointer: pointer,
+          position: const Offset(10, 10),
+        ),
+      );
 
-    // Intentionally omit PointerUpEvent/PointerCancelEvent.
-    // Disposing the recognizer removes its pointer route, but its accepted
-    // gesture-arena entry remains, and the test-binding reset does not clear
-    // the GestureArenaManager.
-    recognizer.dispose();
+      // Intentionally omit PointerUpEvent/PointerCancelEvent.
+      // Disposing the recognizer removes its pointer route, but its accepted
+      // gesture-arena entry remains, and the test-binding reset does not clear
+      // the GestureArenaManager.
+      recognizer.dispose();
+    }
+    _arenasPoisoned = true;
   });
 
-  testWidgets('act.tap works despite a stale gesture arena for pointer 0', (
+  testWidgets('act.tap works despite stale gesture arenas on ids 0-10', (
     tester,
   ) async {
+    expect(
+      _arenasPoisoned,
+      isTrue,
+      reason: 'The poison test must run first, '
+          'otherwise this test passes without testing anything',
+    );
+
     var taps = 0;
 
     await tester.pumpWidget(
@@ -39,11 +56,22 @@ void main() {
       ),
     );
 
+    // Precondition with an explicit id outside the poisoned range, proving
+    // the button itself is tappable. tester.tap would auto-allocate id 1,
+    // which is poisoned.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byType(ElevatedButton)),
+      pointer: 424242,
+    );
+    await gesture.up();
+    await tester.pump();
+    expect(taps, 1, reason: 'precondition: the button must be tappable');
+
     await act.tap(spot<ElevatedButton>());
-    expect(taps, 1);
+    expect(taps, 2);
 
     await act.tapAt(tester.getCenter(find.byType(ElevatedButton)));
-    expect(taps, 2);
+    expect(taps, 3);
   });
 }
 
@@ -63,5 +91,5 @@ final class _EagerRecognizer extends OneSequenceGestureRecognizer {
   void didStopTrackingLastPointer(int pointer) {}
 
   @override
-  String get debugDescription => 'pointer-zero poison';
+  String get debugDescription => 'stale-pointer-id poison';
 }

--- a/test/act/act_tap_pointer_id_test.dart
+++ b/test/act/act_tap_pointer_id_test.dart
@@ -3,11 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:spot/spot.dart';
 
-// Regression test: act.tap must not reuse pointer id 0. A previous test can
-// leave gesture arena 0 unresolved (with a stale winner). A tap that reuses
-// pointer 0 joins that stale arena, its TapGestureRecognizer loses, and the
-// tap is silently swallowed. The two tests below are order-dependent by
-// design: the first poisons arena 0, the second must still tap successfully.
+// Regression for https://github.com/passsy/spot/issues/164
 void main() {
   testWidgets('poison gesture arena 0 with an unresolved eager winner', (
     tester,

--- a/test/act/act_tap_pointer_id_test.dart
+++ b/test/act/act_tap_pointer_id_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:spot/spot.dart';
+
+// Regression test: act.tap must not reuse pointer id 0. A previous test can
+// leave gesture arena 0 unresolved (with a stale winner). A tap that reuses
+// pointer 0 joins that stale arena, its TapGestureRecognizer loses, and the
+// tap is silently swallowed. The two tests below are order-dependent by
+// design: the first poisons arena 0, the second must still tap successfully.
+void main() {
+  testWidgets('poison gesture arena 0 with an unresolved eager winner', (
+    tester,
+  ) async {
+    final recognizer = _EagerRecognizer();
+
+    recognizer.addPointer(
+      const PointerDownEvent(
+        // ignore: avoid_redundant_argument_values
+        pointer: 0,
+        position: Offset(10, 10),
+      ),
+    );
+
+    // Intentionally omit PointerUpEvent/PointerCancelEvent.
+    // Disposing the recognizer removes its pointer route, but its accepted
+    // gesture-arena entry remains, and the test-binding reset does not clear
+    // the GestureArenaManager.
+    recognizer.dispose();
+  });
+
+  testWidgets('act.tap works despite a stale gesture arena for pointer 0', (
+    tester,
+  ) async {
+    var taps = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ElevatedButton(
+          onPressed: () => taps++,
+          child: const Text('tap'),
+        ),
+      ),
+    );
+
+    await act.tap(spot<ElevatedButton>());
+    expect(taps, 1);
+
+    await act.tapAt(tester.getCenter(find.byType(ElevatedButton)));
+    expect(taps, 2);
+  });
+}
+
+final class _EagerRecognizer extends OneSequenceGestureRecognizer {
+  @override
+  void addAllowedPointer(PointerDownEvent event) {
+    super.addAllowedPointer(event);
+    resolve(GestureDisposition.accepted);
+  }
+
+  @override
+  void handleEvent(PointerEvent event) {
+    stopTrackingIfPointerNoLongerDown(event);
+  }
+
+  @override
+  void didStopTrackingLastPointer(int pointer) {}
+
+  @override
+  String get debugDescription => 'pointer-zero poison';
+}


### PR DESCRIPTION
fixes #164

`act.tap`/`act.tapAt` now route through the existing `gestures` allocator instead of constructing raw pointer-zero events, so every tap gets a fresh pointer id and cannot join a stale gesture arena. Includes a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)