### PR TITLE
Fix broken screenshots in the timeline report

### DIFF
--- a/lib/src/timeline/html/render_timeline.dart
+++ b/lib/src/timeline/html/render_timeline.dart
@@ -26,6 +26,11 @@ Future<String> renderTimelineWithJaspr(
     Document(
       title: "Timeline Events",
       head: [
+        // Jaspr injects <base href="/"> when the document declares none, which
+        // sends every relative screenshot path to the root. The report is
+        // opened as a file, and the hot-restart server puts each report in its
+        // own subdirectory, so the base has to stay the document itself.
+        const DomComponent(tag: 'base', attributes: {'href': './'}),
         link(
           href:
               "https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap",

--- a/test/timeline/render_timeline_test.dart
+++ b/test/timeline/render_timeline_test.dart
@@ -16,4 +16,17 @@ void main() {
     },
     skip: kIsWeb ? 'Jaspr server rendering requires the Dart VM' : false,
   );
+
+  test(
+    'screenshots stay relative to the report, not the server root',
+    () async {
+      final html = await renderTimelineWithJaspr([]);
+
+      // Jaspr inserts <base href="/"> when the document declares none, which
+      // sends every relative screenshot path to the root of the file system.
+      expect(html, contains('<base href="./"'));
+      expect(html, isNot(contains('<base href="/"')));
+    },
+    skip: kIsWeb ? 'Jaspr server rendering requires the Dart VM' : false,
+  );
 }


### PR DESCRIPTION
Screenshots stopped rendering in the HTML timeline report. Every thumbnail is a broken-image icon when the report is opened as a file, which is how spot tells you to open it:

```text
View timeline here: file:///…/build/timeline/<test>/index.html
```

Jaspr 0.17 inserts `<base href="/">` into any document that declares none, so `./screenshots/foo.png` resolved against the root of the file system. Jaspr 0.15 inserted no base tag, so this arrived with the update in #167 and is not released yet.

The document declares its own base now. `Document(base:)` cannot express it — Jaspr forces a leading and trailing slash on that value — so it goes in the head directly:

```dart
const DomComponent(tag: 'base', attributes: {'href': './'}),
```

`./` keeps every relative path pointing at the report directory, which is what both `file://` and the hot-restart server need, since that server puts each report in its own subdirectory. The absolute `/script.js` used in hot-restart mode is unaffected, and a test covers both.

### Note for reviewers

Serving the report directory *as* the web root hides this, because `/screenshots/…` resolves there. Reproduce it by opening the file, or by serving `build/timeline/` and requesting `<test>/index.html`.
