### PR TITLE
Fix CI for Flutter 3.47

### DIFF
--- a/hot_restart_timeline/analysis_options.yaml
+++ b/hot_restart_timeline/analysis_options.yaml
@@ -6,10 +6,10 @@ include: package:lint/casual.yaml # For code samples, hackathons and other non-p
 
 
 # You might want to exclude auto-generated files from dart analysis
-analyzer:
-  exclude:
-    #- '**.freezed.dart'
-    #- '**.g.dart'
+# analyzer:
+#   exclude:
+#     - '**.freezed.dart'
+#     - '**.g.dart'
 
 # You can customize the lint rules set to your own liking. A list of all rules
 # can be found at https://dart-lang.github.io/linter/lints/options/options.html

--- a/lib/src/screenshot/screenshot.dart
+++ b/lib/src/screenshot/screenshot.dart
@@ -813,12 +813,26 @@ Frame? _caller({StackTrace? stack}) {
         // ../dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 647:23 in <fn>
         return false;
       }
+      // Since Flutter 3.47, DDC serves sdk and package frames without the
+      // leading ../, making their uris absolute like
+      // http://localhost:53285/dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart
+      final path = line.uri.path;
+      if (path.startsWith('/dart-sdk/') || path.startsWith('/packages/')) {
+        return false;
+      }
     }
     final url = line.uri.toString();
     if (url.contains('package:spot')) return false;
     if (url.startsWith('package:flutter_test')) return false;
     return true;
   }).toList();
-  final Frame? bestGuess = relevantLines.firstOrNull;
+  // Prefer frames outside package:stack_trace. Its zone instrumentation
+  // frames surface before the actual caller on web since Flutter 3.47, but
+  // on older Flutter versions they can be the only frame left (e.g. for
+  // drag events on Flutter 3.10), so they remain as fallback.
+  final Frame? bestGuess = relevantLines.firstOrNullWhere(
+        (frame) => !frame.uri.toString().startsWith('package:stack_trace'),
+      ) ??
+      relevantLines.firstOrNull;
   return bestGuess;
 }


### PR DESCRIPTION
CI on `main` fails since Flutter 3.47 became stable (the Analyze and Web Tests workflows track `channel: stable`). Nightly stays green because it only runs VM tests, so the breakage surfaces as unrelated failures on PRs like #165.

### Analyze: `invalid_section_format`

`hot_restart_timeline/analysis_options.yaml` had an `analyzer: exclude:` key whose entries were all commented out. The analyzer in Flutter 3.47 reports the empty key as `invalid_section_format`, fatal with `--fatal-warnings`. The whole section is now commented out.

### Web Tests: screenshots no longer named after the calling test

`takeScreenshot()` walks the stack trace for the caller and skipped web SDK frames by their `../` prefix. Since Flutter 3.47, DDC reports those frames with absolute uris instead, so they slipped through:

```text
before Flutter 3.47:  ../dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart
since Flutter 3.47:   http://localhost:53285/dart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart

screenshot name on Chrome:  async_patch_618-S7sy4   →   screenshot_test_207-NWFFK
```

`_caller()` now also skips frames by uri path (`/dart-sdk/`, `/packages/`). `package:stack_trace` zone frames, which now precede the caller on web, are only deprioritized — on Flutter 3.10 they are the only candidate for drag events, and a hard filter broke that job.

Older versions aren't fully covered by CI: also verified the Chrome suite on Flutter 3.44 and 3.32 locally.